### PR TITLE
Engineering advances

### DIFF
--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -36,6 +36,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/space)
+"abi" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 6;
+	name = "engineering yellow"
+	},
+/turf/open/floor/carpet/orange,
+/area/engineering/lobby)
 "abq" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -117,6 +126,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"adh" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "ado" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
@@ -136,12 +149,24 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
+"aeB" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/tcomms_all,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "aeC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
+"aeW" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "afW" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
@@ -179,6 +204,16 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"agC" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Vacant Offices A"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "agJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -310,7 +345,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "alZ" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -486,7 +521,7 @@
 	name = "engineering yellow"
 	},
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "ass" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -510,30 +545,36 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "asz" = (
-/turf/open/space/basic,
-/area/maintenance/department/science/xenobiology)
-"atL" = (
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter/room)
 "atP" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aug" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Warehouse Maintenance";
-	req_one_access_txt = "31"
+/obj/structure/reflector/single,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 9;
+	name = "engineering yellow"
 	},
-/turf/open/floor/plating,
-/area/cargo/warehouse)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "aun" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"aur" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "aus" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -584,7 +625,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "axW" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -653,6 +694,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"azp" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/engineering/main)
 "azw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -754,7 +799,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+/area/space)
 "aBS" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/generator,
@@ -891,6 +936,13 @@
 /obj/machinery/navbeacon/wayfinding/det,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"aFv" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/service/chapel/office)
 "aFw" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch/directional/south,
@@ -1105,6 +1157,10 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white,
 /area/science/research)
+"aNJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/service/chapel/office)
 "aOc" = (
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Console"
@@ -1187,7 +1243,7 @@
 "aQe" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "aQu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -1220,6 +1276,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"aRB" = (
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "aRC" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -1359,6 +1418,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"aYz" = (
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "aZb" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/iron/chapel{
@@ -1392,11 +1455,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "bas" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "baK" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -1416,6 +1479,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"bbF" = (
+/obj/machinery/computer/message_monitor{
+	dir = 1
+	},
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms Requests Console"
+	},
+/turf/open/floor/circuit,
+/area/engineering/storage/tcomms)
 "bbY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/glass,
@@ -1466,6 +1541,10 @@
 "bda" = (
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"bdo" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "bdp" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
@@ -1503,15 +1582,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "beY" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "bfk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -1588,6 +1665,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"bgE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
+"bgH" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/engineering/gravity_generator)
 "bgK" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half,
@@ -1600,7 +1689,7 @@
 /area/construction/mining/aux_base)
 "bgY" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/cargo/storage)
 "bhP" = (
 /obj/machinery/door/poddoor/preopen{
@@ -1653,9 +1742,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
-"biO" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
 "bje" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 9
@@ -1711,14 +1797,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"bkV" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/space)
 "ble" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -1742,7 +1820,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/cargo/warehouse/upper)
+/area/space)
 "blz" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
@@ -2011,7 +2089,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "bsj" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -2188,6 +2266,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
+"bAq" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room";
+	req_access_txt = "19;23"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "bAr" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Mix 2 Output"
@@ -2242,6 +2329,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"bCg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "bCh" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -2370,24 +2466,23 @@
 "bGD" = (
 /turf/open/floor/engine/vacuum,
 /area/space/nearstation)
+"bGJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/security_all,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "bHo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bHP" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "bIc" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -2404,8 +2499,13 @@
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
 "bJw" = (
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 5;
+	name = "engineering yellow"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "bKb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2421,6 +2521,17 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
+"bKm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "bKE" = (
 /obj/machinery/door/airlock/external/glass{
 	req_access_txt = "31"
@@ -2464,6 +2575,11 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"bLw" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
 "bLz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -2490,11 +2606,17 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
-"bMB" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
 /area/space)
+"bMB" = (
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "bMC" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -2555,7 +2677,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal)
+/area/space)
 "bPR" = (
 /obj/structure/closet/mini_fridge,
 /turf/open/floor/plating,
@@ -2567,7 +2689,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "bQy" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/machinery/iv_drip,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "bQO" = (
@@ -2584,14 +2706,16 @@
 /turf/open/floor/iron,
 /area/space/nearstation)
 "bQX" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_one_access_txt = "10;24"
 	},
-/obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "bQZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -2710,6 +2834,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
+"bUX" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "bVt" = (
 /obj/structure/flora/ausbushes,
 /turf/open/floor/grass,
@@ -2720,7 +2856,7 @@
 "bVS" = (
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/sorting)
 "bVW" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/effect/turf_decal/tile/brown/half{
@@ -2742,6 +2878,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
+"bWt" = (
+/obj/machinery/modular_computer/console/preset/cargochat/engineering,
+/turf/open/floor/iron,
+/area/engineering/main)
 "bWx" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -2783,6 +2923,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"bYA" = (
+/turf/open/floor/carpet/royalblack,
+/area/engineering/lobby)
 "bYE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2804,6 +2947,9 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"bYP" = (
+/turf/closed/wall,
+/area/cargo/sorting)
 "bZf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2841,7 +2987,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "caa" = (
 /turf/closed/wall/r_wall,
 /area/service/chapel/office)
@@ -2973,6 +3119,13 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"cdI" = (
+/obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "cdM" = (
 /obj/structure/sign/plaques/kiddie/badger{
 	pixel_y = -28
@@ -2981,6 +3134,21 @@
 	dir = 8
 	},
 /area/service/chapel)
+"cdW" = (
+/obj/structure/table,
+/obj/machinery/button/door/directional/east{
+	id = "celock";
+	name = "CE Office Lockdown Button";
+	pixel_x = 40;
+	req_access_txt = "56"
+	},
+/obj/item/stamp/denied,
+/obj/item/stamp/ce{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "ceq" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -2994,6 +3162,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"ceA" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "ceO" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
@@ -3108,7 +3280,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "cid" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -3171,10 +3343,14 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "cko" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/reflector/single,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "ckp" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -3236,6 +3412,9 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"cmr" = (
+/turf/open/floor/iron,
+/area/engineering/storage)
 "cmt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3270,6 +3449,14 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"cnq" = (
+/obj/machinery/computer/apc_control{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/command/heads_quarters/ce)
 "cnG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -3290,12 +3477,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "cnP" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "cnR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -3489,11 +3673,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"cuM" = (
-/obj/effect/landmark/start/cargo_technician,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
 "cuN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -3501,6 +3680,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
+"cve" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "cwa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -3597,7 +3782,7 @@
 "cyE" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/space/nearstation)
+/area/space)
 "cyQ" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -3686,6 +3871,14 @@
 	dir = 8
 	},
 /area/science/research)
+"cBc" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/rnd_all,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cBD" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -3755,8 +3948,10 @@
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
 "cDi" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal)
+/obj/machinery/power/emitter,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "cDj" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -3778,9 +3973,16 @@
 /turf/open/floor/iron,
 /area/space)
 "cEc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/space)
+/obj/structure/reflector/double/anchored{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "cEu" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron/dark,
@@ -3923,6 +4125,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"cIx" = (
+/obj/machinery/gravity_generator/main/station,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cID" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible{
@@ -3936,6 +4142,9 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"cJM" = (
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "cJO" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -4001,7 +4210,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "cOo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -4017,9 +4226,15 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "cOI" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/obj/structure/reflector/single,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "cOR" = (
 /obj/effect/turf_decal/tile/green/half{
 	color = "#00FFFF";
@@ -4060,6 +4275,13 @@
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"cPS" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "cPV" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -4103,6 +4325,10 @@
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cRl" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/engineering/main)
 "cRr" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
@@ -4132,12 +4358,10 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "cSd" = (
-/obj/structure/rack,
-/obj/item/plunger,
 /turf/open/floor/plating,
-/area/space)
+/area/engineering/supermatter/room)
 "cSi" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/sign/warning/electricshock{
@@ -4157,6 +4381,13 @@
 	dir = 1
 	},
 /area/science/research)
+"cSW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Maintenance";
+	req_one_access_txt = "31;48"
+	},
+/turf/open/floor/plating,
+/area/space)
 "cTe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4192,19 +4423,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"cTr" = (
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/obj/item/clothing/under/plasmaman/cargo,
-/obj/item/clothing/under/plasmaman/cargo,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
 "cTt" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/tile/purple/anticorner{
@@ -4223,6 +4441,21 @@
 	},
 /turf/open/floor/plating,
 /area/science/server)
+"cTM" = (
+/obj/structure/table,
+/obj/item/paper_bin/carbon,
+/obj/item/paper/monitorkey,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
+"cTU" = (
+/obj/docking_port/stationary/random{
+	dir = 8;
+	id = "pod_lavaland2";
+	name = "lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
 "cUc" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/purple/half{
@@ -4250,6 +4483,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"cUN" = (
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/engineering/lobby)
 "cUO" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -4262,6 +4501,13 @@
 	dir = 1
 	},
 /area/science/research)
+"cUU" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/engineering/gravity_generator)
 "cUW" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -4287,15 +4533,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cVf" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light/small/directional/east,
-/obj/structure/window{
-	pixel_y = -3
-	},
-/turf/open/floor/wood,
-/area/space)
+/obj/structure/reflector/box/anchored,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "cVk" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
@@ -4330,15 +4570,22 @@
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
 "cVW" = (
-/obj/structure/table,
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/candle{
-	pixel_x = 9;
-	pixel_y = 7
+/obj/structure/reflector/double/anchored{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/status_display/ai/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Engine Emitters E";
+	name = "Engine Camera";
+	network = list("ss13","engineering","engine")
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "cWL" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
@@ -4399,6 +4646,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"cYi" = (
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cYw" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -4435,6 +4685,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"cZu" = (
+/obj/machinery/disposal/delivery_chute{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "cZw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -4480,7 +4755,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/maintenance/disposal)
+/area/space)
 "daO" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -4550,6 +4825,18 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
+"dcw" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/c_tube,
+/obj/item/cane,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dcC" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
@@ -4561,7 +4848,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/maintenance/department/cargo)
+/area/space)
 "dcW" = (
 /obj/structure/sign/directions/command,
 /turf/closed/wall/r_wall,
@@ -4790,6 +5077,11 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/processing)
+"dkB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dkW" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -4820,15 +5112,6 @@
 /obj/item/watertank,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"dlE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
 "dlL" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -4884,14 +5167,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/solars/port/fore)
 "dnI" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/window/reinforced/plasma{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 4
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "dnS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -4932,18 +5217,17 @@
 	dir = 10
 	},
 /area/science/research)
+"dov" = (
+/obj/structure/table,
+/obj/item/aicard,
+/obj/item/ai_module/reset,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "doN" = (
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"dpc" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "QMLoad2"
-	},
-/turf/open/floor/iron,
-/area/space)
 "dpf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -4959,39 +5243,27 @@
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "dpB" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1;
-	pixel_y = 4
+/obj/structure/reflector/single,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
+/obj/machinery/status_display/ai/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Engine Emitters W";
+	name = "Engine Camera";
+	network = list("ss13","engineering","engine")
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/disposal)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dqq" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
-	},
-/obj/machinery/status_display/supply{
-	pixel_x = -32
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall,
+/area/engineering/engine_smes)
 "drD" = (
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "drU" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm/directional/west,
@@ -5083,6 +5355,15 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"dtr" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/mass_driver/chapelgun{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating,
+/area/service/chapel/office)
 "dub" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/black,
@@ -5263,10 +5544,21 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/autolathe,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron,
 /area/cargo/office)
+"dzF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/main)
 "dzH" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank,
 /obj/effect/turf_decal/siding/yellow{
@@ -5410,20 +5702,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"dDB" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "QM #4"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Cargo - Cargobay NW";
-	name = "cargo camera"
-	},
-/turf/open/floor/iron,
-/area/space)
 "dDF" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	color = "#FFD700";
@@ -5454,15 +5732,10 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "dEc" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
-	},
-/obj/structure/sign/warning/docking{
-	pixel_x = -30
-	},
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "dEn" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -5491,7 +5764,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/maintenance/disposal)
+/area/space)
 "dET" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -5510,6 +5783,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"dFn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "dFK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5546,6 +5823,15 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"dId" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
+"dIf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "dIB" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
@@ -5659,38 +5945,13 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "dLf" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "QM #3"
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
-/obj/machinery/status_display/supply{
-	pixel_y = 30
-	},
-/mob/living/simple_animal/bot/mulebot{
-	beacon_freq = 1400;
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/space)
-"dLj" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "QM #3"
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "dLo" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -5732,24 +5993,14 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"dMp" = (
-/obj/effect/turf_decal/delivery,
-/mob/living/simple_animal/bot/mulebot{
-	beacon_freq = 1400;
-	home_destination = "QM #1";
-	suffix = "#1"
+"dMh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "QM #1"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/storage/tcomms)
 "dMw" = (
 /obj/structure/table,
 /obj/machinery/door/window{
@@ -5773,27 +6024,24 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "dMz" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargobaylockdown";
-	name = "Cargobay Lockdown"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dMZ" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
+/obj/machinery/power/emitter,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "dNd" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/wood,
-/area/space)
+/obj/structure/reflector/double/anchored{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dNy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5813,14 +6061,17 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "dNP" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/wood,
-/area/space)
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dNQ" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/wood,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "dNX" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/freezer,
@@ -5840,6 +6091,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/maintenance/solars/starboard/aft)
+"dOL" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Gas to Cold Loop"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dOV" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
@@ -5854,7 +6113,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "dPu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5869,6 +6128,20 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"dQd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
+"dQo" = (
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF0000"
+	},
+/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "dQu" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -5886,6 +6159,11 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"dRD" = (
+/obj/machinery/blackbox_recorder,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "dRY" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -5908,6 +6186,18 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/space)
+"dSJ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "dSP" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -5947,6 +6237,9 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/science/explab)
+"dUD" = (
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "dVp" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -5957,12 +6250,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"dVD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
 "dVF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -5971,18 +6258,10 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "dVQ" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 1;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dVS" = (
 /obj/structure/sink{
 	dir = 8;
@@ -5991,46 +6270,15 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
-"dVT" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
 "dWl" = (
-/obj/structure/table,
-/obj/item/stamp/denied{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/obj/item/paper_bin{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/stamp{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/power/supermatter_crystal,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "dWm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
-"dWn" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "dWG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6055,42 +6303,27 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "dWV" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/window{
-	pixel_y = -3
+/obj/structure/reflector/double/anchored{
+	dir = 6
 	},
-/turf/open/floor/wood,
-/area/space)
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "dWW" = (
-/obj/structure/table/wood,
-/obj/structure/window{
-	pixel_y = -3
-	},
-/turf/open/floor/wood,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "dWZ" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/obj/structure/window{
-	pixel_y = -3
+/obj/structure/reflector/box/anchored,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
 	},
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dXa" = (
-/obj/structure/filingcabinet,
-/obj/structure/window{
-	pixel_y = -3
-	},
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
-/area/space)
+/turf/closed/wall,
+/area/commons/vacant_room)
 "dXd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -6100,13 +6333,13 @@
 /turf/open/floor/iron,
 /area/space)
 "dXh" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/structure/window{
-	pixel_y = -3
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 10;
+	name = "engineering yellow"
 	},
-/turf/open/floor/wood,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "dXA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -6114,7 +6347,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "dXM" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Turbine Access";
@@ -6131,14 +6364,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal)
+/area/space)
 "dXO" = (
 /obj/effect/turf_decal/siding/green{
 	color = "#00FFFF";
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "dXX" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	color = "#4169E1";
@@ -6166,6 +6399,15 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/service/library)
+"dZs" = (
+/obj/machinery/door/poddoor{
+	id = "engstorage";
+	name = "Engineering Secure Storage Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "dZE" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -6204,6 +6446,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
+"dZR" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/iron,
+/area/engineering/main)
 "dZS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -6214,6 +6460,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"eau" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "eav" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -6290,6 +6542,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"ebP" = (
+/obj/structure/tank_dispenser/plasma,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "ebT" = (
 /obj/machinery/button/flasher{
 	id = "permafrontdoor";
@@ -6308,6 +6564,16 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
+"eck" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ecO" = (
 /obj/structure/rack,
 /obj/item/crowbar/red,
@@ -6364,7 +6630,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "edX" = (
 /obj/item/stack/sheet/plastic/fifty{
 	pixel_x = 3;
@@ -6389,6 +6655,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"eea" = (
+/obj/structure/rack,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/obj/item/analyzer,
+/turf/open/floor/iron,
+/area/engineering/main)
 "eec" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -6469,18 +6743,21 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"efX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"efV" = (
+/obj/machinery/vending/tool,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/main)
 "ega" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/window/reinforced/plasma{
+	dir = 8
+	},
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "egl" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/glass,
@@ -6496,34 +6773,41 @@
 /turf/open/floor/iron,
 /area/space)
 "egQ" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
+"ehf" = (
+/obj/machinery/telecomms/bus/preset_two,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "ehh" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "ehJ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Vacant Offices A"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "ehX" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/space)
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "ehY" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -6572,16 +6856,22 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "eiU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/space)
-"ejf" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/turf/open/floor/wood,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
+"ejf" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "ejB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/cafeteria,
@@ -6640,13 +6930,16 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "ekx" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/space)
+/area/engineering/supermatter/room)
 "ekX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -6667,7 +6960,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "elF" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
@@ -6710,7 +7003,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "emc" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -6736,7 +7029,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal)
+/area/space)
 "emj" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/structure/cable,
@@ -6749,7 +7042,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal)
+/area/space)
 "emr" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -6773,7 +7066,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "emW" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -6793,7 +7086,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "enN" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -6836,6 +7129,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/space)
+"eoI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "eoU" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -6857,7 +7155,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "epF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/nuclearbomb/beer,
@@ -6878,6 +7176,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"eqJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "eqK" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -6912,11 +7216,20 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "erL" = (
-/obj/structure/chair/comfy{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"erM" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "erT" = (
 /turf/closed/wall,
 /area/science/mixing)
@@ -6943,9 +7256,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "esZ" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/wood,
-/area/space)
+/obj/structure/reflector/box/anchored,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 6;
+	name = "engineering yellow"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "etl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -6953,14 +7271,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "etA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/engine_smes)
 "etE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/north{
@@ -7010,12 +7324,13 @@
 /turf/open/floor/iron/smooth,
 /area/security/warden)
 "eue" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"eui" = (
+/turf/closed/wall/r_wall,
+/area/engineering/storage/tech)
 "euv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -7036,27 +7351,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
-"evf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance";
-	req_access_txt = "31"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargobaylockdown";
-	name = "Cargobay Lockdown"
+"evh" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/disposal)
 "evm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "evt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -7124,33 +7429,36 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "evQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
-"ewp" = (
-/obj/effect/turf_decal/loading_area{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/turf/open/floor/engine,
+/area/engineering/supermatter)
+"evT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
+"ewp" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "ews" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"ewy" = (
+/obj/machinery/vending/tool,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/storage_shared)
 "ewC" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -7166,23 +7474,26 @@
 /turf/open/floor/engine/vacuum,
 /area/space)
 "ewR" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Vacant Offices A"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "exc" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "exo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
+"exp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "exJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -7204,14 +7515,21 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"exZ" = (
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
+"eya" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "eyh" = (
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
 "eyo" = (
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "eyq" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light/directional/east,
@@ -7276,17 +7594,13 @@
 	pixel_x = 7;
 	pixel_y = 3
 	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	name = "engineering yellow"
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "ezn" = (
 /obj/structure/rack,
 /obj/item/stack/rods/fifty,
@@ -7315,11 +7629,11 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "ezW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal)
+/area/space)
 "ezZ" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -7429,6 +7743,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/service/theater)
+"eEp" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 9;
+	name = "engineering yellow"
+	},
+/turf/open/floor/carpet/orange,
+/area/engineering/lobby)
 "eEw" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/siding/yellow{
@@ -7460,10 +7783,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
-"eGB" = (
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/iron,
-/area/space)
 "eGM" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -7496,6 +7815,21 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"eGY" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "eHr" = (
 /obj/structure/plaque,
 /obj/structure/closet/crate,
@@ -7509,6 +7843,10 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/space/nearstation)
+"eHW" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "eIr" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -7543,20 +7881,17 @@
 /obj/structure/closet/mini_fridge,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eIN" = (
-/obj/machinery/rnd/bepis,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
 "eIO" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/window{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
+"eIR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "eJi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7590,71 +7925,39 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
+"eJY" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/engineering/gravity_generator)
 "eKb" = (
 /obj/machinery/duct,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
-"eKl" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
-"eKp" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_y = 5
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo - Cargobay E";
-	name = "cargo camera"
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
 "eKE" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "eKF" = (
-/obj/structure/filingcabinet,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/window{
-	dir = 4
-	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "eKL" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
 /turf/open/floor/engine,
 /area/science/mixing)
 "eKT" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/structure/window{
 	dir = 8;
 	pixel_x = -4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "eLa" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -7667,14 +7970,9 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "eLc" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "eLt" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "HoP Office";
@@ -7750,17 +8048,11 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "eMl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal)
-"eMx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "eMz" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -7807,7 +8099,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/cargo/warehouse/upper)
+/area/space)
 "eNE" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/white/line{
@@ -7830,13 +8122,15 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"eOw" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/cargo/warehouse)
 "eOZ" = (
 /turf/open/floor/wood,
 /area/security/courtroom)
+"ePd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "ePo" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -7920,15 +8214,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/maintenance/disposal)
-"eSf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
 /area/space)
+"eSf" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "eSk" = (
 /obj/machinery/shower{
 	dir = 8
@@ -7963,6 +8253,10 @@
 /obj/item/camera/detective,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"eTA" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "eTZ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
@@ -7974,6 +8268,11 @@
 /obj/item/multitool,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"eUn" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/ai_all,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "eUr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/green{
@@ -7985,7 +8284,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal)
+/area/space)
 "eUx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8040,13 +8339,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"eWr" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
+"eWm" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "eWF" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -8075,17 +8371,38 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/science/mixing)
+"eXu" = (
+/obj/machinery/door/window/eastright{
+	name = "Danger: Conveyor Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "garbage"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eXJ" = (
 /turf/closed/wall,
 /area/commons/fitness/recreation)
 "eXM" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom/directional/west,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "eYr" = (
-/turf/open/floor/wood,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "eYE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -8097,13 +8414,9 @@
 /turf/open/floor/iron/dark/side,
 /area/construction/mining/aux_base)
 "eYX" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "eZy" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -8121,7 +8434,7 @@
 "eZN" = (
 /obj/structure/sign/poster/official/there_is_no_gas_giant,
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal)
+/area/space)
 "eZP" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/stripes/white/line{
@@ -8156,6 +8469,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"faD" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Shared Engineering Storage";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "faJ" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "cell5lock";
@@ -8177,8 +8498,16 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "faU" = (
-/turf/open/space/basic,
-/area/maintenance/disposal)
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "faX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8195,7 +8524,7 @@
 "fbg" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/cargo/warehouse/upper)
+/area/space)
 "fbl" = (
 /obj/machinery/photocopier,
 /obj/machinery/light/directional/west,
@@ -8222,6 +8551,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fbR" = (
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "fbZ" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -8401,7 +8737,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/cargo/warehouse/upper)
+/area/space)
 "fhc" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics Mixing Chamber";
@@ -8438,7 +8774,7 @@
 	name = "Atmos RC"
 	},
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "fhC" = (
 /obj/structure/table,
 /obj/item/tcgcard_deck,
@@ -8447,6 +8783,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"fib" = (
+/obj/machinery/field/generator,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "fic" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -8532,7 +8872,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "fjG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8621,13 +8961,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/space)
 "fmF" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/space)
 "fmX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -8669,7 +9007,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/cargo/warehouse/upper)
+/area/space)
 "fpg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -8706,7 +9044,7 @@
 	color = "#00FFFF"
 	},
 /turf/open/floor/iron/dark,
-/area/cargo/warehouse/upper)
+/area/space)
 "fpx" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/effect/turf_decal/stripes/line,
@@ -8726,7 +9064,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/cargo/warehouse/upper)
+/area/space)
 "fpJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -8734,7 +9072,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/cargo/warehouse/upper)
+/area/space)
 "fpN" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/yellow{
@@ -8762,7 +9100,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal)
+/area/space)
 "fqH" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -8796,10 +9134,30 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"frd" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "frq" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"frr" = (
+/obj/effect/turf_decal/tile/purple/full{
+	color = "#4D0067"
+	},
+/obj/machinery/telecomms/server/presets/science,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "frx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -8860,6 +9218,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/iron,
 /area/cargo/office)
 "fuV" = (
@@ -8924,6 +9283,21 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"fwB" = (
+/obj/structure/table,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "fwK" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4169E1";
@@ -8964,6 +9338,9 @@
 "fyr" = (
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"fyt" = (
+/turf/open/floor/iron/dark/side,
+/area/command/heads_quarters/ce)
 "fyL" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -9117,12 +9494,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
-"fCT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/cargo/warehouse/upper)
 "fCZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9172,7 +9543,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal)
+/area/space)
 "fDS" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -9195,6 +9566,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
+"fFw" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "fFD" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/table,
@@ -9208,7 +9583,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "fGo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9227,7 +9602,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "fGQ" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
@@ -9246,6 +9620,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"fHD" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
 "fHP" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/white,
@@ -9401,6 +9780,15 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/science/mixing/chamber)
+"fLS" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 5;
+	name = "engineering yellow"
+	},
+/turf/open/floor/carpet/orange,
+/area/engineering/lobby)
 "fLY" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -9415,13 +9803,19 @@
 /obj/machinery/igniter/incinerator_atmos,
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "fMr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"fMz" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "fMI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -9460,16 +9854,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "fPh" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF"
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/window{
+	pixel_y = -3
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "fPu" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"fPN" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/turf/open/floor/iron,
+/area/space)
 "fPZ" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -9586,10 +9990,22 @@
 /obj/structure/table,
 /obj/item/paper{
 	info = "<center><b>INTRUSTIONAL GUIDE TO PROCESSING NEW INMATES</center></b> <br> <br> To process inmates through this genpop system, please see the below described listas to proper processing procedures: <br> 1.Swipe new prisoner ID on a genpop locker to link them together. Store the inmate's equipment in this locker. <br> 2.Swipe your ID on the prisoner ID and assign a time for their sentencing. Attach ID to inmate. <br> 3.Process inmate through the labeled security gate, either willingly or by force. This will activate the timer on their card and start their sentencing. <br> 4.Once their sentence is over, their ID will allow them to pass through the gate once again and they will be able to freely collect their belongings. <br> 5.Escort the newly ex-inmate out through the front brig doors back out into the station.";
-	name = "Genpop - Inmate Processing and You"
+	name = "Genpop - Inmate Processing and You";
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/item/paper{
+	info = "<center><b>INTRUSTIONAL GUIDE TO PROCESSING NEW INMATES</center></b> <br> <br> To process inmates through this genpop system, please see the below described listas to proper processing procedures: <br> 1.Swipe new prisoner ID on a genpop locker to link them together. Store the inmate's equipment in this locker. <br> 2.Swipe your ID on the prisoner ID and assign a time for their sentencing. Attach ID to inmate. <br> 3.Process inmate through the labeled security gate, either willingly or by force. This will activate the timer on their card and start their sentencing. <br> 4.Once their sentence is over, their ID will allow them to pass through the gate once again and they will be able to freely collect their belongings. <br> 5.Escort the newly ex-inmate out through the front brig doors back out into the station.";
+	name = "Genpop - Inmate Processing and You";
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/paper{
+	info = "<center><b>INTRUSTIONAL GUIDE TO PROCESSING NEW INMATES</center></b> <br> <br> To process inmates through this genpop system, please see the below described listas to proper processing procedures: <br> 1.Swipe new prisoner ID on a genpop locker to link them together. Store the inmate's equipment in this locker. <br> 2.Swipe your ID on the prisoner ID and assign a time for their sentencing. Attach ID to inmate. <br> 3.Process inmate through the labeled security gate, either willingly or by force. This will activate the timer on their card and start their sentencing. <br> 4.Once their sentence is over, their ID will allow them to pass through the gate once again and they will be able to freely collect their belongings. <br> 5.Escort the newly ex-inmate out through the front brig doors back out into the station.";
+	name = "Genpop - Inmate Processing and You"
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
@@ -9627,6 +10043,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"fSK" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "fST" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9666,13 +10088,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"fTS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "fTV" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/dest_tagger,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "fUb" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -9832,7 +10259,7 @@
 "gaj" = (
 /obj/machinery/computer/security/mining,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "gar" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9865,7 +10292,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "gbZ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/suit_storage_unit/atmos,
@@ -9928,6 +10355,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gey" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Cold Loop to Gas"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "geE" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -9973,6 +10408,11 @@
 /obj/item/beacon,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"gfZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "ggf" = (
 /obj/machinery/air_sensor/atmos/ordnance_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -10141,7 +10581,7 @@
 /obj/item/gps/mining,
 /obj/item/gps/mining,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "gkI" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -10200,6 +10640,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"gmE" = (
+/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Engine Antechamber";
+	name = "Engine Camera";
+	network = list("ss13","engineering","engine")
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "gmG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
@@ -10209,7 +10660,7 @@
 	color = "#9FED58"
 	},
 /turf/open/floor/iron,
-/area/space/nearstation)
+/area/space)
 "gmN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -10302,6 +10753,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"gpA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/engine_smes)
 "gpF" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/dark,
@@ -10464,7 +10919,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "gsf" = (
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
@@ -10498,6 +10953,19 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"gsz" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Disposal Conveyor Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gsM" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Quarters";
@@ -10548,19 +11016,26 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"gtB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	sortType = 3
-	},
+"gtC" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/storage)
 "gtD" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"gud" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "guY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/vehicle/sealed/mecha/working/ripley/cargo,
@@ -10772,6 +11247,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"gzu" = (
+/turf/closed/wall/r_wall,
+/area/engineering/storage/tcomms)
 "gzv" = (
 /obj/item/food/baguette,
 /obj/structure/closet/crate,
@@ -10794,6 +11272,16 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"gzT" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/keycard_auth/directional/south,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "gzV" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -10964,6 +11452,11 @@
 /obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
+"gFI" = (
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "gFT" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -10977,6 +11470,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"gGf" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "gGs" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -11043,7 +11540,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
-/obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
@@ -11092,6 +11588,13 @@
 /obj/item/pinpointer/wayfinding,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"gKo" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cooling Bypass"
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "gKp" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/bot,
@@ -11142,6 +11645,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"gLF" = (
+/obj/machinery/modular_computer/console/preset/engineering,
+/turf/open/floor/iron,
+/area/engineering/main)
 "gMQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/head_of_personnel,
@@ -11164,6 +11671,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
+"gNn" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "gND" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -11213,9 +11727,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "gPa" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table/wood,
+/obj/structure/window{
+	pixel_y = -3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "gPj" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -11316,11 +11833,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+"gRJ" = (
+/obj/machinery/telecomms/receiver/preset_right,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "gSu" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "gSv" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -11341,7 +11865,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+/area/space)
 "gTi" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
@@ -11732,6 +12256,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hgT" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "hhc" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "researchlock";
@@ -11777,7 +12305,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "hie" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -11812,16 +12340,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/cargo/office)
-"hiC" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/space)
 "hiS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11843,6 +12361,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"hiW" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix Bypass"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"hjF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tcomms)
+"hmZ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -11922,6 +12457,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"hqr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "hqG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
@@ -11972,6 +12514,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
+"hsC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "hsE" = (
 /obj/machinery/door/airlock/security{
 	aiControlDisabled = 1;
@@ -12008,6 +12554,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"hsK" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "htf" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -12079,18 +12631,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"huH" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Cargo - Cargobay NE";
-	name = "cargo camera"
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/dark,
-/area/space)
 "huQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12147,7 +12687,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "hwf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12162,8 +12702,15 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "hwr" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/structure/window{
+	pixel_y = -3
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "hwE" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/red,
@@ -12208,13 +12755,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"hyO" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
 "hzy" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -12258,7 +12798,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "hBG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12276,16 +12816,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hCu" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Engine Coolant Bypass"
 	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/sign/warning/docking{
-	pixel_x = -30
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "hCz" = (
 /obj/item/trash/boritos,
 /turf/open/floor/plating,
@@ -12368,6 +12905,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"hDX" = (
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "hEg" = (
 /obj/machinery/exodrone_launcher,
 /obj/effect/turf_decal/box,
@@ -12489,6 +13029,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"hFE" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "hFK" = (
 /obj/structure/chair{
 	dir = 8
@@ -12513,6 +13060,16 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/space)
+"hGq" = (
+/obj/machinery/door/airlock/command{
+	name = "Telecomms Control Room";
+	req_access_txt = "19; 61"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "hGt" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hazardvest,
@@ -12712,11 +13269,11 @@
 /turf/open/floor/carpet/black,
 /area/service/chapel)
 "hLR" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "hMd" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -12779,6 +13336,10 @@
 /obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"hNg" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/circuit,
+/area/engineering/storage/tcomms)
 "hNi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -12821,6 +13382,11 @@
 	dir = 4
 	},
 /area/science/research)
+"hNV" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "hNZ" = (
 /obj/effect/turf_decal/loading_area,
 /obj/structure/cable,
@@ -12969,16 +13535,8 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "hSp" = (
-/obj/machinery/requests_console/directional/south{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo RC"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall,
+/area/command/heads_quarters/ce)
 "hSr" = (
 /obj/structure/punching_bag,
 /turf/open/floor/iron/dark/smooth_large,
@@ -13057,6 +13615,18 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"hWu" = (
+/obj/machinery/door/airlock/engineering{
+	id_tag = "EngiAccessInner";
+	name = "Engineering Access";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "hWB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -13094,6 +13664,21 @@
 "hXq" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
+"hXt" = (
+/obj/structure/table,
+/obj/item/cartridge/engineering{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 3
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "hXv" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
@@ -13149,6 +13734,13 @@
 	dir = 1
 	},
 /area/command/gateway)
+"hYn" = (
+/obj/structure/closet/crate/coffin,
+/obj/machinery/door/window/brigdoor{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "hYq" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "law3";
@@ -13164,6 +13756,18 @@
 /obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"hYv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door/directional/west{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "hYJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -13203,6 +13807,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"hZo" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "hZA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -13292,6 +13900,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"ibu" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "ibA" = (
 /obj/structure/closet/secure_closet/hos,
 /obj/structure/sign/poster/official/random{
@@ -13341,6 +13956,12 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"icM" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/iron/dark/side,
+/area/command/heads_quarters/ce)
 "icR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/stripes/corner,
@@ -13350,6 +13971,21 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"idl" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
+"idt" = (
+/obj/machinery/atmospherics/components/binary/pump/off,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "idx" = (
 /turf/open/floor/engine/n2o,
 /area/space)
@@ -13417,6 +14053,17 @@
 	},
 /turf/open/floor/wood,
 /area/security/prison/workout)
+"ifx" = (
+/obj/machinery/airalarm/engine{
+	dir = 8;
+	pixel_x = -23
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "ifB" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -13538,7 +14185,7 @@
 "iiZ" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "ijz" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -13606,10 +14253,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
 "ilj" = (
-/obj/structure/closet/cardboard,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "ilo" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -13633,12 +14283,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"ilF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+"ilC" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3;
+	pixel_x = -4
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/table,
+/obj/item/clothing/under/misc/burial,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "ilG" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -13667,6 +14321,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/telecomms,
 /area/science/xenobiology)
+"imc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "img" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 8
@@ -13784,14 +14442,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
-"ioF" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/iron/stairs{
-	dir = 4
-	},
-/area/space)
 "ioH" = (
 /obj/structure/punching_bag,
 /obj/machinery/light/directional/north,
@@ -13821,11 +14471,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "ipK" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/wood,
-/area/space)
+/area/commons/vacant_room)
 "ipP" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -13861,7 +14509,7 @@
 	id = "cargodisposals"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "iqv" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -13951,6 +14599,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"isO" = (
+/obj/effect/turf_decal/tile/blue/full{
+	color = "#73c2fb";
+	name = "Medical blue full"
+	},
+/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "isP" = (
 /obj/effect/turf_decal/loading_area/white{
 	dir = 1
@@ -14037,11 +14694,16 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "iuT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
+/obj/structure/filingcabinet,
+/obj/structure/window{
+	pixel_y = -3
 	},
-/turf/open/floor/iron,
-/area/maintenance/disposal)
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "iuU" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -14074,6 +14736,15 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"ivK" = (
+/obj/item/storage/secure/safe/directional/east,
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/command/heads_quarters/ce)
 "ivL" = (
 /obj/machinery/door/poddoor{
 	id = "Transfers Vent";
@@ -14122,7 +14793,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "ixr" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
@@ -14267,6 +14938,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"iBG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "iBJ" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/freezer,
@@ -14276,22 +14951,14 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "iBR" = (
-/obj/machinery/holopad,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/service/lawoffice)
-"iCm" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Cargo - Cargobay SW";
-	name = "cargo camera"
-	},
+"iCu" = (
+/obj/machinery/recharge_station,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/storage_shared)
 "iCz" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/circuit,
@@ -14328,8 +14995,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/rnd/production/techfab/department/cargo,
-/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/cargo/office)
 "iEG" = (
@@ -14359,6 +15024,7 @@
 /area/space)
 "iFp" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/machinery/photocopier,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "iFT" = (
@@ -14440,23 +15106,9 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "iHa" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access_txt = "48"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown/anticorner,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargobaylockdown";
-	name = "Cargobay Lockdown"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/photocopier,
 /turf/open/floor/iron,
-/area/space)
+/area/command/heads_quarters/ce)
 "iHh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -14469,7 +15121,7 @@
 	target_pressure = 4500
 	},
 /turf/open/space/basic,
-/area/cargo/warehouse/upper)
+/area/space)
 "iHy" = (
 /obj/effect/turf_decal/arrows/white{
 	dir = 4
@@ -14484,13 +15136,25 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "iHA" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"iHL" = (
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "iHM" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
@@ -14683,6 +15347,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/fore)
+"iLy" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "iLA" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/east,
@@ -14720,7 +15388,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+/area/space)
 "iMn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14953,7 +15621,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "iRe" = (
 /obj/structure/noticeboard/directional/north{
 	dir = 2;
@@ -14979,7 +15647,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "iSb" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Post";
@@ -15112,11 +15780,11 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "iUw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "iUy" = (
 /obj/effect/turf_decal/tile/red/anticorner{
 	color = "#FF0000";
@@ -15151,6 +15819,9 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"iUV" = (
+/turf/closed/wall,
+/area/engineering/storage_shared)
 "iUW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -15314,11 +15985,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
+"iZN" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iZW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "jaf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -15363,6 +16040,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"jbi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "jbq" = (
 /obj/machinery/door/window/southleft{
 	dir = 1;
@@ -15445,7 +16127,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "jco" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -15462,6 +16144,10 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/service/chapel)
+"jcq" = (
+/obj/machinery/computer/atmos_control,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "jcv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15477,7 +16163,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "jdB" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -15561,6 +16247,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"jgG" = (
+/obj/machinery/telecomms/processor/preset_one,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "jgL" = (
 /obj/machinery/vending/snack/green,
 /turf/open/floor/iron,
@@ -15595,6 +16288,16 @@
 	},
 /turf/open/space/basic,
 /area/command/heads_quarters/cmo)
+"jii" = (
+/obj/structure/table,
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/candle{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "jil" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine{
@@ -15602,12 +16305,9 @@
 	},
 /area/holodeck/rec_center)
 "jin" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/engineering/main)
 "jiF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15633,6 +16333,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
+"jiV" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/engineering/gravity_generator)
 "jje" = (
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 4
@@ -15664,6 +16370,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"jjM" = (
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341";
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/engineering/lobby)
 "jjN" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
@@ -15791,6 +16504,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"jnr" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "jnv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -15835,6 +16552,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"joG" = (
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "joK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -15869,15 +16598,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"jpC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
 "jpD" = (
 /obj/machinery/computer/atmos_control/incinerator,
 /obj/effect/turf_decal/siding/green{
@@ -15886,7 +16606,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "jpE" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Courtroom Judge";
@@ -15900,6 +16620,10 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"jpM" = (
+/obj/machinery/computer/department_orders/engineering,
+/turf/open/floor/iron,
+/area/engineering/main)
 "jqa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15909,6 +16633,17 @@
 "jqT" = (
 /turf/open/floor/engine/air,
 /area/space)
+"jqV" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "jqW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/bureaucracy/briefcase,
@@ -15944,7 +16679,7 @@
 /obj/item/stack/ore/glass,
 /obj/item/stack/ore/glass,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "jsw" = (
 /obj/structure/chair{
 	dir = 4
@@ -15954,7 +16689,7 @@
 "jsH" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "jtM" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -16043,13 +16778,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jxX" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/gravity_generator)
 "jyj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16070,6 +16803,15 @@
 /obj/structure/chair,
 /turf/open/floor/iron/white/side,
 /area/science/research)
+"jyw" = (
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
+	},
+/obj/machinery/telecomms/server/presets/engineering,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "jyE" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	color = "#FFD700";
@@ -16108,8 +16850,8 @@
 /area/medical/storage)
 "jzC" = (
 /obj/structure/plasticflaps/opaque,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "jzK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16124,6 +16866,13 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"jzP" = (
+/obj/structure/table,
+/obj/item/wirecutters,
+/obj/item/multitool,
+/obj/item/screwdriver,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "jAg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -16144,13 +16893,8 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "jAo" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/iron/dark/corner,
+/area/engineering/gravity_generator)
 "jAv" = (
 /obj/structure/bookcase,
 /turf/open/floor/carpet/red,
@@ -16287,9 +17031,13 @@
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
-/area/maintenance/disposal)
+/area/space)
+"jEJ" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/engineering/gravity_generator)
 "jEP" = (
-/obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16305,9 +17053,13 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "jFp" = (
-/obj/structure/janitorialcart,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/structure/window{
+	pixel_y = -3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "jFq" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/blood/random,
@@ -16353,6 +17105,7 @@
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 4
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jGO" = (
@@ -16411,8 +17164,11 @@
 	name = "Cargo Bay Maintenance";
 	req_one_access_txt = "31"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/fore)
 "jHE" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -16548,6 +17304,9 @@
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/space)
+"jLw" = (
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "jLA" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	color = "#FFD700";
@@ -16594,13 +17353,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"jNg" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
-	},
-/turf/open/floor/iron,
-/area/space)
 "jNh" = (
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/structure/disposalpipe/segment{
@@ -16643,6 +17395,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"jOg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "jOj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar/directional/west,
@@ -16705,6 +17462,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"jPg" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "jPx" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -17029,12 +17790,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "jXR" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/siding/green{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light/small/directional/east,
+/obj/structure/window{
+	pixel_y = -3
 	},
-/turf/open/floor/iron,
-/area/service/hydroponics)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "jYo" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/blue/anticorner{
@@ -17043,6 +17807,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"jYE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
+"jYX" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "jZc" = (
 /obj/machinery/door/airlock{
 	name = "Prosecution Office";
@@ -17183,6 +17955,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"kcO" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "kcP" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/brown/anticorner,
@@ -17323,6 +18101,9 @@
 /obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "kgf" = (
@@ -17521,7 +18302,7 @@
 "kmx" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
-/area/cargo/warehouse/upper)
+/area/space)
 "kmN" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -17589,7 +18370,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "kox" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -17625,6 +18406,13 @@
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kpo" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "kpI" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -17701,7 +18489,7 @@
 /obj/structure/rack,
 /obj/item/paper_bin,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "krK" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17771,6 +18559,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/range)
+"kuW" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "kvc" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -17795,9 +18587,19 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library/private)
+"kwf" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "kwi" = (
 /turf/closed/wall/r_wall,
 /area/medical/morgue)
+"kwA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "kwB" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/radiation,
@@ -17824,7 +18626,7 @@
 	color = "#4D0067"
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "kwN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/south,
@@ -17864,6 +18666,13 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"kxf" = (
+/obj/machinery/telecomms/receiver/preset_left,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "kxs" = (
 /obj/effect/turf_decal/siding/green/end{
 	dir = 1
@@ -18012,9 +18821,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kBW" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "kCe" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -18386,7 +19195,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "kLP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -18483,6 +19292,10 @@
 "kNl" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"kNq" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kNw" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
@@ -18522,6 +19335,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"kOj" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "kOB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18873,6 +19690,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
+"kUC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "kUL" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron/dark/smooth_large,
@@ -19176,6 +19999,12 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"lbc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/storage)
 "lbf" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Aux Base Construction";
@@ -19253,23 +20082,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
-"lcf" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo - Cargobay SE";
-	name = "cargo camera"
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
 "lcn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "lcD" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "AI Core - Teleporter Room";
@@ -19302,7 +20120,6 @@
 	c_tag = "Public Defender Office";
 	name = "Law Office Camera"
 	},
-/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
 "ldO" = (
@@ -19377,6 +20194,15 @@
 /obj/item/clothing/suit/armor/riot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"leC" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "leV" = (
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
@@ -19408,12 +20234,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"lfe" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/space)
 "lfA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -19553,6 +20373,16 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"ljB" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Monitoring";
+	req_access_txt = "32"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "ljD" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/tile/bar,
@@ -19651,7 +20481,6 @@
 /area/space)
 "lmC" = (
 /obj/effect/landmark/start/roboticist,
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
@@ -19928,11 +20757,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
-"lsY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/brown/half,
-/turf/open/floor/iron,
-/area/space)
 "ltl" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -19980,6 +20804,12 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"ltN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "ltU" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -19992,6 +20822,10 @@
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
+"lud" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "luo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -20131,6 +20965,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
+"lyB" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "lyK" = (
 /obj/machinery/processor/slime,
 /obj/machinery/light/directional/west,
@@ -20159,7 +20999,7 @@
 /area/science/research)
 "lzH" = (
 /turf/open/floor/iron,
-/area/maintenance/starboard/fore)
+/area/cargo/sorting)
 "lAa" = (
 /obj/machinery/rnd/bepis,
 /obj/effect/turf_decal/tile/brown/half,
@@ -20333,6 +21173,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"lDY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/storage/tcomms)
 "lEa" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -20369,6 +21214,9 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"lER" = (
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "lFH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -20376,9 +21224,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "lFM" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/cargo/warehouse/upper)
+/turf/closed/wall,
+/area/maintenance/disposal)
 "lFX" = (
 /obj/effect/turf_decal/caution/stand_clear/red{
 	dir = 1
@@ -20406,9 +21253,10 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "lGL" = (
-/obj/effect/spawner/random/entertainment/gambling,
+/obj/machinery/door/poddoor/massdriver_trash,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/disposal)
 "lGU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -20438,6 +21286,11 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
+"lHv" = (
+/obj/structure/table,
+/obj/item/plant_analyzer,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "lHF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -20569,12 +21422,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "lKW" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_one_access_txt = "10;24"
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "lKY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20777,6 +21633,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"lOF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "lOI" = (
 /obj/machinery/shower{
 	dir = 4
@@ -20794,9 +21654,13 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "lPl" = (
-/obj/machinery/firealarm/directional/south,
-/turf/closed/wall,
-/area/space)
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/ce)
 "lPs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -20839,6 +21703,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"lQI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "lQK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -20977,10 +21853,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "lTg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "lTh" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/green/anticorner{
@@ -21023,6 +21899,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"lUd" = (
+/obj/machinery/telecomms/processor/preset_two,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "lUf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -21223,6 +22103,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"lYm" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "lYo" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -21259,6 +22146,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"lZm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "lZC" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "toxinsrd";
@@ -21447,21 +22340,11 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "mda" = (
-/obj/effect/turf_decal/stripes/white/line{
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/structure/railing{
-	layer = 3.1;
-	pixel_y = -4
-	},
-/obj/structure/statue{
-	desc = "A lifelike statue of a horrifying monster.";
-	dir = 8;
-	icon = 'icons/mob/lavaland/lavaland_monsters.dmi';
-	icon_state = "goliath";
-	name = "goliath"
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/space)
 "mdq" = (
 /obj/structure/chair{
@@ -21557,6 +22440,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central/aft)
+"mfx" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/engineering/engine_smes)
 "mfA" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/research_and_development,
@@ -21635,17 +22528,22 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/space/nearstation)
+"mhF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "mic" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "miw" = (
-/obj/machinery/conveyor/inverted{
-	dir = 6;
-	id = "QMLoad2"
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "miE" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
@@ -21807,7 +22705,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "mmC" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/geneticist,
@@ -21828,6 +22726,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"mmN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "mmP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -21898,8 +22800,11 @@
 /turf/open/floor/engine/plasma,
 /area/space)
 "mpa" = (
-/turf/closed/wall/r_wall,
-/area/cargo/warehouse/upper)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "mpd" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
@@ -21989,15 +22894,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"msI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
 "msP" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/co2,
@@ -22036,8 +22932,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"mtQ" = (
+/obj/effect/spawner/random/entertainment/gambling,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mtR" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
 	dir = 1;
@@ -22061,6 +22960,10 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/space)
+"mux" = (
+/obj/machinery/modular_computer/console/preset/civilian,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "muz" = (
 /obj/structure/chair{
 	dir = 4
@@ -22082,6 +22985,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"muK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "muW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22147,6 +23056,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"mwe" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/rnd_secure_all,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "mwp" = (
 /obj/structure/sink{
 	pixel_y = 14
@@ -22155,6 +23069,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"mwF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "mwG" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -22261,6 +23179,10 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"mAI" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/engineering/main)
 "mAO" = (
 /obj/structure/table/wood/fancy,
 /obj/item/book/granter/spell/smoke/lesser,
@@ -22677,20 +23599,21 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "mHk" = (
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 10
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "mHA" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"mHD" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "mIh" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22945,6 +23868,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
+"mMH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "mMO" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
@@ -23074,6 +24001,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"mOK" = (
+/turf/closed/wall/r_wall,
+/area/engineering/storage)
+"mOS" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 10;
+	name = "engineering yellow"
+	},
+/turf/open/floor/carpet/orange,
+/area/engineering/lobby)
+"mOV" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "mPn" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -23133,6 +24083,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"mQn" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "mQD" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -23198,7 +24154,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "mSw" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/iron,
@@ -23317,6 +24273,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"mVb" = (
+/obj/structure/closet/crate/solarpanel_small,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "mVh" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -23333,20 +24295,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "mVt" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargobaylockdown";
-	name = "Cargobay Lockdown"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "mVG" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Post - Medbay";
@@ -23420,6 +24373,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"mYR" = (
+/obj/machinery/door/poddoor{
+	id = "engstorage";
+	name = "Engineering Secure Storage Lockdown"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage)
 "mYY" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/microwave,
@@ -23482,6 +24442,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"mZy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "mZJ" = (
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
@@ -23588,10 +24554,11 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "nbT" = (
-/obj/machinery/holopad,
-/obj/structure/window/reinforced,
-/turf/open/floor/wood,
-/area/security/courtroom)
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "nbV" = (
 /obj/item/target,
 /obj/effect/decal/cleanable/dirt,
@@ -23607,6 +24574,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"ncD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "ncK" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -23621,6 +24592,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
+"ncY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "ndh" = (
 /obj/structure/chair{
 	dir = 8;
@@ -23666,15 +24642,10 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "neq" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/light/small/directional/west,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "new" = (
 /obj/effect/turf_decal/tile/red/anticorner{
 	color = "#FF0000";
@@ -23745,7 +24716,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/maintenance/department/cargo)
+/area/space)
 "ngw" = (
 /obj/machinery/exodrone_launcher,
 /obj/item/exodrone,
@@ -23882,21 +24853,22 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "nnj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "nnF" = (
 /obj/machinery/suit_storage_unit/rd,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
+"nnK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "nnR" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red/half{
@@ -23967,7 +24939,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "noy" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/carpet/neon/simple/purple,
@@ -24053,6 +25025,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
+"nqe" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/engineering/gravity_generator)
 "nqf" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
@@ -24072,6 +25049,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"nqk" = (
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/command/heads_quarters/ce)
 "nqv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24105,6 +25088,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"nrF" = (
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/healthanalyzer,
+/obj/machinery/camera/autoname/directional/south,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "nrG" = (
 /obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron/white/smooth_large,
@@ -24158,6 +25148,12 @@
 	dir = 4
 	},
 /area/medical/treatment_center)
+"ntB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "ntE" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -24166,6 +25162,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"ntM" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/multitool,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"nub" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "nuk" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24193,6 +25207,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"nuN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/storage)
 "nve" = (
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
@@ -24204,6 +25224,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"nvq" = (
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/lighter,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "nvA" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -24253,6 +25284,16 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"nwX" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "nxd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -24283,6 +25324,18 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"nxm" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "nxy" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/directional/east,
@@ -24382,7 +25435,7 @@
 	id = "cargodisposals"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "nyK" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
@@ -24496,6 +25549,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/space)
+"nBn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "nBB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/purple,
@@ -24532,6 +25592,13 @@
 	dir = 4
 	},
 /area/medical/treatment_center)
+"nCd" = (
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341";
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/engineering/lobby)
 "nDc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24628,6 +25695,10 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
+	},
+/obj/item/paper{
+	info = "<center><b>INTRUSTIONAL GUIDE TO PROCESSING NEW INMATES</center></b> <br> <br> To process inmates through this genpop system, please see the below described listas to proper processing procedures: <br> 1.Swipe new prisoner ID on a genpop locker to link them together. Store the inmate's equipment in this locker. <br> 2.Swipe your ID on the prisoner ID and assign a time for their sentencing. Attach ID to inmate. <br> 3.Process inmate through the labeled security gate, either willingly or by force. This will activate the timer on their card and start their sentencing. <br> 4.Once their sentence is over, their ID will allow them to pass through the gate once again and they will be able to freely collect their belongings. <br> 5.Escort the newly ex-inmate out through the front brig doors back out into the station.";
+	name = "Genpop - Inmate Processing and You"
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
@@ -24758,10 +25829,17 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "nLH" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"nLY" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "nMr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -24834,6 +25912,20 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
+"nNN" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office";
+	req_access_txt = "56"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "nNQ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/directional/east,
@@ -24857,6 +25949,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
+"nOD" = (
+/obj/structure/closet/crate/coffin,
+/obj/machinery/door/window/brigdoor/eastright{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "nOP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24880,6 +25979,10 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"nQn" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "nQo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -24906,6 +26009,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
+"nQT" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Supermatter Chamber";
+	network = list("engine")
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "nQV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
@@ -24921,6 +26031,14 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/plastic,
 /area/command/heads_quarters/captain/private)
+"nRD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "nRG" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -24950,23 +26068,9 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "nRQ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1;
-	pixel_y = 4
-	},
-/obj/structure/statue{
-	desc = "A lifelike statue of a horrifying monster.";
-	dir = 8;
-	icon = 'icons/mob/lavaland/lavaland_monsters.dmi';
-	icon_state = "goliath";
-	name = "goliath"
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "nRR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -24988,6 +26092,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"nSw" = (
+/obj/structure/table,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "nSO" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/black,
@@ -25022,6 +26133,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"nTy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "nTC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25054,6 +26170,15 @@
 /obj/item/paper_bin,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"nWc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nWm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -25077,7 +26202,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/ore_box,
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "nWT" = (
 /obj/structure/rack,
 /obj/item/screwdriver{
@@ -25136,23 +26261,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "nXR" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access_txt = "48"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargobaylockdown";
-	name = "Cargobay Lockdown"
-	},
+/obj/structure/filingcabinet/chestdrawer,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron,
-/area/space)
+/area/command/heads_quarters/ce)
 "nXY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -25289,6 +26401,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"ocs" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/engineering/main)
 "ocN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -25396,7 +26513,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "ofj" = (
 /obj/effect/landmark/event_spawn,
 /obj/item/beacon,
@@ -25410,13 +26527,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ofF" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4;
+	name = "Output Release"
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "ofJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
@@ -25606,6 +26722,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"omi" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "omD" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -25753,6 +26873,18 @@
 	dir = 8
 	},
 /area/science/research)
+"opQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "oqg" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/purple/half{
@@ -25763,6 +26895,12 @@
 	dir = 1
 	},
 /area/science/research)
+"oql" = (
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "oqB" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -25852,6 +26990,12 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"osD" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/engineering_all,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "osW" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -25862,6 +27006,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"otg" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
+"otv" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/wizard,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "otI" = (
 /obj/machinery/prisongate,
 /obj/machinery/door/firedoor,
@@ -25906,6 +27063,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ovA" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "owe" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -25950,6 +27111,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
+"oxl" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "oxx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -26071,6 +27237,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"oAn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
 "oAr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/full{
@@ -26081,6 +27252,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"oAs" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "oAE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "researchlock";
@@ -26096,13 +27271,8 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "oAL" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "oBb" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -26132,7 +27302,7 @@
 	icon_state = "plant-10"
 	},
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "oBA" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -26272,11 +27442,12 @@
 	id = "cargodisposals"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "oDC" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "oDR" = (
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_y = 30
@@ -26447,26 +27618,26 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oHf" = (
-/obj/machinery/holopad,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"oHk" = (
+/obj/effect/turf_decal/tile/blue/full{
+	color = "#4169E1";
+	name = "Command blue full"
+	},
+/obj/machinery/telecomms/server/presets/command,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "oHn" = (
-/obj/machinery/computer/cargo{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/brown/half{
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/area/engineering/gravity_generator)
 "oHJ" = (
 /obj/machinery/doppler_array/research/science{
 	dir = 8
@@ -26508,17 +27679,9 @@
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"oIx" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/space)
 "oIK" = (
 /turf/open/floor/iron/dark,
-/area/cargo/warehouse/upper)
+/area/space)
 "oJf" = (
 /obj/effect/mapping_helpers/dead_body_placer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26631,6 +27794,11 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
+"oLD" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/service_all,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "oLE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -26649,6 +27817,19 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"oNf" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"oNh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tcomms)
 "oNz" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -26659,12 +27840,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
 "oNH" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/gravity_generator)
 "oNI" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -26690,6 +27869,11 @@
 /obj/structure/chair/pew,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"oOX" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/techstorage/command_all,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "oPq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26789,7 +27973,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "oRE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/slot_machine,
@@ -26806,6 +27990,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"oRZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "oSh" = (
 /obj/structure/sign/poster/official/ian{
 	pixel_y = 30
@@ -26827,6 +28017,13 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"oSy" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "oSC" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
@@ -26886,6 +28083,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"oUh" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "oUA" = (
 /obj/structure/closet/crate/grave,
 /obj/structure/sign/poster/official/ian{
@@ -26933,9 +28139,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "oVP" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "oVY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26953,6 +28161,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"oWe" = (
+/obj/machinery/suit_storage_unit/engine,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "oWl" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
@@ -27060,14 +28272,9 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "oZZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/engineering/engine_smes)
 "pap" = (
 /obj/item/target,
 /obj/effect/decal/cleanable/dirt,
@@ -27160,6 +28367,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"pcr" = (
+/turf/closed/wall/r_wall,
+/area/engineering/engine_smes)
 "pcs" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4169E1";
@@ -27173,7 +28383,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/science/xenobiology)
+/area/space)
 "pdl" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
@@ -27194,6 +28404,12 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
+"peN" = (
+/obj/structure/rack,
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/spawner/random/techstorage/medical_all,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "pfm" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -27484,6 +28700,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"pnE" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "pnG" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/siding/purple{
@@ -27551,6 +28771,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central/aft)
+"prg" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Cooling Loop"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "prj" = (
 /obj/structure/bed/dogbed/mcgriff,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
@@ -27565,9 +28793,12 @@
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "prR" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/hop)
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 4;
+	filter_type = list(/datum/gas/nitrogen)
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "psq" = (
 /obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
@@ -27593,6 +28824,11 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/space/nearstation)
+"psW" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "ptd" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/table/glass,
@@ -27664,6 +28900,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"pvs" = (
+/obj/structure/table,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "pwb" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -27730,7 +28972,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "pyY" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -27825,7 +29067,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "pBD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27989,6 +29231,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"pGX" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron,
+/area/engineering/main)
 "pIx" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -28024,6 +29273,14 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
+"pKo" = (
+/obj/structure/table,
+/obj/item/toy/figure/ce,
+/obj/item/storage/box/matches{
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "pKC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
@@ -28061,39 +29318,23 @@
 /obj/structure/aquarium,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"pLj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/command/heads_quarters/ce)
 "pLs" = (
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/east{
-	id = "cargoload";
-	layer = 3.3;
-	name = "Loading Doors";
-	pixel_x = -24;
-	pixel_y = -8;
-	req_access_txt = "31"
-	},
-/obj/machinery/button/door/directional/east{
-	id = "cargounload";
-	layer = 3.3;
-	name = "Unloading Doors";
-	pixel_x = -24;
-	pixel_y = 8;
-	req_access_txt = "31"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Cargo - Cargobay W";
-	name = "cargo camera"
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/analyzer,
+/obj/item/analyzer,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "pLD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/meter,
@@ -28247,7 +29488,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "pPY" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -28380,23 +29621,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"pTO" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargobaylockdown";
-	name = "Cargobay Lockdown"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
 "pTX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -28441,7 +29665,6 @@
 /area/command/heads_quarters/hos)
 "pWg" = (
 /obj/structure/cable,
-/obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "pWq" = (
@@ -28475,6 +29698,11 @@
 "pWO" = (
 /turf/closed/indestructible/opshuttle,
 /area/science/test_area)
+"pWP" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pXe" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -28489,11 +29717,9 @@
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
 "pXW" = (
-/obj/structure/table/wood,
-/obj/item/toy/figure/wizard,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/wood,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "pYh" = (
 /turf/closed/wall,
 /area/cargo/qm)
@@ -28704,6 +29930,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/space)
+"qfU" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "qgi" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/regular,
@@ -28806,6 +30036,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"qhN" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "qic" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
@@ -28838,6 +30078,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"qiS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "qiV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/chapel{
@@ -28915,6 +30159,16 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qlL" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering Escape Pod";
+	req_access_txt = "32"
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "qlZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -28975,7 +30229,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "qnZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29006,6 +30260,11 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"qph" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "qpm" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -29042,6 +30301,15 @@
 "qpX" = (
 /turf/open/space/basic,
 /area/command/heads_quarters/cmo)
+"qqK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qrh" = (
 /obj/structure/rack,
 /obj/item/grenade/barrier,
@@ -29065,6 +30333,13 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
+"qsL" = (
+/obj/structure/table,
+/obj/item/electronics/apc,
+/obj/item/electronics/airlock,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "qta" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
@@ -29116,10 +30391,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"qtW" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "qtY" = (
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/iron,
-/area/space/nearstation)
+/area/space)
 "qum" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
@@ -29159,9 +30442,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
+"qwo" = (
+/turf/closed/wall,
+/area/engineering/lobby)
 "qwq" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/central)
+"qwr" = (
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "qwH" = (
 /obj/structure/grille/broken,
 /turf/open/space/basic,
@@ -29185,6 +30474,12 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"qxy" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "qxH" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
@@ -29314,12 +30609,25 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
+"qBP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"qBU" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "qCa" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "qCy" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
@@ -29626,12 +30934,15 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "qIu" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/structure/window{
-	dir = 4
+/obj/machinery/mass_driver/trash{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "qID" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -29665,6 +30976,12 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"qIG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "qII" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29676,7 +30993,7 @@
 /obj/structure/table,
 /obj/item/crowbar,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/fore)
 "qIV" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -29721,7 +31038,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "qJQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29816,6 +31133,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qNP" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "qNU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29841,7 +31164,7 @@
 /obj/structure/rack,
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "qOv" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -29926,6 +31249,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"qRD" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "qRX" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -29944,6 +31273,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/server)
+"qTF" = (
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "qTK" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -29951,6 +31283,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qTL" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "qUk" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/security_space_law,
@@ -29965,6 +31303,12 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
+"qUy" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/space)
 "qUK" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29975,12 +31319,11 @@
 	name = "Warehouse Maintenance";
 	req_one_access_txt = "31"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "qmlock";
-	name = "Quartermaster Lockdown Shutters"
-	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/fore)
+"qVC" = (
+/turf/closed/wall,
+/area/cargo/miningdock)
 "qWk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -29995,7 +31338,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "qWM" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -30044,7 +31387,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "qXY" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/barricade/wooden,
@@ -30094,7 +31437,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/cargo/sorting)
 "qZl" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/window/reinforced,
@@ -30127,6 +31470,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/lawoffice)
+"qZI" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "rav" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -30254,6 +31607,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"reH" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "reI" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /obj/structure/sign/painting/library_secure{
@@ -30278,16 +31642,10 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "rff" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
+/turf/open/floor/iron/dark/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/space)
+/area/engineering/gravity_generator)
 "rfm" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/heater,
 /turf/open/floor/iron,
@@ -30391,10 +31749,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"riR" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "rjB" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "rjC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30423,6 +31785,11 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"rkd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "rkj" = (
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
@@ -30440,6 +31807,17 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"rkN" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
 "rkX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -30539,10 +31917,15 @@
 "rny" = (
 /turf/open/space/basic,
 /area/medical/surgery)
-"rnT" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/space)
+"rnM" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "rnV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30575,6 +31958,13 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"roG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "roU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30702,10 +32092,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"rrQ" = (
-/obj/machinery/door/poddoor/atmos_test_room_mainvent_2,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/solars/port/fore)
 "rsm" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -30713,11 +32099,22 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"rst" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access_txt = "23"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "rsF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/maintenance/starboard/fore)
+/area/cargo/sorting)
 "rte" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30739,6 +32136,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"rua" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "rug" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -30765,7 +32169,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "ruy" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/trimline/red/line{
@@ -31038,6 +32442,13 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rCS" = (
+/obj/machinery/telecomms/broadcaster/preset_left,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "rCX" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -31208,6 +32619,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rGK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "rGQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
@@ -31215,6 +32633,38 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
+"rGR" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_y = 10;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_x = -36;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door/directional/west{
+	desc = "A remote control switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_y = -6;
+	req_access_txt = "10"
+	},
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 5;
+	name = "Chief Engineer's Request Console"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "rGX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -31275,7 +32725,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "rIK" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -31315,6 +32765,14 @@
 	icon_state = "wood-broken"
 	},
 /area/service/abandoned_gambling_den)
+"rJk" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
+"rJl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/miningdock)
 "rJm" = (
 /obj/machinery/door/window/northright,
 /obj/effect/decal/cleanable/dirt,
@@ -31437,13 +32895,15 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "rKO" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "rLq" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "rLr" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/bot,
@@ -31535,6 +32995,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"rMT" = (
+/obj/effect/turf_decal/trimline/blue/corner,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "rNG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31587,6 +33051,9 @@
 "rQB" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"rQF" = (
+/turf/closed/wall,
+/area/engineering/storage/tech)
 "rQL" = (
 /obj/structure/chair{
 	dir = 1
@@ -31596,6 +33063,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"rQM" = (
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/engineering/gravity_generator)
 "rRa" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067"
@@ -31662,6 +33134,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rSj" = (
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341";
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/royalblack,
+/area/engineering/lobby)
 "rSA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -31694,6 +33174,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"rSO" = (
+/obj/structure/table,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "rSQ" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Ordnance Lab";
@@ -31831,11 +33315,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/prison/workout)
-"rWd" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
-/turf/open/floor/iron/dark,
-/area/space)
 "rWk" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -31970,11 +33449,8 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "rXN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "rXV" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/roboticist,
@@ -32081,6 +33557,15 @@
 	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
 /area/maintenance/port/fore)
+"saS" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	desc = "NT didn't give them one, so they made one..";
+	name = "jury-rigged microwave";
+	pixel_y = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "saW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32149,6 +33634,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
+"scO" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "scV" = (
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -32192,6 +33681,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"sdD" = (
+/obj/machinery/computer/station_alert,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "sdF" = (
 /obj/machinery/modular_computer/console/preset/cargochat/science,
 /obj/effect/turf_decal/tile/brown/full,
@@ -32210,6 +33703,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"sdW" = (
+/obj/machinery/telecomms/bus/preset_three,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "sef" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -32267,6 +33764,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"sgh" = (
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "sgj" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/structure/window/reinforced,
@@ -32305,6 +33813,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"shc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "shd" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/yellow{
@@ -32395,6 +33909,20 @@
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"sjN" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 1;
+	icon_state = "left";
+	name = "Danger: Conveyor Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "skL" = (
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 8
@@ -32638,17 +34166,8 @@
 	},
 /area/service/chapel)
 "spf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall,
+/area/engineering/main)
 "spg" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	color = "#990099";
@@ -32794,6 +34313,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
+"ssB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/turf/open/floor/plating,
+/area/command/heads_quarters/ce)
 "ssG" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -32828,13 +34355,17 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"suo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/storage_shared)
 "suB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/department/cargo)
+/area/space)
 "suG" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -32850,6 +34381,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"suW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "suX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32869,6 +34406,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"svk" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/circuit,
+/area/engineering/storage/tcomms)
 "svy" = (
 /obj/item/radio/off,
 /obj/item/screwdriver,
@@ -32930,10 +34471,12 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "swf" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "sww" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -32963,6 +34506,14 @@
 	},
 /turf/open/floor/iron,
 /area/science/genetics)
+"swF" = (
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255
+	},
+/obj/machinery/telecomms/server/presets/common,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "swM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32988,6 +34539,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/brig/upper)
+"swT" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tcomms)
 "swV" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -33030,6 +34587,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"syp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "syX" = (
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 1
@@ -33047,6 +34608,10 @@
 	dir = 1
 	},
 /area/security/range)
+"szo" = (
+/obj/machinery/power/emitter,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "szr" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -33073,13 +34638,9 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "sAa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "sAG" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 1;
@@ -33090,17 +34651,16 @@
 /obj/item/bedsheet/green,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"sAK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/xenobiology)
 "sAM" = (
 /obj/structure/rack,
 /obj/effect/spawner/costume/pirate,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"sAN" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "sBx" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -33176,6 +34736,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"sDu" = (
+/turf/closed/wall,
+/area/engineering/storage)
 "sDK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33245,6 +34808,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"sGE" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/tank_holder/oxygen/red,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "sHa" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -33267,6 +34836,10 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
+"sIF" = (
+/obj/machinery/shieldgen,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "sIJ" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Prison Medbay";
@@ -33767,6 +35340,17 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"sXV" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Shared Engineering Storage";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "sYj" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/siding/green{
@@ -33779,12 +35363,11 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "sYm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/security/brig/upper)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "sYs" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
@@ -33917,6 +35500,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/carpet,
 /area/service/bar)
+"tct" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "tcN" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -34058,6 +35645,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
+"tgF" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/engineering/gravity_generator)
 "tgL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -34080,6 +35673,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"thi" = (
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "thy" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -34302,6 +35905,9 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"tmX" = (
+/turf/closed/wall,
+/area/engineering/gravity_generator)
 "tmZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -34359,15 +35965,11 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "tok" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
-/area/maintenance/disposal)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "toB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -34385,6 +35987,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/security/prison/workout)
+"tqj" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "tqs" = (
 /turf/closed/wall,
 /area/science/genetics)
@@ -34424,6 +36030,14 @@
 	dir = 1
 	},
 /area/medical/treatment_center)
+"tri" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/engineering/main)
+"tru" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "trU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -34567,6 +36181,10 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tux" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "tuJ" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -34582,7 +36200,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "tvj" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/tile/blue{
@@ -34732,7 +36350,7 @@
 	id = "qmprivacy";
 	name = "Quartermaster Privacy Shutters"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/cargo/qm)
 "tyu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -34993,13 +36611,10 @@
 /turf/open/floor/iron,
 /area/space)
 "tDP" = (
-/mob/living/simple_animal/sloth/paperwork,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/beacon,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "tDR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -35149,6 +36764,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tIE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tII" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/contraband/permabrig_gear,
@@ -35169,14 +36793,12 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "tJp" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/power/smes{
+	charge = 500000
 	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "tJH" = (
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
@@ -35199,7 +36821,7 @@
 	id = "qmlock";
 	name = "Quartermaster Lockdown Shutters"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/cargo/qm)
 "tKL" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -35315,6 +36937,10 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"tOo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "tOH" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -35510,6 +37136,19 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"tSL" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "tSO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -35532,6 +37171,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"tTp" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "tTw" = (
 /obj/item/lightreplacer,
 /obj/item/lightreplacer,
@@ -35639,6 +37289,13 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
+"tVD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron,
+/area/engineering/main)
 "tVL" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -35770,6 +37427,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"tYo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/side,
+/area/command/heads_quarters/ce)
 "tYq" = (
 /obj/structure/railing{
 	dir = 1;
@@ -35997,12 +37658,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ucB" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "ucK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -36321,6 +37981,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"ukK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "ukN" = (
 /obj/machinery/computer/turbine_computer{
 	id = "incineratorturbine"
@@ -36330,7 +37995,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/disposal)
+/area/space)
 "ukP" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 10
@@ -36342,6 +38007,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"ukZ" = (
+/obj/machinery/telecomms/bus/preset_four,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "ulG" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/purple{
@@ -36374,10 +38046,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"umn" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/maintenance/department/cargo)
+"umA" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "umF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Transfers Chamber";
@@ -36627,8 +38301,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable,
+/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/cargo/office)
 "uqu" = (
@@ -36817,6 +38491,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
+"uup" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "uuq" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -36829,11 +38509,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "uuQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "uuR" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron,
@@ -36978,12 +38656,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uxX" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 2
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/space)
+/area/engineering/gravity_generator)
 "uyA" = (
 /obj/structure/moisture_trap,
 /turf/open/floor/plating,
@@ -36993,7 +38671,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/cargo/warehouse/upper)
+/area/space)
 "uzd" = (
 /obj/item/storage/briefcase/lawyer,
 /obj/structure/rack,
@@ -37005,14 +38683,9 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
 "uAD" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "uBb" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating,
@@ -37082,6 +38755,14 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"uCz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "uCF" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -37290,6 +38971,19 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/solars/port/fore)
+"uGI" = (
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Danger: Conveyor Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "uGJ" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
@@ -37367,6 +39061,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
+"uHP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "uHU" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -37403,14 +39103,13 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "uIp" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "uIq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -37418,6 +39117,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/range)
+"uIT" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "uIW" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Firing Range";
@@ -37441,6 +39149,10 @@
 "uJl" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science)
+"uJn" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "uJr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -37455,9 +39167,9 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "uKd" = (
-/obj/machinery/photocopier,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "uKi" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
@@ -37470,7 +39182,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "uKs" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
@@ -37505,6 +39217,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/range)
+"uLm" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "uLL" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -37520,6 +39237,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"uLY" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/iron,
+/area/engineering/main)
 "uMm" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -37559,6 +39280,11 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"uMv" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "uMB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -37645,12 +39371,16 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "uNX" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
 	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/main)
 "uNY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
@@ -37898,6 +39628,13 @@
 /obj/item/taperecorder,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
+"uTx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "uTD" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -37991,9 +39728,10 @@
 /turf/open/floor/iron,
 /area/space/nearstation)
 "uVI" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "uVJ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/west,
@@ -38056,7 +39794,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "uXf" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -38094,6 +39831,12 @@
 /obj/item/pen/red,
 /turf/open/floor/carpet/red,
 /area/service/lawoffice)
+"uXN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "uXP" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/tile/blue,
@@ -38210,8 +39953,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/filingcabinet/filingcabinet,
 /obj/structure/cable,
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/cargo/office)
 "vbB" = (
@@ -38368,6 +40112,12 @@
 /obj/structure/chair/pew/left,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"vgf" = (
+/obj/structure/table/glass,
+/obj/item/folder/yellow,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "vgg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38380,7 +40130,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/space)
+/area/cargo/miningdock)
 "vgw" = (
 /obj/structure/chair/pew/right,
 /turf/open/floor/wood,
@@ -38670,6 +40420,10 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
+"vmh" = (
+/obj/machinery/computer/telecomms/monitor,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "vml" = (
 /obj/structure/chair{
 	dir = 8
@@ -38685,6 +40439,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"vmn" = (
+/obj/machinery/telecomms/broadcaster/preset_right,
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
+	dir = 8
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "vmr" = (
 /obj/effect/wisp,
 /turf/open/floor/plating{
@@ -38695,12 +40456,9 @@
 /turf/closed/wall,
 /area/security)
 "vmG" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "vnV" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
@@ -38733,6 +40491,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
+"vph" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "vpw" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood,
@@ -38830,6 +40597,10 @@
 /obj/item/reagent_containers/glass/rag,
 /turf/open/floor/carpet,
 /area/service/bar)
+"vsz" = (
+/obj/machinery/power/smes,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "vsF" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/stripes/line,
@@ -38850,6 +40621,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"vsW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/engineering/storage/tcomms)
 "vsX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -39045,6 +40822,23 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"vvN" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_access_txt = "19;23"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "vvO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -39122,6 +40916,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"vxh" = (
+/obj/effect/turf_decal/tile/green/full,
+/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "vxx" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/r_wall,
@@ -39293,14 +41093,11 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "vBi" = (
-/obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/gravity_generator)
 "vBp" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -39346,6 +41143,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"vCt" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "vCG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -39447,6 +41249,25 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
+"vGM" = (
+/obj/machinery/vending/coffee,
+/obj/structure/sign/poster/contraband/hacking_guide{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/command/heads_quarters/ce)
+"vHi" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/structure/sign/poster/official/build{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/engineering/storage)
 "vHs" = (
 /obj/structure/rack,
 /obj/item/hfr_box/body/fuel_input,
@@ -39479,6 +41300,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
+"vHD" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "vHL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -39515,6 +41347,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vIL" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "vJe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -39571,6 +41414,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"vKv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "vKH" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -39688,20 +41537,15 @@
 	},
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "vMB" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
 "vME" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/status_display/supply{
-	pixel_y = -30
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/space)
+/turf/open/floor/iron,
+/area/engineering/main)
 "vMH" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
@@ -39851,18 +41695,16 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "vPe" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "Disposal Exit";
+	name = "disposal exit vent"
 	},
-/turf/open/floor/iron/stairs{
-	dir = 4
-	},
-/area/space)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "vPE" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -39950,10 +41792,24 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/range)
+"vRZ" = (
+/turf/open/floor/iron/dark/side,
+/area/engineering/gravity_generator)
 "vSo" = (
 /obj/machinery/research/explosive_compressor,
 /turf/open/floor/iron,
 /area/science/mixing)
+"vSB" = (
+/obj/structure/window/reinforced/plasma{
+	dir = 4
+	},
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "vSJ" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/requests_console/directional/south{
@@ -39964,17 +41820,11 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "vSX" = (
-/obj/machinery/modular_computer/console/preset/cargochat/cargo{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/area/engineering/gravity_generator)
 "vTr" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/toy/gun,
@@ -39983,6 +41833,20 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood/parquet,
 /area/service/theater)
+"vTV" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
+"vUk" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "vUy" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -40017,17 +41881,17 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "vUN" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+/obj/machinery/light/small/directional/west,
+/obj/machinery/computer/pod/old/mass_driver_controller/trash{
+	pixel_x = -24
 	},
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/c_tube,
-/obj/item/cane,
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "garbage";
+	name = "disposal conveyor"
+	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/disposal)
 "vUQ" = (
 /obj/machinery/modular_computer/console/preset/cargochat/service{
 	dir = 4
@@ -40052,17 +41916,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "vVE" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "vVL" = (
 /obj/structure/closet{
 	anchored = 1;
@@ -40091,6 +41947,13 @@
 	},
 /turf/open/floor/grass,
 /area/science/genetics)
+"vWL" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 1;
+	network = "tcommsat"
+	},
+/turf/open/floor/circuit,
+/area/engineering/storage/tcomms)
 "vWR" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/poster/contraband/random{
@@ -40477,22 +42340,16 @@
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/miningdock)
 "wes" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/main)
 "wet" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "weB" = (
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/blue/half{
@@ -40587,25 +42444,23 @@
 	dir = 6
 	},
 /area/medical/treatment_center)
+"wgB" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wgC" = (
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/structure/table,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/brown/half{
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
+"wgE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"wgK" = (
+/obj/effect/turf_decal/trimline/blue/line{
 	dir = 4
 	},
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/accessory/armband/cargo,
-/turf/open/floor/iron,
-/area/space)
-"wgE" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/commons/dorms)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "wgX" = (
 /turf/closed/wall,
 /area/security/interrogation)
@@ -40675,6 +42530,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
+"wjU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "wka" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40754,6 +42613,10 @@
 "wmR" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"wmX" = (
+/obj/machinery/power/energy_accumulator/tesla_coil,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "wnd" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -40762,7 +42625,7 @@
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/department/cargo)
+/area/space)
 "wnr" = (
 /obj/structure/rack,
 /obj/item/book/random,
@@ -40827,12 +42690,34 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"woH" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access_txt = "23"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "woX" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
 	},
 /turf/open/floor/iron/white/side,
 /area/science/research)
+"wpe" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/machinery/recycler,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "wpi" = (
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
@@ -40862,6 +42747,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
+"wpw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "wpD" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -41105,7 +42998,7 @@
 "wwi" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/cargo/warehouse/upper)
+/area/space)
 "wwq" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -41188,6 +43081,17 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
+"wxu" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/space/basic,
+/area/space)
 "wxL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41209,9 +43113,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "wxS" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/grimy,
-/area/security/detectives_office)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "wxV" = (
 /turf/open/floor/iron,
 /area/security/prison)
@@ -41368,6 +43272,9 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"wAS" = (
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "wBk" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067"
@@ -41449,7 +43356,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "wCg" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Lab";
@@ -41573,6 +43480,11 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"wDN" = (
+/obj/structure/rack,
+/obj/item/plunger,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wDW" = (
 /turf/closed/wall,
 /area/hallway/primary/central/fore)
@@ -41649,6 +43561,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wGD" = (
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "wGP" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -42019,6 +43938,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"wPp" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Storage";
+	req_access_txt = "11"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "wPQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42112,6 +44041,10 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
+/obj/item/paper{
+	info = "<center><b>INTRUSTIONAL GUIDE TO PROCESSING NEW INMATES</center></b> <br> <br> To process inmates through this genpop system, please see the below described listas to proper processing procedures: <br> 1.Swipe new prisoner ID on a genpop locker to link them together. Store the inmate's equipment in this locker. <br> 2.Swipe your ID on the prisoner ID and assign a time for their sentencing. Attach ID to inmate. <br> 3.Process inmate through the labeled security gate, either willingly or by force. This will activate the timer on their card and start their sentencing. <br> 4.Once their sentence is over, their ID will allow them to pass through the gate once again and they will be able to freely collect their belongings. <br> 5.Escort the newly ex-inmate out through the front brig doors back out into the station.";
+	name = "Genpop - Inmate Processing and You"
+	},
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
 "wSd" = (
@@ -42129,7 +44062,7 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "wSk" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/status_display/ai/directional/south,
@@ -42179,7 +44112,7 @@
 	},
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "wTD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -42207,12 +44140,11 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "wTX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "wUj" = (
 /obj/structure/table,
 /obj/machinery/light/directional/west,
@@ -42235,6 +44167,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"wVl" = (
+/obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
+	pixel_x = -24
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Holy Driver";
+	req_access_txt = "22"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "wVx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -42305,6 +44251,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"wXt" = (
+/obj/machinery/telecomms/hub/preset,
+/turf/open/floor/iron/dark/telecomms,
+/area/engineering/storage/tcomms)
 "wXw" = (
 /turf/closed/wall,
 /area/service/chapel/office)
@@ -42376,8 +44326,10 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "wZl" = (
-/turf/open/floor/engine/vacuum,
-/area/maintenance/solars/port/fore)
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "wZt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
@@ -42421,12 +44373,36 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"xaL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	freq = 1400;
+	location = "Disposals"
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/door/window/northright{
+	dir = 2;
+	name = "delivery door";
+	req_access_txt = "31"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xbA" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/space)
+"xcp" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/massdriver_chapel,
+/turf/open/floor/plating,
+/area/service/chapel/office)
 "xcu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/blue/half{
@@ -42626,6 +44602,10 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"xgU" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "xgX" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -42741,6 +44721,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xkk" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "xkq" = (
 /obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/tile/blue/half{
@@ -42864,6 +44848,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"xox" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/engineering/engine_smes)
 "xoE" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/flasher/portable,
@@ -42942,6 +44934,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
+"xrq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "xrI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -43144,6 +45140,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"xxJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/engineering/lobby)
+"xxM" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "xxN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43213,6 +45224,10 @@
 /obj/structure/chair/pew,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"xzG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "xzS" = (
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -43247,7 +45262,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "xBo" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/blue/half{
@@ -43294,6 +45309,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"xDZ" = (
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
+/area/service/chapel/office)
 "xEl" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -43369,7 +45388,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/cargo)
+/area/space)
 "xGd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -43385,7 +45404,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "xGr" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
@@ -43394,6 +45412,15 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
+"xGA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xGI" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
@@ -43489,6 +45516,12 @@
 "xHU" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
+"xIf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
 "xIq" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -43509,7 +45542,7 @@
 /obj/item/stamp,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "xIP" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -43533,6 +45566,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"xIU" = (
+/obj/structure/rack,
+/obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/plasma_stabilizer,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "xIX" = (
 /turf/open/floor/carpet/green,
 /area/service/library)
@@ -43671,12 +45710,29 @@
 /turf/open/floor/engine/vacuum,
 /area/space)
 "xMh" = (
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "QMLoad"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"xMT" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
+"xNs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
+"xNy" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Secure Tech Storage"
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "xNB" = (
 /obj/machinery/door/window/brigdoor/eastright{
 	dir = 2;
@@ -43733,13 +45789,15 @@
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
 "xOu" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#c45c57";
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/light/small/directional/west,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "xOw" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -43749,7 +45807,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/science/xenobiology)
+/area/space)
 "xOT" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -43766,6 +45824,14 @@
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"xQg" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/telecomms/server/presets/supply,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/engineering/storage/tcomms)
 "xQn" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -43789,6 +45855,17 @@
 /obj/machinery/suit_storage_unit/hos,
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
+"xRd" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/t_scanner,
+/obj/item/multitool,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "xRg" = (
 /obj/effect/turf_decal/trimline/red/corner,
 /obj/structure/closet/bombcloset/security,
@@ -43870,7 +45947,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/disposal)
+/area/space)
 "xSa" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Gateway Chamber";
@@ -43925,12 +46002,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
 "xSw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "xSC" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -44007,10 +46082,20 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"xTZ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering Escape Pod";
+	req_access_txt = "32"
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "xUf" = (
 /obj/machinery/door/poddoor/atmos_test_room_mainvent_2,
 /turf/open/floor/engine/vacuum,
-/area/space/nearstation)
+/area/space)
 "xUk" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
@@ -44020,7 +46105,7 @@
 	color = "#FFD700"
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+/area/space)
 "xUA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -44045,6 +46130,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"xUN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
 "xUT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -44062,6 +46153,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
+"xVl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
+"xVt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "xVC" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white/smooth_large,
@@ -44376,6 +46478,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"ycS" = (
+/obj/machinery/announcement_system,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tcomms)
 "ydp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -44417,6 +46523,10 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"yfe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "yfg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/siding/yellow{
@@ -44435,17 +46545,23 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/cargo)
+/area/space)
 "yfA" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/sorting)
 "yfC" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/science/lab)
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "yfD" = (
 /obj/structure/toilet/greyscale,
 /obj/machinery/camera{
@@ -44615,9 +46731,16 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
 "yiO" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/obj/structure/filingcabinet,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "yje" = (
 /turf/open/floor/iron,
 /area/security/courtroom)
@@ -44689,6 +46812,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"ykc" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/command/heads_quarters/ce)
 "yki" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44706,6 +46837,15 @@
 "ykr" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"ykO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ylh" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -44714,6 +46854,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"ylm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "yls" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -60600,7 +62744,7 @@ erd
 wAj
 erd
 pbC
-uVI
+erd
 pbC
 boW
 ooI
@@ -61824,15 +63968,15 @@ fej
 llp
 niu
 qdF
-oVP
+fej
 kTt
 bpF
-tok
+xeV
 eSc
-dpB
-iuT
+pRq
+uNY
 vMc
-cDi
+gqE
 meC
 meC
 meC
@@ -62086,10 +64230,10 @@ kTt
 okH
 dEJ
 daA
-dpB
-iuT
+pRq
+uNY
 ezi
-cDi
+gqE
 meC
 meC
 meC
@@ -62344,7 +64488,7 @@ kLJ
 jEp
 bae
 nor
-iuT
+uNY
 asq
 eZN
 meC
@@ -62601,9 +64745,9 @@ wCf
 xRT
 dXA
 elD
-iuT
+uNY
 wTA
-cDi
+gqE
 meC
 meC
 meC
@@ -62860,7 +65004,7 @@ cNB
 ema
 ezO
 oBo
-cDi
+gqE
 meC
 meC
 meC
@@ -63111,13 +65255,13 @@ tDN
 mBS
 cri
 gqE
-cDi
+gqE
 bPI
 dXM
 emh
 ezW
-eMl
-cDi
+gqE
+gqE
 meC
 meC
 meC
@@ -63373,8 +65517,7 @@ fDD
 eUr
 emj
 fql
-eMx
-faU
+yfo
 meC
 meC
 meC
@@ -63402,8 +65545,9 @@ meC
 meC
 meC
 meC
-meC
-meC
+lOf
+lOf
+lOf
 ebr
 beA
 beA
@@ -63624,14 +65768,13 @@ pYk
 uHe
 mBS
 cri
-hwr
+gqE
 jpD
 bZV
 mmr
 gSH
 aBG
-sAK
-asz
+yfo
 meC
 meC
 meC
@@ -63659,16 +65802,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 ebr
 omP
 fgx
@@ -63884,7 +66028,7 @@ cri
 pyH
 dXO
 kwI
-biO
+oIK
 xUk
 iMm
 pcU
@@ -63915,17 +66059,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 ebr
 ebr
 ebr
@@ -64172,20 +66316,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 xHU
 yjO
 eNE
@@ -64397,12 +66541,12 @@ dwu
 ikC
 fju
 oRt
-biO
+oIK
 pPW
 oIK
 fbg
 fpe
-fCT
+yfo
 meC
 meC
 meC
@@ -64429,26 +66573,26 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 xHU
 oDR
 cEu
 jjp
 lgW
-aun
+lgW
 hLq
 hLq
 hLq
@@ -64659,7 +66803,7 @@ pPW
 oIK
 fbg
 fpp
-fCT
+yfo
 meC
 meC
 meC
@@ -64686,20 +66830,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 xHU
 fAT
 lgW
@@ -64916,7 +67060,7 @@ oeH
 eNt
 eNt
 fpE
-fCT
+yfo
 meC
 meC
 meC
@@ -64943,20 +67087,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 txV
 ewC
 lgW
@@ -65170,7 +67314,7 @@ qCa
 qWC
 dcC
 lcn
-mpa
+gqE
 blu
 fpJ
 uyW
@@ -65200,20 +67344,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 xHU
 sTk
 nFs
@@ -65427,7 +67571,7 @@ cgV
 bMc
 mSv
 qXI
-lFM
+tEZ
 uyW
 iHm
 meC
@@ -65457,20 +67601,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 xHU
 maU
 nFs
@@ -65680,12 +67824,12 @@ hSR
 gQD
 rFL
 uhe
-hwr
+gqE
 qWC
 ngs
 lcn
-mpa
-mpa
+gqE
+gqE
 fgK
 meC
 meC
@@ -65714,20 +67858,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 xHU
 pPR
 mJT
@@ -65914,9 +68058,9 @@ meC
 meC
 meC
 meC
-bqT
-xdu
-uVu
+meC
+unY
+tVL
 qtY
 gmJ
 cyE
@@ -65937,7 +68081,7 @@ beP
 aJL
 fOu
 poI
-yiO
+unY
 ixl
 fMg
 suB
@@ -65971,20 +68115,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 xHU
 xHU
 xHU
@@ -66171,7 +68315,7 @@ meC
 meC
 meC
 meC
-bqT
+meC
 xdu
 uVu
 lJR
@@ -66194,13 +68338,13 @@ ghG
 fZz
 kDY
 ffE
-hwr
-hwr
+gqE
+gqE
 qnG
-hwr
-hwr
-umn
-umn
+gqE
+gqE
+wwi
+wwi
 meC
 meC
 meC
@@ -66228,22 +68372,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 uJl
 mRE
 fnV
@@ -66428,7 +68572,7 @@ meC
 meC
 meC
 meC
-bqT
+meC
 xdu
 wgb
 aZo
@@ -66451,12 +68595,12 @@ kDY
 kDY
 kDY
 lSw
-hwr
-hwr
+gqE
+gqE
 pBp
-hwr
-umn
-umn
+gqE
+wwi
+wwi
 meC
 meC
 meC
@@ -66485,22 +68629,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 mNf
 atP
 vBc
@@ -66685,7 +68829,7 @@ meC
 meC
 meC
 meC
-bqT
+meC
 bAu
 fuP
 ccS
@@ -66708,11 +68852,11 @@ kDY
 kDY
 kDY
 dRY
-hwr
-hwr
+gqE
+gqE
 jsH
-hwr
-umn
+gqE
+wwi
 meC
 meC
 meC
@@ -66742,22 +68886,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 fnV
 dDP
@@ -66942,7 +69086,7 @@ meC
 meC
 meC
 meC
-bqT
+meC
 aQw
 sne
 sne
@@ -66965,11 +69109,11 @@ kDY
 kDY
 kDY
 tTw
-yiO
-umn
-umn
-eOw
-eOw
+unY
+wwi
+wwi
+wwi
+wwi
 meC
 meC
 meC
@@ -66999,22 +69143,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 fnV
 fpd
@@ -67199,7 +69343,7 @@ meC
 meC
 meC
 meC
-bqT
+meC
 bqT
 bUt
 bUt
@@ -67222,7 +69366,7 @@ kDY
 kDY
 kDY
 xxU
-yiO
+unY
 meC
 meC
 meC
@@ -67256,22 +69400,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 fnV
 fpd
@@ -67310,7 +69454,7 @@ ykr
 hqc
 mgo
 wdg
-wgE
+wdg
 gaG
 xjN
 ibr
@@ -67456,7 +69600,7 @@ meC
 meC
 meC
 meC
-bqT
+meC
 bAy
 bAy
 bAy
@@ -67479,7 +69623,7 @@ ghG
 fZz
 kDY
 lbM
-yiO
+unY
 meC
 meC
 meC
@@ -67513,22 +69657,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 fnV
 hSl
@@ -67713,14 +69857,14 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bAy
-bAy
-bAy
-bAy
-bAy
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 sne
 oFg
 iNw
@@ -67728,15 +69872,15 @@ hrx
 xyZ
 dnk
 tJQ
-kYz
-kYz
-kYz
-tJQ
-fPh
-eIO
-tJQ
-cnP
-yiO
+kDY
+kDY
+kDY
+rFL
+hSR
+gQD
+rFL
+lbM
+unY
 meC
 meC
 meC
@@ -67756,36 +69900,36 @@ meC
 meC
 meC
 meC
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 fnV
 hSl
@@ -67970,14 +70114,14 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bAy
-bAy
-bAy
-bAy
-bAy
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 sne
 nsk
 iNw
@@ -67985,15 +70129,15 @@ gMT
 tDB
 kSA
 jLJ
-kYz
-kYz
-kYz
-jLJ
-myC
-mhD
-jLJ
-ofF
-hwr
+kDY
+kDY
+kDY
+fOu
+beP
+aJL
+fOu
+ffE
+gqE
 meC
 meC
 meC
@@ -68011,38 +70155,38 @@ meC
 meC
 meC
 meC
+gzu
+gzu
+gzu
+vgf
+xQg
+vxh
+dQo
+oHk
+kxf
+lDY
+ycS
+swT
+hNg
+gzu
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 fnV
 vdi
@@ -68227,14 +70371,14 @@ meC
 meC
 meC
 meC
-bqT
-bAy
-bAy
-bAy
-bAy
-bAy
-bAy
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 bAu
 nsk
 iNw
@@ -68250,7 +70394,7 @@ sQz
 gTT
 nrR
 wnd
-hwr
+gqE
 meC
 meC
 meC
@@ -68268,38 +70412,38 @@ meC
 meC
 meC
 meC
+gzu
+dRD
+aYz
+jLw
+shc
+jLw
+jLw
+jLw
+shc
+lDY
+vsW
+svk
+bbF
+gzu
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 fnV
 mvG
@@ -68484,14 +70628,14 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bAy
-bAy
-bAy
-bAy
-bAy
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 bAu
 jAR
 fST
@@ -68506,8 +70650,8 @@ uRi
 gqE
 gqE
 qlZ
-hwr
-hwr
+gqE
+gqE
 meC
 meC
 meC
@@ -68525,38 +70669,38 @@ meC
 meC
 meC
 meC
+gzu
+jLw
+sdW
+jLw
+shc
+jLw
+aeW
+hmZ
+rCS
+lDY
+oNh
+hjF
+vWL
+gzu
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 hSl
 hSl
 hSl
-meC
-meC
+fej
+fej
 hSl
 fnV
 dEz
@@ -68741,14 +70885,14 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 aQw
 wCC
 fpg
@@ -68763,8 +70907,8 @@ gqE
 bGs
 fyN
 fyN
-bJw
-hwr
+fyN
+gqE
 meC
 meC
 meC
@@ -68782,32 +70926,32 @@ meC
 meC
 meC
 meC
+gzu
+bgE
+hmZ
+hmZ
+qRD
+jLw
+ukZ
+gzu
+gzu
+gzu
+hGq
+gzu
+gzu
+gzu
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 rDl
 rDl
@@ -68998,14 +71142,14 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 aQw
 cGn
 aog
@@ -69020,8 +71164,8 @@ gqE
 aBS
 fyN
 sCL
-xOu
-hwr
+sCL
+gqE
 meC
 meC
 meC
@@ -69039,32 +71183,32 @@ meC
 meC
 meC
 meC
+gzu
+shc
+wXt
+dId
+vsz
+eWm
+uTx
+vTV
+xkk
+dSJ
+cve
+lER
+eTA
+gzu
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 lVr
 dEz
@@ -69255,14 +71399,14 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 aQw
 cGn
 eQg
@@ -69277,8 +71421,8 @@ gqE
 gqE
 gqE
 gqE
-hwr
-hwr
+gqE
+gqE
 meC
 meC
 meC
@@ -69296,32 +71440,32 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+gzu
+fSK
+hmZ
+hmZ
+gud
+eWm
+cdI
+gzu
+gzu
+gzu
+cve
+cve
+wpw
+gzu
+spf
+spf
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 dDP
 bvL
@@ -69512,14 +71656,14 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 aQw
 vdF
 bGD
@@ -69553,32 +71697,32 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+gzu
+jLw
+lUd
+eWm
+uTx
+eWm
+jgG
+hmZ
+vmn
+dMh
+nRD
+nTy
+hqr
+gzu
+vME
+vME
+lOf
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 tek
 tek
@@ -69769,21 +71913,21 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
-sne
-wZl
-wZl
-wZl
-xdu
-xOw
-xdu
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+unY
+sMF
+sMF
+sMF
+unY
+urx
+unY
 sMF
 sMF
 sMF
@@ -69810,32 +71954,32 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+gzu
+erM
+ehf
+eWm
+shc
+jLw
+jLw
+jLw
+shc
+lDY
+vmh
+yfe
+cve
+vIL
+oRZ
+vME
+fPN
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 tek
 hSl
@@ -70027,20 +72171,20 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-aQw
-bGD
-bGD
-wZl
-aQw
-xOw
-aQw
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+gqE
+sMF
+sMF
+sMF
+gqE
+urx
+gqE
 sMF
 sMF
 sMF
@@ -70058,41 +72202,41 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+gzu
+gzu
+gzu
+sGE
+frr
+isO
+jyw
+swF
+gRJ
+dMh
+tqj
+kuW
+lER
+qtW
+oRZ
+vME
+fPN
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
+fej
 hSl
 tek
 hSl
@@ -70283,25 +72427,25 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-aQw
-xUf
-xUf
-rrQ
-aQw
-xOw
-aQw
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+gqE
 xUf
 xUf
 xUf
-aQw
+gqE
+urx
+gqE
+xUf
+xUf
+xUf
+gqE
 meC
 meC
 meC
@@ -70315,41 +72459,41 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+nbT
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+gzu
+oRZ
+exp
+lOf
+fej
+fej
+fej
+fej
+fej
+mOK
+mOK
+mOK
+mOK
 hSl
 tek
 hSl
@@ -70526,39 +72670,6 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-aQw
-jyU
-jyU
-bUt
-jyU
-jyU
-jyU
-jyU
-jyU
-jyU
-aQw
 meC
 meC
 meC
@@ -70581,6 +72692,17 @@ meC
 meC
 meC
 meC
+gqE
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+gqE
 meC
 meC
 meC
@@ -70593,21 +72715,43 @@ meC
 meC
 meC
 meC
+asz
+neq
+neq
+neq
+neq
+neq
+asz
+asz
+asz
+urx
+urx
+urx
+urx
+urx
+urx
 meC
 meC
 meC
 meC
+cTU
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-hSl
+spf
+oRZ
+vME
+lOf
+fej
+fej
+fej
+fej
+fej
+mOK
+sIF
+sIF
+vUk
+uJl
 tek
 lAg
 akd
@@ -70779,42 +72923,42 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-xOw
-xOw
-xOw
-cOI
-xOw
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 urx
 urx
 urx
 urx
-xOw
+urx
+urx
+urx
+urx
+urx
+urx
 meC
 meC
 meC
@@ -70827,6 +72971,22 @@ meC
 meC
 meC
 meC
+asz
+asz
+nRQ
+dMz
+dMz
+fMz
+fMz
+mQn
+mQn
+asz
+urx
+urx
+urx
+urx
+urx
+urx
 meC
 meC
 meC
@@ -70835,36 +72995,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-hSl
+spf
+oRZ
+vME
+sDu
+sDu
+sDu
+sDu
+sDu
+sDu
+mOK
+fib
+cmr
+vUk
+uJl
 tek
 hSl
 akd
@@ -70879,7 +73023,7 @@ hbk
 crV
 noV
 hRK
-yfC
+xeA
 slG
 fdx
 wDJ
@@ -71035,38 +73179,6 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
-bAy
-bAy
 meC
 meC
 meC
@@ -71109,6 +73221,29 @@ meC
 meC
 meC
 meC
+asz
+asz
+asz
+asz
+asz
+asz
+asz
+asz
+dMz
+nRQ
+dMz
+dMz
+iBG
+iBG
+iBG
+eoI
+asz
+eSf
+eSf
+eSf
+asz
+urx
+urx
 meC
 meC
 meC
@@ -71117,11 +73252,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-hSl
+spf
+oRZ
+ePd
+sDu
+uIT
+gtC
+vHi
+oWe
+oWe
+mOK
+fib
+lbc
+wmX
+uJl
 tek
 hSl
 qdJ
@@ -71291,39 +73435,6 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
-bAy
-bAy
 meC
 meC
 meC
@@ -71367,6 +73478,29 @@ meC
 meC
 meC
 meC
+asz
+aug
+cko
+cOI
+dpB
+dNP
+dXh
+asz
+dMz
+ofF
+dMz
+dMz
+iBG
+dMz
+dMz
+iBG
+dMz
+dMz
+dMz
+dMz
+asz
+urx
+urx
 meC
 meC
 meC
@@ -71375,10 +73509,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-hSl
+spf
+oRZ
+vME
+sDu
+bdo
+cmr
+lOF
+fTS
+fTS
+dZs
+fTS
+rGK
+wmX
+uJl
 tek
 hSl
 lJK
@@ -71544,43 +73688,6 @@ meC
 meC
 meC
 meC
-bqT
-bqT
-meC
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bqT
-bAy
-bAy
-bAy
 meC
 meC
 meC
@@ -71628,14 +73735,51 @@ meC
 meC
 meC
 meC
+asz
+aun
+dMz
+dMz
+dMz
+dMz
+ehJ
+eYr
+dMz
+nRQ
+uKd
+nLH
+dOL
+nLH
+nLH
+gey
+nLH
+roG
+nLH
+oNf
+asz
+urx
+urx
 meC
 meC
 meC
 meC
+wxu
 meC
 meC
 meC
-hSl
+spf
+oRZ
+vME
+sDu
+hZo
+hsC
+fTS
+qiS
+cmr
+mYR
+szo
+szo
+szo
+uJl
 tek
 hSl
 akd
@@ -71848,51 +73992,51 @@ meC
 meC
 meC
 meC
+eSf
+bHP
+cnP
+cnP
+cDi
+cnP
+ehX
+asz
+kBW
+nRQ
+uVI
+uVI
+uVI
+hiW
+imc
+imc
+imc
+xNs
+xNs
+xMh
+pcr
+dqq
+dqq
+dqq
+dqq
+dqq
+qwr
+qlL
+qwr
+qwr
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-hSl
+spf
+oRZ
+vME
+sDu
+mVb
+jOg
+fTS
+uJn
+psW
+eui
+eui
+eui
+eui
+uJl
 tek
 hSl
 vry
@@ -72105,51 +74249,51 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-hSl
+eSf
+bHP
+cnP
+cSd
+cSd
+dNQ
+eiU
+eYX
+dMz
+nRQ
+uVI
+hgT
+dLf
+oUh
+dLf
+hgT
+rua
+idt
+xNs
+xMh
+oZZ
+mHD
+eau
+vCt
+ebP
+dqq
+jin
+vME
+ocs
+qwr
+spf
+spf
+dzF
+spf
+sDu
+iLy
+muK
+lOF
+nuN
+cmr
+eui
+eUn
+mwe
+oOX
+uJl
 tek
 hSl
 akd
@@ -72362,51 +74506,51 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-hSl
+eSf
+bHP
+cnP
+cSd
+cSd
+cSd
+eiU
+eYX
+dMz
+oVP
+uVI
+qTF
+nQT
+egQ
+oAL
+qTF
+rua
+idt
+xNs
+xMh
+oZZ
+wGD
+wet
+wet
+ebP
+dqq
+qwr
+xTZ
+qwr
+qwr
+vME
+vME
+evT
+azp
+sDu
+jPg
+muK
+cmr
+oWe
+oWe
+eui
+xNy
+dUD
+adh
+uJl
 tek
 hSl
 akd
@@ -72619,51 +74763,51 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-hSl
+eSf
+bHP
+cnP
+cVf
+cSd
+dWV
+eiU
+eYX
+dMz
+ews
+uVI
+ceA
+tTp
+vSB
+mOV
+qIG
+qTF
+qTF
+xNs
+uup
+mfx
+jbi
+jbi
+jbi
+riR
+dqq
+tri
+vME
+syp
+xVt
+xVt
+xVt
+evT
+azp
+sDu
+sDu
+wPp
+sDu
+rQF
+rQF
+eui
+eui
+vvN
+eui
+uJl
 tek
 hSl
 qdJ
@@ -72876,50 +75020,50 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+eSf
+bHP
+cnP
+cSd
+cSd
+cVf
+eiU
+eYX
+dMz
+oVP
+uVI
+xgU
+vKv
+vKv
+vKv
+mhF
+ifx
+ncD
+xNs
+xMh
+oZZ
+otg
+dFn
+jbi
+kwf
+dqq
+cRl
+vME
+vME
+vME
+mMH
+xzG
+evT
+azp
+spf
+vME
+xUN
+pGX
+rQF
+bGJ
+oLD
+aeB
+dUD
+pnE
 hSl
 tek
 hSl
@@ -73133,19 +75277,19 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-cTr
+eSf
+bHP
+cnP
+cSd
+cSd
+cSd
+eiU
+eYX
+dMz
+ews
+uVI
+xgU
+oAL
 dWl
 evm
 lKW
@@ -73155,28 +75299,28 @@ hCu
 xMh
 etA
 pLs
-jpC
+vVE
 miw
 dEc
 dqq
-jNg
-jNg
-bkV
-iCm
-dpc
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+spf
+spf
+spf
+spf
+spf
+vME
+xUN
+kwA
+evT
+evT
+evT
+pGX
+rQF
+xRd
+dUD
+dUD
+dUD
+lHv
 hSl
 tek
 hSl
@@ -73390,50 +75534,50 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-dlE
-efX
+eSf
+bHP
+cnP
+cSd
+cSd
+cSd
+eiU
+eYX
+dMz
+oVP
+uVI
+xgU
+evQ
+evQ
 evQ
 nnj
-nnj
-nnj
+gmE
+eIR
 dVQ
-msI
+nLH
 oZZ
-fej
+nSw
 wet
-msI
+jbi
 vVE
-msI
-msI
-msI
-msI
-jpC
-oIx
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+wet
+spf
+mAI
+thi
+mAI
+spf
+bLw
+dIf
+vME
+oAn
+vME
+evT
+tVD
+rQF
+osD
+mmN
+mmN
+ntB
+nrF
 hSl
 tek
 hSl
@@ -73647,50 +75791,50 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+eSf
+bHP
+cDi
+cSd
+dMZ
+dWW
+ejf
+eYX
+dMz
+ews
+uVI
+ceA
 dnI
 ega
 ewp
 rKO
-rKO
-efX
-rKO
-rKO
-rKO
-cuM
-rKO
-rKO
-rKO
-rKO
-rKO
-wes
-fej
-lsY
+qTF
+qTF
+dVQ
+nLH
+xox
+wet
+jYE
+jbi
+miw
+miw
 uNX
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+wes
+wes
+wes
+uNX
+wes
+gfZ
+vME
+oAn
+vME
+xUN
+tVD
+rQF
+peN
+mmN
+dUD
+dUD
+fwB
 hSl
 mjL
 hSl
@@ -73904,51 +76048,51 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-dDB
+eSf
+bHP
+cnP
+cnP
+cnP
+cnP
+ekx
+asz
+kBW
+prR
+uVI
+qTF
+oAL
 egQ
-fej
-fej
-fej
+oAL
+qTF
+qxy
 hLR
-fej
+qBU
 nLH
-fej
-oDC
-fej
-oDC
-fej
-oDC
-fej
+oZZ
+jnr
+tDP
+tDP
+wet
+miw
+spf
 jin
 bMB
-wet
+eea
 spf
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+fHD
+xUN
+xUN
+oAn
+vME
+xUN
+vME
+rQF
+cBc
+ncY
+qBP
+dUD
+ntM
+rQF
 jiF
 nYv
 nYv
@@ -74161,51 +76305,51 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+asz
+aun
+dMz
+dMz
+dMz
+dMz
+erL
+faU
+dMz
+ews
+vmG
+hgT
 dLf
-egQ
-fej
-fej
-fej
-hLR
-vCG
+oUh
+dLf
+hgT
+qxy
+lZm
+dVQ
 oDC
-fej
-oDC
-fej
-oDC
-vCG
-oDC
-fej
-jin
-bMB
-fej
-rWd
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+pcr
+gpA
+ljB
+gpA
+wgC
+qZI
+tmX
+tmX
+spf
+spf
+spf
+vME
+ltN
+xUN
+nnK
+vME
+xUN
+xUN
+rst
+suW
+suW
+suW
+suW
+suW
+woH
 jiF
 jiF
 jiF
@@ -74418,51 +76562,51 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-dLj
+asz
+bJw
+cEc
+cVW
+dNd
+dWZ
+esZ
+asz
+dMz
+ews
+ehh
+ehh
+ehh
 ehh
 ews
-rKO
-rKO
+gKo
+uAD
 uAD
 iUw
-hyO
-eWr
-hyO
+nLH
+oZZ
+exZ
 tDP
-hyO
-iUw
+oql
+wgC
 vBi
-mZg
+ibu
 tJp
-lfe
-fej
-rWd
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+spf
+bWt
+vME
+vME
+vME
+xUN
+vME
+vME
+xUN
+vME
+rQF
+dov
+eGY
+qsL
+jzP
+xxM
+rQF
 nYv
 nYv
 jiF
@@ -74675,52 +76819,52 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-dMp
+asz
+asz
+asz
+asz
+asz
+asz
+asz
+asz
+dMz
+pXW
+uuQ
+dkB
+uuQ
 eue
-ega
-fej
-fej
-hLR
 uuQ
-oDC
-fej
-oDC
-rnT
-oDC
 uuQ
+dVQ
+uuQ
+uuQ
+eqJ
+oZZ
+jYE
+tDP
+xIf
+wgC
 jxX
-fej
-jin
-lfe
-fej
+dQd
+xVl
+spf
+gLF
 vME
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
-wDW
+vME
+vME
+xUN
+vME
+vME
+xUN
+vME
+rQF
+rQF
+rQF
+rQF
+rQF
+rQF
+rQF
+iUV
 nYv
 jiF
 xZl
@@ -74939,45 +77083,45 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
+asz
+asz
 dMz
-lOf
-eIN
-fej
-fej
+dMz
+ews
+dMz
 vmG
-fej
-oDC
-fej
-oDC
-fej
+vmG
+vmG
+prg
+vmG
+vmG
+vmG
+etA
 swf
-fej
+swf
+swf
+wgC
 oNH
-fej
-jin
-lfe
-fej
-bMB
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+dQd
+fFw
+spf
+jpM
+vME
+vME
+vME
+xUN
+vME
+vME
+xUN
+xUN
+vME
+uLY
+iUV
+xIU
+eya
+oxl
+ewy
+iUV
 vBM
 lKT
 fjo
@@ -75196,45 +77340,45 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-dVD
-lOf
-eKl
-fej
-fej
+urx
+asz
 eSf
-rKO
-rKO
-rKO
-rKO
+eSf
+cPS
+eSf
+eSf
+eSf
+eSf
+cPS
+eSf
+asz
+asz
+pcr
+fbR
 ilj
-rKO
-rKO
+fbR
+rJk
 xSw
-rKO
-xSw
-atL
+bAq
+rkd
+spf
 hSp
 lPl
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+lPl
+hSp
+nNN
+hSp
+hSp
+vME
+xUN
+xUN
+dZR
+iUV
+hFE
+ylm
+qph
+tru
+iUV
 nYv
 jiF
 xPg
@@ -75453,45 +77597,45 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-dVD
-lOf
+urx
+urx
+wwi
+urx
+mda
 fmF
-fej
-fej
-sAa
-fej
-fej
-fej
-fej
-fej
-eGB
-ilF
-xSw
+nBn
+fmF
+nBn
+mda
+urx
+wwi
+urx
+pcr
+wgC
+wgC
+wgC
+wgC
+jAo
 uxX
-xSw
-iUw
-gtB
+jiV
+jEJ
+lPl
 nXR
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+icM
+jqV
+opQ
+cTM
+hSp
+hSp
+vME
+xUN
+efV
+iUV
+gFI
+tux
+uXN
+umA
+iUV
 nYv
 jiF
 xPg
@@ -75710,45 +77854,45 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-dVT
-evf
-hiC
-dWn
-dWn
-bHP
-dWn
-dWn
-dWn
+urx
+urx
+wwi
+urx
+mda
+mda
+mda
+mda
+mda
+mda
+urx
+wwi
+urx
+urx
 wgC
 jAo
-eKp
+oHn
 oHn
 vSX
 beY
 uIp
 rff
-lcf
+lPl
 iHa
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+tYo
+qhN
+hXt
+pKo
+rGR
+hSp
+spf
+rkN
+spf
+iUV
+mux
+aRB
+uXN
+iCu
+iUV
 nYv
 jiF
 xPg
@@ -75967,45 +78111,45 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-dVT
-lOf
-huH
+urx
+urx
+wwi
+urx
 mda
-ioF
-vPe
-ioF
-nRQ
-rXN
-lOf
-lOf
-lOf
+mda
+mda
+mda
+mda
+mda
+urx
+wwi
+urx
+urx
+wgC
+vRZ
+qNP
 wTX
 wTX
-lOf
+kcO
 mVt
-pTO
-lOf
-lOf
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
+rff
+ssB
+eHW
+fyt
+leC
+cdW
+sgh
+gzT
+hSp
+jYX
+aur
+wAS
+iUV
+suo
+faD
+sXV
+suo
+iUV
 nYv
 jiF
 xPg
@@ -76224,44 +78368,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+urx
+urx
+wwi
+urx
+mda
+mda
+mda
+mda
+mda
+mda
+urx
+wwi
+urx
+urx
+wgC
+vRZ
+xMT
+cYi
+cIx
+rMT
+idl
+rff
+ssB
+hNV
+fyt
+leC
+rSO
+lYm
+cnq
+hSp
+saS
+aur
+aur
+gNn
+aur
+aur
+aur
+kOj
 wDW
 nYv
 jiF
@@ -76481,44 +78625,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+urx
+urx
+wwi
+urx
+mda
+mda
+mda
+mda
+mda
+mda
+urx
+wwi
+urx
+urx
+wgC
+vRZ
+lyB
+wgK
+wgK
+qTL
+bgH
+eJY
+ssB
+omi
+fyt
+vHD
+frd
+vph
+ivK
+hSp
+hsK
+qfU
+wAS
+wjU
+wAS
+aur
+mZy
+uMv
 wDW
 nYv
 jiF
@@ -76738,44 +78882,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+urx
+urx
+wwi
+urx
+nub
+oSy
+nub
+oSy
+nub
+oSy
+urx
+wwi
+urx
+urx
+wgC
+nqe
+tgF
+rQM
+rQM
+rQM
+cUU
+wgC
+hSp
+hSp
+vGM
+pLj
+ykc
+nqk
+hSp
+hSp
+gGf
+qfU
+xrq
+wjU
+wAS
+aur
+wAS
+lud
 wDW
 bvV
 jiF
@@ -76825,7 +78969,7 @@ udI
 lGU
 xjc
 xjc
-nbT
+cWL
 wxl
 wIi
 bzI
@@ -76995,44 +79139,44 @@ meC
 meC
 meC
 meC
+urx
+urx
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+wwi
+urx
+urx
+wgC
+wgC
+wgC
+wgC
+wgC
+wgC
+wgC
+wgC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+hSp
+hSp
+hSp
+hSp
+hSp
+hSp
+jcq
+wAS
+qfU
+bYA
+nCd
+nCd
+xxJ
+aur
+wAS
 wDW
 nYv
 mBf
@@ -77253,6 +79397,19 @@ meC
 meC
 meC
 meC
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
 meC
 meC
 meC
@@ -77267,33 +79424,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-wDW
-nYv
+qwo
+uLm
+wAS
+qfU
+cUN
+eEp
+mOS
+jjM
+aur
+aur
+hWu
+jiF
 kWt
-lTg
+xPg
 qwq
 qeo
 ptd
@@ -77510,6 +79654,19 @@ meC
 meC
 meC
 meC
+urx
+urx
+urx
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+urx
+urx
+urx
 meC
 meC
 meC
@@ -77524,29 +79681,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+qwo
+sdD
+wAS
+sAN
+cUN
+fLS
+abi
+rSj
+wAS
+wAS
 wDW
 nYv
 mBf
@@ -77767,6 +79911,9 @@ meC
 meC
 meC
 meC
+urx
+urx
+urx
 meC
 meC
 meC
@@ -77774,12 +79921,9 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
+urx
+urx
+urx
 meC
 meC
 meC
@@ -77804,7 +79948,7 @@ lOf
 lOf
 lOf
 lOf
-wDW
+lOf
 nYv
 mBf
 lUx
@@ -78024,18 +80168,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
+urx
 meC
 meC
 meC
@@ -78061,7 +80205,7 @@ fyN
 fyN
 fyN
 fyN
-wDW
+qUy
 nYv
 mBf
 xPg
@@ -78281,18 +80425,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+lFM
+lFM
+lFM
+rjB
+lFM
+rjB
+rjB
+lFM
+urx
+urx
+urx
+urx
 meC
 meC
 meC
@@ -78309,16 +80453,16 @@ meC
 meC
 lOf
 fyN
-sPF
-sPF
-sPF
-sPF
-sPF
-sPF
-sPF
-sPF
-sPF
-wDW
+lOf
+lOf
+lOf
+lOf
+lOf
+lOf
+lOf
+lOf
+lOf
+lOf
 nYv
 mBf
 xPg
@@ -78378,7 +80522,7 @@ vzS
 vzS
 vzS
 tIy
-sYm
+wYb
 sil
 xWc
 xWc
@@ -78538,16 +80682,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-pYh
+lGL
+qIu
+vPe
+evh
+eck
+nLY
+bUX
+vdE
+vdE
+vdE
 tyb
 tyb
 tyb
@@ -78566,7 +80710,7 @@ meC
 meC
 lOf
 fyN
-sPF
+lOf
 yjh
 rgu
 pWC
@@ -78795,16 +80939,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-pYh
+lFM
+rjB
+lFM
+lFM
+lFM
+kpo
+nwX
+xaL
+sQJ
+vdE
 tJl
 kfo
 hNc
@@ -78823,7 +80967,7 @@ meC
 meC
 lOf
 fyN
-sPF
+lOf
 mLn
 wor
 uHM
@@ -79052,16 +81196,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-pYh
+lFM
+rXN
+vUN
+hYv
+cZu
+kpo
+nxm
+vdE
+sQJ
+vdE
 ure
 eJw
 mQl
@@ -79080,7 +81224,7 @@ meC
 meC
 lOf
 fyN
-sPF
+lOf
 lsd
 nTC
 hJZ
@@ -79309,16 +81453,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-lOf
-lOf
+lFM
+sAa
+wgE
+uCz
+sjN
+kpo
+wpe
+vdE
+sQJ
+vdE
 wcJ
 vwX
 fxq
@@ -79337,7 +81481,7 @@ meC
 meC
 lOf
 fyN
-sPF
+lOf
 deR
 aXe
 fJS
@@ -79566,15 +81710,15 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
+lFM
+lFM
+wxS
+bCg
+joG
+uGI
+eXu
+vdE
+sQJ
 qVa
 wKp
 bVW
@@ -79592,9 +81736,9 @@ kmO
 lOf
 meC
 meC
-hUA
-hUA
-sPF
+lOf
+cSW
+lOf
 sPF
 jaP
 sPF
@@ -79824,17 +81968,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-lOf
-lOf
-lOf
+lFM
+wZl
+reH
+tSL
+lQI
+bKm
+vdE
+sQJ
+vdE
+vdE
+vdE
 tKA
 tXd
 pYh
@@ -80077,20 +82221,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-fyN
-fyN
+dXa
+dXa
+dXa
+dXa
+lFM
+lFM
+lFM
+vdE
+gsz
+uHP
+vdE
+sQJ
+sQJ
+lVP
 jHw
 kfX
 uYf
@@ -80334,21 +82478,21 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-lOf
-lOf
-lOf
-fyN
-fyN
-fyN
-lOf
+dXa
+ewR
+fPh
+eyo
+eyo
+xOu
+ewR
+vdE
+qqK
+xGA
+sQJ
+sQJ
+sQJ
+lVP
+vdE
 cgI
 hNZ
 cox
@@ -80591,20 +82735,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-fyN
-fyN
-fyN
-fyN
-fyN
+dXa
+exo
+gPa
+eyo
+eyo
+yfC
+eyo
+vdE
+qqK
+lVP
+lVP
+lVP
+lVP
+lVP
 jzC
 qEo
 lQH
@@ -80848,21 +82992,21 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-lOf
-lOf
-lOf
-lOf
-lOf
-lOf
+dXa
+eyo
+eyo
+eyo
+eyo
+eyo
+eyo
+vdE
+tIE
+vdE
+qVa
+vdE
+vdE
+vdE
+vdE
 ydG
 wBs
 wBs
@@ -81105,16 +83249,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-ydG
+dXa
+eIO
+hwr
+eyo
+eyo
+yiO
+eIO
+vdE
+lVP
+vdE
 cQD
 ohS
 qQM
@@ -81362,16 +83506,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-ydG
+dXa
+eKE
+eyo
+eyo
+sYm
+eyo
+eyo
+vdE
+lVP
+vdE
 btO
 lVX
 dIB
@@ -81619,16 +83763,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-ydG
+dXa
+eKF
+ipK
+lTg
+tok
+tok
+tok
+agC
+lVP
+vdE
 ixh
 oLU
 jlb
@@ -81876,16 +84020,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-aug
+dXa
+eyo
+eyo
+mpa
+eyo
+eyo
+eyo
+vdE
+sQJ
+vdE
 ozS
 xzS
 xzS
@@ -81966,7 +84110,7 @@ vjJ
 xQY
 mQQ
 aEZ
-wxS
+vBd
 wJK
 wTV
 rFE
@@ -82133,16 +84277,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-ydG
+dXa
+eKT
+iuT
+eyo
+eyo
+iHL
+eKT
+vdE
+sQJ
+vdE
 jzp
 oSK
 cPR
@@ -82157,12 +84301,12 @@ hWD
 epo
 hWD
 hWD
-lOf
+bYP
 gbI
-hBD
+kUC
 jda
 alQ
-vdE
+bYP
 vdE
 vdE
 vdE
@@ -82390,17 +84534,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fyN
-ydG
-ydG
+dXa
+eLc
+eyo
+eyo
+eyo
+eyo
+tct
+vdE
+sQJ
+vdE
+vdE
 ydG
 ydG
 ydG
@@ -82410,15 +84554,15 @@ ydG
 ydG
 ydG
 rLq
-fej
+hDX
 hBD
 rLq
-lOf
+qVC
 iiZ
 rIz
-hBD
-aQe
-aQe
+kUC
+oAs
+oAs
 rsF
 vdE
 abz
@@ -82647,6 +84791,17 @@ meC
 meC
 meC
 meC
+dXa
+eMl
+jFp
+eyo
+eyo
+rnM
+eMl
+vdE
+sQJ
+sQJ
+vdE
 meC
 meC
 meC
@@ -82654,28 +84809,17 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-fyN
-lOf
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-xuv
+rJl
 rLq
-fej
+hDX
 hBD
 rLq
-lOf
+qVC
 xIH
-cnR
-mZg
-fej
-fej
+mwF
+ukK
+lzH
+lzH
 lzH
 tVf
 sQJ
@@ -82892,10 +85036,6 @@ meC
 meC
 meC
 meC
-lOf
-lOf
-lOf
-lOf
 meC
 meC
 meC
@@ -82908,32 +85048,36 @@ meC
 meC
 meC
 meC
+dXa
+eXM
+jXR
+eyo
+eyo
+yfC
+otv
+vdE
+sQJ
+sQJ
+vdE
 meC
 meC
 meC
-lOf
-lOf
-fyN
-lOf
 meC
-meC
-meC
-meC
-xuv
-xuv
-xuv
-xuv
+rJl
+rJl
+rJl
+rJl
 gSu
-cnR
+tOo
 hBD
 rLq
-lOf
+qVC
 fTV
 cRL
 bsi
 iRD
 oDa
-vdE
+bYP
 vdE
 sQJ
 vdE
@@ -83149,10 +85293,6 @@ meC
 meC
 meC
 meC
-lOf
-cSd
-fyN
-lOf
 meC
 meC
 meC
@@ -83165,26 +85305,30 @@ meC
 meC
 meC
 meC
+dXa
+dXa
+dXa
+dXa
+dXa
+vdE
+vdE
+vdE
+vdE
+sQJ
+vdE
 meC
 meC
 meC
 meC
-lOf
-fyN
-lOf
-meC
-meC
-meC
-meC
-xuv
+rJl
 axD
 hvS
-xuv
+rJl
 epp
-fej
+hDX
 iZW
 drD
-lOf
+qVC
 wSd
 yfA
 iqb
@@ -83406,10 +85550,6 @@ meC
 meC
 meC
 meC
-lOf
-cko
-fyN
-lOf
 meC
 meC
 meC
@@ -83426,9 +85566,13 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-lOf
+meC
+vdE
+pud
+wDN
+vdE
+sQJ
+vdE
 meC
 meC
 meC
@@ -83437,11 +85581,11 @@ vgt
 grU
 iHz
 edR
-fej
-fej
+hDX
+hDX
 iZW
 jrT
-lOf
+qVC
 bVS
 nyI
 vdE
@@ -83663,10 +85807,6 @@ meC
 meC
 meC
 meC
-lOf
-erL
-fyN
-fyN
 meC
 meC
 meC
@@ -83683,23 +85823,27 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-lOf
+meC
+vdE
+iZN
+sQJ
+sQJ
+sQJ
+vdE
 meC
 meC
 meC
 meC
-xuv
+rJl
 ruv
 nWF
-xuv
+rJl
 tuK
 dWm
 iZW
 qOk
-lOf
-lOf
+vdE
+vdE
 vdE
 vdE
 sQJ
@@ -83920,10 +86064,6 @@ meC
 meC
 meC
 meC
-lOf
-cVW
-fyN
-lOf
 meC
 meC
 meC
@@ -83940,23 +86080,27 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-lOf
+meC
+vdE
+jii
+sQJ
+sQJ
+sQJ
+vdE
 meC
 meC
 meC
 meC
-xuv
-xuv
-xuv
-xuv
+rJl
+rJl
+rJl
+rJl
 gaj
 aQe
-fej
+hDX
 krH
-lOf
-kBW
+vdE
+pRp
 vdE
 lVP
 lVP
@@ -84177,10 +86321,6 @@ meC
 meC
 meC
 meC
-lOf
-vUN
-fyN
-lOf
 meC
 meC
 meC
@@ -84197,9 +86337,13 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-lOf
+meC
+vdE
+dcw
+sQJ
+vdE
+sQJ
+vdE
 meC
 meC
 meC
@@ -84207,12 +86351,12 @@ meC
 meC
 meC
 meC
-xuv
+rJl
 bas
 hhL
 weo
 gkx
-lOf
+vdE
 qIQ
 oVb
 lVP
@@ -84451,12 +86595,12 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-lOf
-fyN
-lOf
+tXp
+tXp
+tXp
+vdE
+sQJ
+vdE
 meC
 meC
 meC
@@ -84711,9 +86855,9 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-lOf
+vdE
+sQJ
+vdE
 meC
 meC
 meC
@@ -84726,7 +86870,7 @@ vdE
 lVP
 lVP
 lVP
-lVP
+ykO
 lVP
 lVP
 lVP
@@ -84953,14 +87097,6 @@ meC
 meC
 meC
 meC
-lOf
-lOf
-lOf
-ehJ
-ewR
-lOf
-lOf
-lOf
 meC
 meC
 meC
@@ -84968,9 +87104,17 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-lOf
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+vdE
+sQJ
+vdE
 vdE
 vdE
 vdE
@@ -84983,7 +87127,7 @@ vdE
 lVP
 sQJ
 sQJ
-sQJ
+vdE
 sQJ
 sQJ
 sQJ
@@ -85210,14 +87354,6 @@ meC
 meC
 meC
 meC
-lOf
-eXM
-dWV
-ehX
-eYr
-neq
-eXM
-lOf
 meC
 meC
 meC
@@ -85225,16 +87361,24 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-fyN
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+vdE
+sQJ
+sQJ
 vdE
 lEH
 lME
 vdE
 rbh
-sQJ
-sQJ
+pWP
+pWg
 pWg
 lVP
 lVP
@@ -85467,14 +87611,6 @@ meC
 meC
 meC
 meC
-lOf
-dMZ
-dWW
-ehX
-cEc
-eKE
-eYr
-lOf
 meC
 meC
 meC
@@ -85482,9 +87618,17 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-fyN
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+vdE
+sQJ
+sQJ
 sQJ
 sQJ
 lSf
@@ -85724,14 +87868,6 @@ meC
 meC
 meC
 meC
-lOf
-dNd
-rjB
-ehX
-cEc
-eYr
-eYr
-lOf
 meC
 meC
 meC
@@ -85739,15 +87875,23 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-fyN
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+vdE
+kNq
 sQJ
-lGL
+sQJ
+sQJ
 lTH
 vdE
 xKX
-sQJ
+mtQ
 uYn
 pbB
 lVP
@@ -85981,14 +88125,6 @@ meC
 meC
 meC
 meC
-lOf
-qIu
-dWZ
-eiU
-exo
-eKF
-qIu
-lOf
 meC
 meC
 meC
@@ -85996,11 +88132,19 @@ meC
 meC
 meC
 meC
-lOf
-fyN
-fyN
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 vdE
+kNq
+sQJ
 vdE
+sQJ
 vdE
 vdE
 vdE
@@ -86238,14 +88382,14 @@ meC
 meC
 meC
 meC
-lOf
-eYX
-dXa
-ejf
-eYr
-eKT
-eYX
-lOf
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -86258,8 +88402,8 @@ vdE
 vdE
 vdE
 sQJ
-jFp
 sQJ
+wgB
 vdE
 hCc
 lmS
@@ -86495,14 +88639,14 @@ meC
 meC
 meC
 meC
-lOf
-dNP
-eYr
-eYr
-eYr
-eYr
-esZ
-lOf
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -86515,10 +88659,10 @@ lIi
 hnn
 vdE
 vdE
-gPa
+sQJ
 sQJ
 vdE
-sQJ
+ovA
 sQJ
 sQJ
 lVP
@@ -86752,14 +88896,14 @@ meC
 meC
 meC
 meC
-lOf
-ipK
-dXh
-eYr
-eYr
-eLc
-ipK
-lOf
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -86772,7 +88916,7 @@ hhw
 uJr
 umZ
 vdE
-gPa
+sQJ
 sQJ
 vdE
 kfm
@@ -86819,7 +88963,7 @@ rrH
 ydp
 uCs
 rBC
-prR
+pdl
 frq
 wWJ
 wcD
@@ -87009,14 +89153,14 @@ meC
 meC
 meC
 meC
-lOf
-dNQ
-cVf
-eYr
-eyo
-eKE
-pXW
-lOf
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -87028,7 +89172,7 @@ vdE
 ppk
 hBG
 uJr
-sQJ
+iiC
 sQJ
 hKU
 sQJ
@@ -87266,14 +89410,14 @@ meC
 meC
 meC
 meC
-lOf
-lOf
-lOf
-ekx
-lOf
-lOf
-lOf
-lOf
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -87291,7 +89435,7 @@ vdE
 vdE
 vdE
 vdE
-wzp
+nWc
 lkY
 lVP
 lVP
@@ -87808,7 +89952,7 @@ wzp
 wzp
 sQJ
 sQJ
-sQJ
+cFu
 sQJ
 sQJ
 lVP
@@ -89359,7 +91503,7 @@ fTj
 bcU
 kbe
 qGv
-jXR
+kbe
 kbe
 iOD
 vaF
@@ -96336,7 +98480,7 @@ prs
 pBD
 pBD
 pBD
-uKd
+cql
 sHh
 caa
 meC
@@ -96593,10 +98737,10 @@ caa
 caa
 caa
 caa
+cJM
 caa
 caa
 caa
-meC
 meC
 meC
 meC
@@ -96847,13 +98991,13 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+caa
+dtr
+wVl
+cJM
+scO
+hYn
+caa
 meC
 meC
 meC
@@ -97104,13 +99248,13 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+caa
+aFv
+aNJ
+cJM
+cJM
+nOD
+caa
 meC
 meC
 meC
@@ -97361,13 +99505,13 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+caa
+xDZ
+aNJ
+cJM
+cJM
+ilC
+caa
 meC
 meC
 meC
@@ -97618,13 +99762,13 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+caa
+xcp
+caa
+nvq
+nQn
+pvs
+caa
 meC
 meC
 meC
@@ -97877,11 +100021,11 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
+caa
+caa
+caa
+caa
+caa
 meC
 meC
 meC


### PR DESCRIPTION
Adds all of Engineering (not atmos) but lacks decals.
Adds Chapel's mass driver because it was missing
Adds disposals to Cargo (was missing)

What it looks like currently (ignore atmos at the top left that's old solitaire and has to be deleted.)
![solitaireengie](https://user-images.githubusercontent.com/53777086/156725530-b438a155-08c4-420d-ba2b-efa11b429a18.png)

