### PR TITLE
atmos outline, HFR, Turbine, last solars

### DIFF
--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -19,21 +19,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aaB" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics Tanks NE ";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "abq" = (
@@ -48,13 +38,22 @@
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
 "abu" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "abz" = (
 /obj/structure/closet/mini_fridge,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"abG" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "abW" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -150,8 +149,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
 "afW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/shower{
+	dir = 1;
+	name = "emergency shower"
+	},
+/turf/open/floor/iron/dark,
 /area/space)
 "agf" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
@@ -161,8 +168,14 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "agi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/light/directional/west,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -246,11 +259,13 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "ajy" = (
-/obj/structure/window/reinforced,
-/obj/machinery/computer/atmos_control{
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/space_heater,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "ajH" = (
 /obj/structure/bed,
@@ -352,18 +367,13 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "amG" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
-/obj/effect/turf_decal/loading_area{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "anB" = (
 /obj/machinery/deepfryer,
@@ -389,13 +399,16 @@
 /turf/open/floor/iron/smooth,
 /area/security/warden)
 "aog" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - Mix Chamber 1";
-	name = "atmospherics camera"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
 	},
-/turf/open/floor/engine/vacuum,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF"
+	},
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "aoP" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -430,7 +443,13 @@
 /turf/open/floor/plating,
 /area/command/meeting_room/council)
 "apG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "apO" = (
@@ -489,6 +508,10 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"arU" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/engineering/atmos/storage)
 "arV" = (
 /obj/item/storage/secure/safe/directional/east,
 /obj/machinery/modular_computer/console/preset/id{
@@ -499,19 +522,17 @@
 	},
 /area/command/heads_quarters/ce)
 "ase" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/button/door/atmos_test_room_mainvent_2,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/space)
 "asq" = (
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/structure/table,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/space)
 "ass" = (
 /obj/structure/table/wood,
@@ -649,6 +670,16 @@
 /obj/item/bedsheet/dorms,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
+"axZ" = (
+/obj/structure/cable,
+/obj/machinery/power/compressor{
+	comp_id = "incineratorturbine";
+	dir = 4;
+	luminosity = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "aye" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -672,8 +703,10 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ayA" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8
+	},
+/turf/open/floor/engine/vacuum,
 /area/space)
 "ayH" = (
 /obj/structure/cable,
@@ -770,12 +803,7 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "aBb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/vacuum,
 /area/space)
 "aBi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -797,27 +825,24 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "aBB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/door/poddoor/atmos_test_room_mainvent_2,
+/turf/open/floor/engine/vacuum,
 /area/space)
 "aBG" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF"
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space)
 "aBS" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/generator,
-/obj/effect/spawner/random/maintenance/two,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/space)
 "aCj" = (
@@ -903,17 +928,19 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "aEh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 9;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	color = "#00FFFF";
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "aEz" = (
 /obj/structure/table,
@@ -985,22 +1012,21 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "aGP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Filter"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/structure/railing{
-	layer = 3.1;
-	pixel_y = -4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -5
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "aGY" = (
 /obj/machinery/light/directional/east,
@@ -1077,9 +1103,18 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aJL" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics - Testing Room N";
+	name = "atmospherics camera"
 	},
 /turf/open/floor/iron/smooth_large,
 /area/space)
@@ -1117,16 +1152,12 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "aLa" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/yellow{
+/obj/effect/turf_decal/siding/yellow/corner{
 	color = "#FFD700";
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "aLi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -1151,19 +1182,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"aMh" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/space/nearstation)
 "aMt" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "AI Core - Southwest";
@@ -1173,10 +1191,20 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
+"aMN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "aNf" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white,
 /area/science/research)
+"aNh" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/storage)
 "aNj" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
@@ -1278,16 +1306,22 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "aQw" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
-"aQC" = (
-/obj/docking_port/stationary/random{
-	dir = 8;
-	id = "pod_lavaland2";
-	name = "lavaland"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
+"aQC" = (
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aQI" = (
 /turf/open/floor/iron/chapel{
 	dir = 8
@@ -1336,17 +1370,6 @@
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"aSN" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/bot,
-/obj/item/holosign_creator/atmos,
-/obj/item/holosign_creator/atmos,
-/obj/item/holosign_creator/atmos,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
 "aSQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1372,11 +1395,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aTW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "aUo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1391,8 +1413,14 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "aVD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos/glass{
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/engine/vacuum,
 /area/space)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -1440,9 +1468,19 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aYi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
+/obj/structure/railing{
+	layer = 3.1;
+	pixel_y = -4
+	},
+/obj/structure/window/reinforced{
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron,
 /area/space)
 "aYo" = (
 /obj/structure/filingcabinet,
@@ -1454,33 +1492,16 @@
 	dir = 1
 	},
 /area/service/chapel)
-"aZo" = (
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
 "aZI" = (
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
 "bae" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1;
-	pixel_y = 4
+/obj/machinery/light/small/directional/south,
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics - Mix Chamber 1";
+	name = "atmospherics camera"
 	},
-/obj/structure/railing{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/vacuum,
 /area/space)
 "bas" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -1614,11 +1635,13 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "beP" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/door/airlock/atmos/glass{
+	req_access_txt = "24"
+	},
+/turf/open/floor/engine/vacuum,
 /area/space)
 "beX" = (
 /obj/structure/table/glass,
@@ -1728,11 +1751,12 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "bhP" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/space)
 "bie" = (
@@ -1837,12 +1861,13 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ble" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/yellow/half{
-	color = "#FFD700";
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/smooth_large,
 /area/space)
 "bln" = (
@@ -1855,10 +1880,10 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "blu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/engine/vacuum,
 /area/space)
 "blz" = (
 /obj/machinery/light/directional/south,
@@ -1957,17 +1982,18 @@
 "bnS" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 9;
+	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/space)
 "boe" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -1990,13 +2016,14 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "boJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "boO" = (
 /obj/machinery/door/airlock/engineering{
@@ -2063,23 +2090,8 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "bpF" = (
-/obj/structure/table,
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
 /area/space)
 "bqn" = (
 /obj/machinery/door/window/southleft{
@@ -2207,18 +2219,11 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "bsI" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
+/obj/effect/turf_decal/tile/green/anticorner{
+	color = "#00FFFF";
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "bsK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -2248,6 +2253,14 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"buv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "bvC" = (
 /obj/structure/chair{
 	dir = 8
@@ -2258,7 +2271,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/engine/atmos)
 "bvV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -2278,6 +2291,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"bwX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "bwY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2309,7 +2326,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "bxW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
 "byV" = (
@@ -2327,6 +2347,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"bzp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "bzI" = (
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -2338,19 +2362,30 @@
 /turf/open/floor/wood,
 /area/service/library)
 "bAr" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Mix 2 Output"
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = 27
 	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "bAu" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/fore)
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2,
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "bAv" = (
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2358,8 +2393,19 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "bAy" = (
-/turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "bAG" = (
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -2466,6 +2512,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"bEh" = (
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "bEi" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2508,13 +2557,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"bFn" = (
-/turf/open/floor/engine/n2,
-/area/space)
-"bFv" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input,
-/turf/open/floor/engine/n2,
-/area/space)
 "bFE" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -2544,10 +2586,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "bGs" = (
-/obj/item/circuitboard/machine/circulator,
-/obj/structure/rack,
-/obj/item/circuitboard/machine/circulator,
-/turf/open/floor/plating,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
 /area/space)
 "bGv" = (
 /obj/structure/table/wood,
@@ -2562,8 +2605,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "bGD" = (
-/turf/open/floor/engine/vacuum,
-/area/space/nearstation)
+/obj/item/circuitboard/machine/circulator,
+/obj/structure/rack,
+/obj/item/circuitboard/machine/circulator,
+/turf/open/floor/plating,
+/area/space)
 "bHo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
@@ -2691,14 +2737,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bMc" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
+	dir = 4
 	},
-/obj/machinery/airlock_sensor/incinerator_atmos{
-	pixel_x = 23
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/turf/open/floor/engine/vacuum,
+/turf/open/space/basic,
 /area/space)
 "bMm" = (
 /obj/structure/cable,
@@ -2728,9 +2772,8 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bOa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "bOb" = (
 /obj/machinery/airalarm/directional/east,
@@ -2773,10 +2816,12 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bPI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/space/basic,
 /area/space)
 "bPR" = (
 /obj/structure/closet/mini_fridge,
@@ -2792,6 +2837,10 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"bQL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "bQO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2799,12 +2848,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"bQQ" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
-/turf/open/floor/iron,
-/area/space/nearstation)
 "bQX" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -2886,11 +2929,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
 "bTC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 10
 	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
+/turf/open/space/basic,
 /area/space)
 "bTI" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -2920,10 +2963,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"bUt" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/maintenance/solars/port/fore)
 "bUz" = (
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people,
@@ -3006,12 +3045,19 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
-"bXM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 1
+"bXw" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_access_txt = "24"
 	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/engineering/atmos/project)
+"bXM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
 /area/space)
 "bYw" = (
 /obj/machinery/computer/cargo{
@@ -3079,11 +3125,9 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "bZV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/space)
 "caa" = (
 /turf/closed/wall/r_wall,
@@ -3156,12 +3200,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cbh" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow/anticorner{
-	color = "#FFD700";
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/space)
 "cbp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3181,23 +3222,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "ccy" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "ccz" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/aft)
-"ccS" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
 "cdo" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno4";
@@ -3346,17 +3377,28 @@
 /turf/open/floor/wood,
 /area/service/library)
 "cgQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "cgV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron/smooth_large,
 /area/space)
+"chL" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "cid" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -3428,15 +3470,15 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "ckp" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "ckN" = (
 /mob/living/carbon/human/species/monkey,
@@ -3555,22 +3597,16 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "cnR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cnV" = (
-/obj/effect/turf_decal/tile/green{
-	color = "#00FFFF";
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 6
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "con" = (
 /obj/machinery/hydroponics/constructable,
@@ -3595,14 +3631,6 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"cpH" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Mixing Chamber";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/engine/o2,
-/area/space)
 "cqb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3627,15 +3655,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cqx" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 10;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cqE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -3650,11 +3675,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "cri" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/space)
 "crm" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on,
@@ -3691,11 +3715,12 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "csy" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Air to Mix"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "csA" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -3721,7 +3746,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "cuF" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Post - Science";
@@ -3755,11 +3780,31 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "cuN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
+/obj/structure/railing{
+	layer = 3.1;
+	pixel_y = -4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/railing{
+	dir = 4;
+	layer = 3.1;
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/item/tank/internals/generic,
+/obj/item/tank/internals/generic,
+/obj/item/tank/internals/generic,
+/obj/item/tank/internals/generic,
+/obj/item/tank/internals/generic,
+/turf/open/floor/iron,
 /area/space)
 "cvz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -3820,17 +3865,11 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "cxy" = (
-/obj/structure/window/reinforced/plasma/spawner/east,
-/obj/machinery/light/directional/north,
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cxH" = (
 /obj/structure/table,
@@ -3861,8 +3900,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cyE" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "cyQ" = (
 /obj/effect/turf_decal/tile/yellow/half,
@@ -3903,8 +3948,11 @@
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
 "czs" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/o2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "czD" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3944,12 +3992,16 @@
 /turf/open/space/basic,
 /area/maintenance/solars/starboard/aft)
 "cAS" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/space)
 "cAW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half{
@@ -4028,6 +4080,13 @@
 	},
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
+"cCO" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8;
+	name = "Ports to Distro"
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "cDi" = (
 /obj/machinery/power/emitter,
 /obj/structure/cable,
@@ -4048,11 +4107,21 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
 "cDo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/turf/closed/wall/r_wall,
 /area/space)
+"cDs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "cEc" = (
 /obj/structure/reflector/double/anchored{
 	dir = 6
@@ -4085,15 +4154,11 @@
 	},
 /area/science/research)
 "cEE" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
 	},
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cEI" = (
 /obj/structure/cable,
@@ -4142,11 +4207,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cGn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
 	},
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "cGC" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red/full{
@@ -4155,12 +4222,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cGG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance";
-	req_one_access_txt = "24"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
 "cHe" = (
@@ -4238,11 +4303,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cID" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cJI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4270,14 +4333,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "cLM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/structure/sign/directions/engineering{
+	desc = "A handy sign praising the engineering department.";
+	icon_state = "safety";
+	name = "engineering plaque"
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/smooth_large,
+/turf/closed/wall/r_wall,
 /area/space)
 "cLQ" = (
 /obj/machinery/door/firedoor,
@@ -4310,18 +4371,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
 "cNB" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cOo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -4348,12 +4400,27 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cOR" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
+/obj/machinery/shower{
+	dir = 1;
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - Testing Room S";
+	name = "atmospherics camera"
 	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "cOZ" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -4448,10 +4515,8 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "cRz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cRL" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -4619,14 +4684,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cVo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "cVp" = (
 /obj/machinery/duct,
@@ -4798,14 +4862,8 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "daA" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/computer/atmos_alert{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "daO" = (
 /obj/effect/turf_decal/siding/brown{
@@ -4889,29 +4947,20 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "dcC" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
-	pixel_y = 27
-	},
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/half{
+	color = "#FFD700";
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "dcW" = (
 /obj/structure/sign/directions/command,
 /turf/closed/wall/r_wall,
 /area/command/bridge)
-"ddF" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Mixing Chamber";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/engine/air,
-/area/space)
 "ddR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -4987,16 +5036,20 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "dgo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/engineering/storage/tcomms)
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	color = "#FFD700";
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "dgT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/closet/radiation,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	color = "#FFD700"
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "dhe" = (
 /obj/structure/cable,
@@ -5044,15 +5097,16 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "diz" = (
-/obj/item/beacon,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/yellow/half{
+	color = "#FFD700";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/table,
+/obj/item/tank/internals/generic,
+/obj/item/tank/internals/generic,
+/obj/item/tank/internals/generic,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "diK" = (
 /obj/effect/turf_decal/siding/brown/corner{
@@ -5088,9 +5142,16 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "dje" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Mix 1 to Filter"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 9;
+	name = "engineering yellow"
 	},
+/obj/effect/turf_decal/tile/purple/full{
+	color = "#4D0067"
+	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/space)
 "dji" = (
@@ -5145,6 +5206,12 @@
 	luminosity = 2
 	},
 /area/ai_monitored/command/nuke_storage)
+"dkY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "dla" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -5223,12 +5290,15 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "dnk" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
-	dir = 4
+/obj/item/lightreplacer,
+/obj/item/lightreplacer,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "dnI" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -5402,10 +5472,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "dtp" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "Pure to Port"
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	name = "Gas Mix 2 Tank Control";
+	sensors = list("mix_sensor2" = "Gas Mix 2 Tank")
 	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/effect/turf_decal/tile/purple/full{
+	color = "#4D0067"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/space)
 "dtq" = (
@@ -5496,15 +5575,16 @@
 "dwu" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 4;
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/purple/full{
+	color = "#4D0067"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 1;
+	name = "Mix 2 Input"
+	},
 /turf/open/floor/iron,
 /area/space)
 "dwz" = (
@@ -5565,19 +5645,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"dyA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255;
-	color = "#000000"
-	},
-/turf/open/floor/iron,
-/area/space)
 "dzo" = (
 /obj/structure/closet/bombcloset,
 /obj/item/clothing/mask/gas,
@@ -5605,14 +5672,12 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "dzH" = (
-/obj/machinery/computer/atmos_control/tank/nitrogen_tank,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -5727,8 +5792,8 @@
 /turf/open/floor/plating,
 /area/science/storage)
 "dDf" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
+/turf/open/floor/iron,
 /area/space)
 "dDs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -5748,9 +5813,14 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "dDF" = (
-/obj/effect/turf_decal/siding/yellow/corner{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
+	dir = 1;
 	name = "engineering yellow"
+	},
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -5794,30 +5864,35 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "dEJ" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Atmoshperics Monitoring";
-	req_one_access_txt = "24"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/computer/atmos_control/tank/mix_tank{
+	name = "Gas Mix 1 Tank Control"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "dET" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
 "dEV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 5;
+	name = "engineering yellow"
+	},
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Mix 1 Input"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -5869,18 +5944,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tcomms)
-"dHC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
-	},
-/turf/open/floor/iron,
-/area/space)
 "dIB" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
@@ -5935,16 +5998,8 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
 "dJv" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 9;
-	name = "engineering yellow"
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/sign/poster/official/build{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/turf/closed/wall/r_wall,
 /area/space)
 "dJG" = (
 /obj/machinery/power/terminal{
@@ -5993,6 +6048,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"dKh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "dLf" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -6095,6 +6158,11 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dNC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "dNK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 10
@@ -6137,13 +6205,15 @@
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
 "dPm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 4;
+	dir = 9;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 6
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF0000"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -6179,30 +6249,27 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "dRY" = (
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 9
-	},
+/obj/machinery/computer/atmos_control/tank/nitrous_tank,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - Testing Room S";
-	name = "atmospherics camera"
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "dSP" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/space)
 "dSR" = (
 /obj/machinery/vending/cigarette,
@@ -6224,10 +6291,16 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "dTy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF0000"
+	},
+/turf/open/floor/iron,
 /area/space)
 "dUt" = (
 /obj/structure/closet/crate/trashcart/laundry,
@@ -6327,11 +6400,16 @@
 /turf/closed/wall,
 /area/commons/vacant_room)
 "dXd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/space)
 "dXh" = (
@@ -6343,36 +6421,41 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "dXA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF6700"
+	},
 /turf/open/floor/iron,
 /area/space)
 "dXM" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF6700"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/computer/atmos_control/tank/plasma_tank,
+/turf/open/floor/iron,
 /area/space)
 "dXO" = (
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF6700"
+	},
+/turf/open/floor/iron,
 /area/space)
 "dXX" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
@@ -6481,18 +6564,25 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "eaV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics Tanks NW";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/iron,
 /area/space)
 "ebf" = (
 /obj/structure/cable,
@@ -6657,24 +6747,33 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "eep" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 8;
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255;
+	color = "#000000"
+	},
 /turf/open/floor/iron,
 /area/space)
 "eeu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/space)
 "eeR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/computer/atmos_control/tank/carbon_tank,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255;
+	color = "#000000"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -6711,8 +6810,24 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "efq" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+/obj/structure/railing{
+	dir = 1;
+	layer = 3.1;
+	pixel_y = 4
+	},
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -6731,6 +6846,19 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"egb" = (
+/obj/structure/rack,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "egl" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/glass,
@@ -6746,11 +6874,16 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tcomms)
 "egF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255;
+	color = "#000000"
+	},
 /turf/open/floor/iron,
 /area/space)
 "egQ" = (
@@ -6905,12 +7038,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ejZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/atmospherics,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/iron,
 /area/space)
 "ekt" = (
 /obj/structure/chair/stool/directional/south,
@@ -6955,10 +7092,15 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "elD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255
+	},
 /turf/open/floor/iron,
 /area/space)
 "elF" = (
@@ -6991,17 +7133,15 @@
 	},
 /area/science/research)
 "ema" = (
+/obj/machinery/computer/atmos_control/tank/air_tank,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 4;
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/full{
+	alpha = 255
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "emc" = (
@@ -7024,24 +7164,30 @@
 /turf/open/floor/carpet/green,
 /area/service/library/private)
 "emh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
+/obj/machinery/status_display/evac/directional/north,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/iron,
 /area/space)
 "emj" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/full{
+	color = "#4169E1";
+	name = "Command blue full"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/space)
 "emr" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -7062,10 +7208,17 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "emQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 5
+/obj/machinery/computer/atmos_control/tank/oxygen_tank,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/full{
+	color = "#4169E1";
+	name = "Command blue full"
+	},
+/turf/open/floor/iron,
 /area/space)
 "emW" = (
 /obj/machinery/door/airlock/external{
@@ -7079,13 +7232,17 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "end" = (
-/obj/machinery/atmospherics/components/trinary/filter,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/full{
+	color = "#4169E1";
+	name = "Command blue full"
+	},
+/turf/open/floor/iron,
 /area/space)
 "enN" = (
 /obj/effect/turf_decal/siding/purple{
@@ -7108,6 +7265,10 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"enW" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "eof" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -7134,12 +7295,21 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "eoC" = (
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 8;
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics Tanks NE ";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/space)
 "eoU" = (
@@ -7155,6 +7325,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "epp" = (
@@ -7276,6 +7447,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"etu" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "etA" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
@@ -7363,10 +7538,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
+"evh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "evm" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"evs" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "evt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -7461,12 +7653,16 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "ewL" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - Mix Chamber 2";
-	name = "atmospherics camera"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
 	},
-/turf/open/floor/engine/vacuum,
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF0000"
+	},
+/turf/open/floor/iron,
 /area/space)
 "ewR" = (
 /obj/structure/table/wood,
@@ -7499,16 +7695,14 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
 "exO" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "N2O Outlet"
-	},
+/obj/machinery/computer/atmos_control/tank/nitrogen_tank,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 8;
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/red/full{
+	color = "#FF0000"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -7520,12 +7714,12 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room)
 "eyq" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow/anticorner{
-	color = "#FFD700"
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
 /area/space)
 "eyH" = (
 /obj/structure/table,
@@ -7568,27 +7762,16 @@
 	},
 /area/science/research)
 "ezi" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
+	dir = 9;
 	name = "engineering yellow"
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "ezn" = (
 /obj/structure/rack,
@@ -7606,22 +7789,19 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "ezO" = (
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/siding/yellow{
+/obj/effect/turf_decal/siding/yellow/corner{
 	color = "#FFD700";
-	dir = 4;
+	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "ezW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "ezZ" = (
 /obj/structure/grille/broken,
@@ -7659,10 +7839,12 @@
 /turf/open/floor/carpet/orange,
 /area/command/heads_quarters/ce)
 "eAW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release"
+	},
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 8;
+	dir = 5;
 	name = "engineering yellow"
 	},
 /turf/open/floor/iron,
@@ -7698,6 +7880,11 @@
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"eCY" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "eDm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -7727,12 +7914,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "eDD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/mixer{
+	name = "air mixer";
+	node1_concentration = 0.8;
+	node2_concentration = 0.2;
+	on = 1;
+	target_pressure = 4500
 	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "eEn" = (
 /obj/machinery/vending/autodrobe,
@@ -7765,12 +7954,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eGa" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "eGM" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -7809,13 +7997,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eHR" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/yellow/half{
 	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
+	dir = 4
 	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/area/space)
 "eIr" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -7989,14 +8182,13 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "eLT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 1;
+	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -8061,13 +8253,8 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "eNt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/space)
 "eNE" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -8106,17 +8293,13 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "ePJ" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/yellow/half{
+	color = "#FFD700";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "ePU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -8138,14 +8321,13 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "eQg" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/atmos/glass{
-	req_access_txt = "24"
+/obj/machinery/light/small/directional/south,
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics - Mix Chamber 2";
+	name = "atmospherics camera"
 	},
 /turf/open/floor/engine/vacuum,
-/area/space/nearstation)
+/area/space)
 "eQz" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -8178,11 +8360,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "eSc" = (
-/obj/structure/window/reinforced,
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Mix 2 Output"
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/turf/open/floor/iron,
 /area/space)
 "eSf" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -8202,9 +8388,10 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
 "eSw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/space)
 "eSJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -8227,7 +8414,9 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "eTZ" = (
-/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/space)
 "eUc" = (
@@ -8238,16 +8427,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "eUr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/space)
 "eUx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8382,8 +8565,13 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "eZN" = (
-/obj/structure/sign/poster/official/there_is_no_gas_giant,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Mix 1 Output"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "eZP" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
@@ -8470,8 +8658,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "fbg" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/space)
 "fbl" = (
 /obj/machinery/photocopier,
@@ -8520,7 +8711,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fcT" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -8585,6 +8781,22 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "fej" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/machinery/navbeacon/wayfinding/atmos,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/space)
 "fep" = (
@@ -8623,18 +8835,21 @@
 /turf/open/floor/wood,
 /area/service/library)
 "ffg" = (
-/obj/machinery/air_sensor/atmos/mix_tank{
-	name = "mix 1 tank gas sensor"
-	},
-/turf/open/floor/engine/vacuum,
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/iron,
 /area/space)
+"ffm" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "ffE" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/plating,
 /area/space)
 "ffI" = (
 /obj/structure/rack,
@@ -8678,11 +8893,18 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "fgK" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "N2O Outlet"
 	},
-/turf/open/space/basic,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "fgN" = (
 /obj/effect/turf_decal/trimline/blue/line{
@@ -8690,14 +8912,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"fhc" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Mixing Chamber";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/engine/co2,
-/area/space)
 "fhd" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
@@ -8715,16 +8929,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fhv" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC"
-	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "fhC" = (
@@ -8806,21 +9014,19 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "fjp" = (
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Mix 1 to Turbine"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "fju" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Plasma Outlet"
+	},
+/turf/open/floor/iron,
 /area/space)
 "fjG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8885,6 +9091,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
 "flO" = (
@@ -8893,11 +9100,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
 "flU" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/space)
 "fmi" = (
@@ -8910,18 +9116,10 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "fmr" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "fmF" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -8929,7 +9127,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "fmX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/white,
@@ -8945,9 +9143,11 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "fnR" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "CO2 Outlet"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -8955,9 +9155,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "foA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron,
 /area/space)
 "fpd" = (
 /obj/structure/rack,
@@ -8965,22 +9171,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "fpe" = (
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/space)
-"fpg" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos/glass{
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine/vacuum,
-/area/space/nearstation)
 "fpl" = (
 /obj/machinery/door/airlock{
 	name = "Service Lathe Access";
@@ -9002,11 +9197,13 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "fpp" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air Outlet Pump"
+	},
+/turf/open/floor/iron,
 /area/space)
 "fpx" = (
 /obj/machinery/modular_computer/console/preset/civilian,
@@ -9016,53 +9213,43 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "fpE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/space)
-"fpJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/space)
-"fpN" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/machinery/status_display/evac/directional/north,
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
+/area/space)
+"fpJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "O2 Outlet Pump"
+	},
+/turf/open/floor/iron,
+/area/space)
+"fpN" = (
+/obj/structure/chair/office,
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "fqj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
 "fql" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/space)
 "fqH" = (
 /obj/effect/turf_decal/tile/brown,
@@ -9087,14 +9274,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "frb" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "N2 Outlet Pump"
 	},
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "frq" = (
@@ -9132,16 +9317,22 @@
 /obj/item/analyzer,
 /turf/open/floor/iron,
 /area/engineering/main)
+"fse" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "fsG" = (
 /obj/machinery/processor,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "fsI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/iron,
 /area/space)
 "fsQ" = (
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -9170,19 +9361,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/security/prison/workout)
-"fuP" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - HFR Main Room";
-	name = "atmospherics camera"
-	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 5;
-	name = "engineering yellow"
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
 "fuR" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -9266,9 +9444,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "fwZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/half{
+	color = "#FFD700";
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "fxq" = (
 /obj/structure/cable,
@@ -9314,7 +9497,14 @@
 /turf/open/floor/wood,
 /area/service/library)
 "fyN" = (
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	color = "#FFD700";
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "fze" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -9357,13 +9547,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "fAK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air Outlet Pump"
-	},
-/turf/open/floor/iron,
+/obj/structure/window/reinforced,
+/obj/machinery/suit_storage_unit/atmos,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "fAL" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -9506,16 +9692,25 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fDD" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 8
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 20;
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+/obj/item/stack/sheet/rglass{
+	amount = 20;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/tile/yellow/anticorner{
+	color = "#FFD700";
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "fDS" = (
 /obj/effect/turf_decal/trimline/red/line{
@@ -9541,6 +9736,12 @@
 /obj/item/cane,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fEd" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "fEj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -9567,13 +9768,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "fFN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/yellow/half{
+	color = "#FFD700";
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "fGo" = (
 /obj/structure/cable,
@@ -9717,12 +9918,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"fKI" = (
-/obj/machinery/air_sensor/atmos/mix_tank{
-	id_tag = "mix_sensor2";
-	name = "mix 2 tank gas sensor"
+"fKG" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
+"fKI" = (
+/obj/effect/turf_decal/siding/yellow/corner{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "fKP" = (
 /obj/structure/cable,
@@ -9736,20 +9945,17 @@
 /turf/open/floor/iron/smooth,
 /area/security/warden)
 "fKX" = (
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	name = "Gas Mix 2 Tank Control";
-	sensors = list("mix_sensor2" = "Gas Mix 2 Tank")
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
+/obj/machinery/camera/directional/east{
+	c_tag = "Atmospherics - Testing Room E";
+	name = "atmospherics camera"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "fLn" = (
 /obj/structure/table/reinforced,
@@ -9761,8 +9967,11 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "fLu" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "fLH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9789,9 +9998,11 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "fMg" = (
-/obj/machinery/igniter/incinerator_atmos,
-/obj/structure/cable,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/space)
 "fMr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -9804,12 +10015,17 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "fMW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "N2 Outlet Pump"
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "fNt" = (
@@ -9821,11 +10037,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "fOu" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/space)
 "fPg" = (
 /obj/structure/cable,
@@ -9962,6 +10176,12 @@
 /obj/item/laser_pointer/blue,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"fRX" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "fSa" = (
 /obj/structure/table,
 /obj/item/paper{
@@ -10019,12 +10239,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"fST" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "fTj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -10066,11 +10280,8 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "fUb" = (
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
-"fUt" = (
-/obj/machinery/portable_atmospherics/canister/tier_3,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/open/floor/iron,
 /area/space)
 "fUP" = (
 /obj/machinery/vending/coffee,
@@ -10208,30 +10419,24 @@
 /obj/item/hand_labeler,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"fYu" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
 "fYC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "fZz" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
 /area/space)
 "fZH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix 2 to Port"
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "fZM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -10293,17 +10498,18 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "gbZ" = (
-/obj/structure/window/reinforced,
-/obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/iron/dark/smooth_large,
-/area/space)
-"gcI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 8;
 	name = "engineering yellow"
 	},
 /turf/open/floor/iron,
+/area/space)
+"gcI" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/space/basic,
 /area/space)
 "gde" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -10340,7 +10546,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gdX" = (
-/obj/machinery/airalarm/directional/south,
+/obj/structure/tank_dispenser/plasma,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "gea" = (
@@ -10454,10 +10660,16 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "ghG" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/structure/sign/warning/radiation,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
 /area/space)
 "ghN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10632,6 +10844,25 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"glN" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
+"gmk" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos/project)
 "gmA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/closed/wall/r_wall,
@@ -10644,12 +10875,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"gmJ" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
-	},
-/turf/open/floor/iron,
-/area/space)
 "gmN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -10820,9 +11045,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gpZ" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/iron,
 /area/space)
 "gqh" = (
 /obj/structure/window/reinforced{
@@ -11054,16 +11278,15 @@
 /turf/open/floor/plating,
 /area/medical/patients_rooms)
 "gwa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "gwl" = (
 /obj/effect/turf_decal/tile/purple/half{
@@ -11195,23 +11418,26 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "gzh" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 8
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Engine";
+	req_access_txt = "24"
 	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/space)
 "gzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
@@ -11274,11 +11500,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gAG" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	color = "#FFD700"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/space)
 "gAL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -11374,6 +11598,10 @@
 	dir = 4
 	},
 /area/command/gateway)
+"gEn" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "gEt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11434,6 +11662,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"gGn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "gGs" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -11492,10 +11726,6 @@
 	},
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
-"gHX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/plasma_output,
-/turf/open/floor/engine/plasma,
-/area/space)
 "gIv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -11507,14 +11737,10 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "gIz" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 8
-	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "gJp" = (
@@ -11628,13 +11854,6 @@
 /obj/effect/landmark/start/head_of_personnel,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
-"gMT" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "gNb" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -11659,13 +11878,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gNY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron,
 /area/space)
 "gOi" = (
 /obj/structure/sink{
@@ -11726,22 +11942,27 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
+"gQr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gQs" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/space)
 "gQD" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 10;
+	name = "engineering yellow"
 	},
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron/smooth_large,
 /area/space)
 "gQG" = (
@@ -11828,13 +12049,9 @@
 /turf/open/floor/plating,
 /area/science/breakroom)
 "gSH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/turf/open/floor/iron,
 /area/space)
 "gTi" = (
 /obj/effect/turf_decal/plaque{
@@ -11858,17 +12075,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
 "gTT" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
+/obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 4;
-	name = "engineering yellow"
+	name = "O2 To Pure"
 	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "gTU" = (
 /obj/structure/chair/comfy/beige{
@@ -11911,13 +12122,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gVC" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
 	},
-/obj/machinery/door/airlock/atmos/glass{
-	req_access_txt = "24"
-	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/iron,
 /area/space)
 "gVM" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -12128,8 +12336,11 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "hdN" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Air to Mix"
+	},
+/turf/open/floor/iron,
 /area/space)
 "hdR" = (
 /obj/machinery/light/directional/south,
@@ -12137,9 +12348,17 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hen" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
+/obj/effect/turf_decal/tile/green{
+	color = "#00FFFF";
+	dir = 4
 	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "heI" = (
@@ -12396,8 +12615,12 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
 "hnI" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
-/turf/open/floor/engine/n2o,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space)
 "hnN" = (
 /obj/effect/turf_decal/tile/bar,
@@ -12446,9 +12669,8 @@
 /turf/open/floor/plating,
 /area/commons/dorms)
 "hqG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/space)
 "hqH" = (
@@ -12475,20 +12697,11 @@
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
 "hrg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix 1 to Distro"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/space)
-"hrx" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "hrF" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -12574,16 +12787,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"hue" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2,
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
 "hup" = (
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
@@ -12870,10 +13073,12 @@
 /turf/open/floor/iron,
 /area/medical/treatment_center)
 "hCO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/obj/machinery/meter,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/space)
 "hCP" = (
@@ -12997,10 +13202,17 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "hEP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 8
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "hFk" = (
 /obj/machinery/computer/crew{
@@ -13082,27 +13294,27 @@
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "hGp" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/space)
-"hGt" = (
-/obj/structure/table,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
+	dir = 8;
 	name = "engineering yellow"
+	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix 2 to Distro"
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Air Distribution";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+	},
+/turf/open/floor/iron,
+/area/space)
+"hGt" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -13148,10 +13360,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "hIz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_one_access_txt = "24"
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/space)
 "hIG" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -13173,15 +13388,10 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "hJA" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "hJC" = (
@@ -13190,14 +13400,20 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "hJD" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron{
-	amount = 50
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/multitool,
-/obj/item/multitool,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/turf/open/floor/iron,
 /area/space)
 "hJL" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -13261,7 +13477,7 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/space)
 "hKn" = (
@@ -13304,6 +13520,19 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet/black,
 /area/service/chapel)
+"hLH" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "hLR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
@@ -13487,9 +13716,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hPR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/space)
 "hPT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13525,12 +13756,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "hQH" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/engineering/storage/tcomms)
 "hQJ" = (
 /obj/structure/table,
@@ -13560,10 +13786,10 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "hRS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 8;
+	name = "plasma mixer"
+	},
 /turf/open/floor/iron,
 /area/space)
 "hRT" = (
@@ -13579,6 +13805,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
+"hSi" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "hSl" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -13594,8 +13824,19 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
 "hSR" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/smooth_large,
 /area/space)
@@ -13612,6 +13853,13 @@
 	dir = 8
 	},
 /area/engineering/gravity_generator)
+"hTs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "hTI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
@@ -13660,9 +13908,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"hVF" = (
-/turf/open/floor/engine/plasma,
-/area/space)
 "hVJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -13677,9 +13922,10 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "hWB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "hWD" = (
@@ -13728,16 +13974,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/lawoffice/upper)
-"hXR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"hXI" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Exterior Airlock";
-	req_access_txt = "24"
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
+"hXR" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "N2 To Pure"
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/iron,
+/area/space)
 "hXW" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/blue{
@@ -13976,7 +14227,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "idx" = (
-/turf/open/floor/engine/n2o,
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
+/turf/open/floor/iron,
 /area/space)
 "idJ" = (
 /obj/item/kirbyplants/random,
@@ -14083,6 +14335,18 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
+"igx" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/engineering/main)
+"igM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "ihm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14113,6 +14377,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"ihJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ihM" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/south{
@@ -14201,12 +14474,9 @@
 /turf/open/floor/iron/white,
 /area/security)
 "ikC" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 6;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 4
 	},
-/obj/structure/closet/crate/internals,
 /turf/open/floor/iron,
 /area/space)
 "ikJ" = (
@@ -14303,25 +14573,19 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/xenobiology)
 "img" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
 /area/space)
 "imn" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "imr" = (
-/obj/effect/turf_decal/siding/yellow/corner{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/item/circuitboard/machine/generator,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
 /area/space)
 "imH" = (
 /obj/effect/turf_decal/siding/purple/corner{
@@ -14329,10 +14593,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"imO" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
-/area/space)
 "imP" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/brute{
@@ -14368,15 +14628,11 @@
 	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/space)
 "inr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
@@ -14398,6 +14654,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"inY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "iok" = (
 /obj/structure/chair{
 	dir = 4
@@ -14409,14 +14671,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "iom" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "ioH" = (
@@ -14428,10 +14686,6 @@
 /obj/item/trash/raisins,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ipr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output,
-/turf/open/floor/engine/n2,
-/area/space)
 "ipB" = (
 /obj/machinery/computer/cargo/request{
 	dir = 4
@@ -14534,6 +14788,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"iqM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "iqU" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -14573,8 +14831,17 @@
 /turf/closed/wall,
 /area/maintenance/department/medical)
 "irQ" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "isd" = (
@@ -14616,6 +14883,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cargo Lobby"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "itF" = (
@@ -14703,9 +14971,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ivo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix 1 to Port"
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -14771,13 +15038,12 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "ixl" = (
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = 32
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/iron,
 /area/space)
 "ixr" = (
 /obj/effect/turf_decal/bot,
@@ -14948,16 +15214,15 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "iCJ" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "iCW" = (
 /obj/machinery/light/directional/north,
@@ -15064,24 +15329,16 @@
 	},
 /turf/open/space/basic,
 /area/medical/surgery)
-"iGF" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
 "iGM" = (
-/obj/machinery/computer/atmos_control/tank/air_tank,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/item/beacon,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "iGR" = (
 /obj/structure/closet/secure_closet,
@@ -15120,20 +15377,22 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "iHm" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Incinerator Output Pump";
-	target_pressure = 4500
-	},
-/turf/open/space/basic,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
 /area/space)
 "iHy" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "iHz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15149,13 +15408,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"iHM" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "O2 To Pure"
-	},
-/turf/open/floor/iron,
-/area/space)
 "iIb" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -15166,8 +15418,8 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "iIw" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/n2,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
+/turf/open/floor/iron,
 /area/space)
 "iIy" = (
 /obj/structure/table/reinforced,
@@ -15376,12 +15628,18 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/fore)
 "iMm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "iMn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15456,9 +15714,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"iNw" = (
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "iOC" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000"
@@ -15512,17 +15767,21 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "iPe" = (
-/obj/machinery/computer/atmos_control/tank/oxygen_tank,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Atmoshperics Monitoring";
+	req_one_access_txt = "24"
 	},
-/obj/effect/turf_decal/tile/blue/full{
-	color = "#4169E1";
-	name = "Command blue full"
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "iPh" = (
 /obj/item/radio/intercom/directional/east,
@@ -15615,10 +15874,10 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "iQY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/space)
 "iRe" = (
 /obj/structure/noticeboard/directional/north{
@@ -15665,23 +15924,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "iSh" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/space)
 "iSi" = (
@@ -15852,14 +16102,9 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "iVZ" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 10;
-	name = "engineering yellow"
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix 1 to Port"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -15897,12 +16142,8 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "iXo" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "iXz" = (
@@ -15919,16 +16160,14 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "iXF" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "iYE" = (
@@ -15985,8 +16224,8 @@
 	},
 /area/holodeck/rec_center)
 "iZx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output,
-/turf/open/floor/engine/co2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/turf/open/floor/iron,
 /area/space)
 "iZy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16079,22 +16318,24 @@
 "jbW" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
-"jbY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
 	dir = 4;
 	name = "engineering yellow"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
+/area/space)
+"jbY" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	color = "#c45c57";
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/space)
 "jcg" = (
 /obj/structure/cable,
@@ -16104,23 +16345,19 @@
 "jci" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 9;
+	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/space)
-"jcm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron,
+/area/space)
+"jcm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/space)
 "jco" = (
 /obj/effect/turf_decal/trimline/red/line{
@@ -16211,19 +16448,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "jfQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/structure/window/reinforced,
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "O2 Outlet Pump"
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "jfV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "jgn" = (
@@ -16297,15 +16532,20 @@
 /turf/open/floor/iron/smooth,
 /area/security/warden)
 "jiM" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
+"jiP" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "jje" = (
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 4
@@ -16418,9 +16658,13 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "jmc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/turf/open/floor/plating,
+/area/space)
 "jmj" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -16433,8 +16677,12 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/office)
 "jmW" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16490,17 +16738,15 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "jnC" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/tile/yellow/half{
+/obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "jnN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16564,13 +16810,11 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "jpD" = (
-/obj/machinery/computer/atmos_control/incinerator,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
+/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/space)
 "jpE" = (
 /obj/machinery/camera/directional/north{
@@ -16591,9 +16835,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
-"jqT" = (
-/turf/open/floor/engine/air,
-/area/space)
+"jqb" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "jqW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/bureaucracy/briefcase,
@@ -16637,8 +16882,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jsH" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "jtM" = (
 /obj/machinery/light/directional/north,
@@ -16654,21 +16902,11 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "jtT" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/turf/open/floor/iron,
 /area/space)
 "jtX" = (
 /obj/machinery/door/airlock{
@@ -16790,14 +17028,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron/white/side,
 /area/science/research)
-"jyE" = (
-/obj/effect/turf_decal/siding/yellow/corner{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "jyS" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
@@ -16874,15 +17104,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"jAR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "jBc" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -16937,16 +17158,17 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "jCg" = (
-/obj/structure/window/reinforced,
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix 2 to Port"
+	},
+/turf/open/floor/iron,
 /area/space)
 "jCl" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Engine"
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "jCs" = (
@@ -17000,12 +17222,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"jEh" = (
+/turf/open/floor/iron,
+/area/engineering/atmos/storage)
 "jEp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/stairs{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/binary/thermomachine/heater,
+/turf/open/floor/iron,
 /area/space)
 "jEP" = (
 /obj/structure/cable,
@@ -17058,9 +17280,11 @@
 /turf/open/floor/carpet/red,
 /area/service/lawoffice)
 "jFD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/space)
 "jGf" = (
 /obj/effect/turf_decal/tile/blue{
@@ -17208,19 +17432,12 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "jIq" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/tile/green/anticorner{
+	color = "#00FFFF";
 	dir = 8
 	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "jIr" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -17248,9 +17465,23 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "jIC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "jII" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -17301,8 +17532,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
 "jKq" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 4;
+	name = "Mix to Port 1"
+	},
+/turf/open/floor/iron,
 /area/space)
 "jKE" = (
 /obj/machinery/light/directional/east,
@@ -17331,13 +17565,6 @@
 /obj/item/plant_analyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"jLJ" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
 "jMl" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
@@ -17415,6 +17642,13 @@
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
+"jOl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "jOs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -17515,13 +17749,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "jQu" = (
-/obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 10;
+	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/space)
 "jQC" = (
@@ -17600,11 +17833,10 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "jSg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow/corner{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/space)
 "jSm" = (
@@ -17766,13 +17998,9 @@
 "jWs" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 10;
 	name = "engineering yellow"
 	},
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "jWv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17892,13 +18120,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
-"kaD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/space)
 "kaE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -18176,14 +18397,6 @@
 	icon_state = "chapel"
 	},
 /area/ai_monitored/turret_protected/ai_upload)
-"khb" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Mixing Chamber";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/engine/n2o,
-/area/space)
 "khd" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18218,12 +18431,12 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/xenobiology)
 "kjc" = (
-/obj/structure/window/reinforced,
-/obj/structure/tank_dispenser/oxygen{
-	pixel_x = -1;
-	pixel_y = 2
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
 /area/space)
 "kjf" = (
 /obj/structure/cable,
@@ -18239,6 +18452,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"kjk" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "kjp" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	color = "#FFD700";
@@ -18255,10 +18474,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"kjr" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/space)
 "kkh" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
@@ -18337,8 +18552,13 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "kmx" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
-/turf/open/floor/engine/vacuum,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 6;
+	name = "engineering yellow"
+	},
+/obj/structure/closet/crate/internals,
+/turf/open/floor/iron,
 /area/space)
 "kmN" = (
 /obj/structure/cable,
@@ -18393,20 +18613,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "kod" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - Turbine Room";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "kox" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -18481,6 +18693,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
+"kqx" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
+	pixel_y = 27
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "kqC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -18501,6 +18725,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"kqV" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/engineering/atmos/hfr_room)
 "kro" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /turf/open/floor/iron/cafeteria,
@@ -18580,6 +18808,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/service/janitor)
+"kuK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "kuT" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = -30
@@ -18589,13 +18822,20 @@
 	},
 /turf/open/floor/iron,
 /area/security/range)
-"kvc" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/tile/yellow/half{
-	color = "#FFD700";
-	dir = 8
+"kuZ" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
 	},
-/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
+"kvc" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
 /turf/open/floor/iron/smooth_large,
 /area/space)
 "kvI" = (
@@ -18647,14 +18887,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "kwI" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "Mix 2 Input"
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "kwN" = (
 /obj/structure/filingcabinet,
@@ -18713,6 +18951,11 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"kxB" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kxS" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -18735,6 +18978,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"kyz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "kyH" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/white,
@@ -18782,9 +19031,22 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "kAc" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/shower{
+	dir = 1;
+	name = "emergency shower"
 	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/smooth_large,
 /area/space)
 "kAm" = (
@@ -18893,6 +19155,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "kDY" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 6;
+	name = "engineering yellow"
+	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron/smooth_large,
 /area/space)
 "kEo" = (
@@ -18981,10 +19249,7 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tcomms)
 "kGC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
 "kGH" = (
@@ -19011,17 +19276,8 @@
 /turf/closed/wall,
 /area/medical/storage)
 "kHp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
 /area/space)
 "kHx" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
@@ -19109,10 +19365,12 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "kKe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/obj/machinery/meter,
+/obj/machinery/pipedispenser,
 /turf/open/floor/iron,
 /area/space)
 "kKg" = (
@@ -19120,8 +19378,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kKj" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/plasma_input,
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/turf/open/floor/iron,
 /area/space)
 "kKs" = (
 /obj/effect/turf_decal/tile/green/anticorner{
@@ -19210,22 +19471,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "kLJ" = (
-/obj/structure/railing{
-	layer = 3.1;
-	pixel_y = -4
-	},
-/obj/structure/railing{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/space)
 "kLM" = (
@@ -19234,15 +19480,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "kLP" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/space)
 "kLY" = (
 /obj/structure/table,
@@ -19313,13 +19554,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "kML" = (
-/obj/effect/turf_decal/siding/yellow/corner{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 4;
+	name = "Pure to Port"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "kNd" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -19590,12 +19829,15 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "kSA" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
-	dir = 1
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "kSC" = (
 /obj/machinery/computer/security/telescreen/auxbase{
 	dir = 8;
@@ -19620,37 +19862,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kTe" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics Tanks NW";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "kTt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
+	dir = 4;
+	name = "Mix to Port 2"
 	},
-/obj/structure/railing{
-	layer = 3.1;
-	pixel_y = -4
-	},
-/obj/structure/window/reinforced{
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/tile/green/half{
+/obj/effect/turf_decal/tile/green{
 	color = "#00FFFF"
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/iron,
 /area/space)
 "kTv" = (
@@ -19682,16 +19906,19 @@
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
 "kUm" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
+/obj/machinery/meter,
+/obj/structure/railing{
+	layer = 3.1;
+	pixel_y = -4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Distro to Waste"
+/obj/structure/window/reinforced{
+	pixel_y = -5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron,
 /area/space)
 "kUp" = (
@@ -19820,21 +20047,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"kXs" = (
-/obj/machinery/airalarm/unlocked{
-	dir = 4;
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "kXw" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -19848,16 +20060,22 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "kXC" = (
-/obj/machinery/door/window/brigdoor/westright{
-	name = "Atmospherics Monitoring";
-	req_one_access_txt = "24"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Filter"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/railing{
+	layer = 3.1;
+	pixel_y = -4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/window/reinforced{
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron,
 /area/space)
 "kXJ" = (
 /turf/closed/wall/r_wall,
@@ -19889,8 +20107,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "kYz" = (
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/space)
 "kYA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20016,9 +20235,6 @@
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/storage/tcomms)
@@ -20031,30 +20247,18 @@
 /turf/open/floor/carpet/green,
 /area/service/library/private)
 "laV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/structure/railing{
 	layer = 3.1;
 	pixel_y = -4
 	},
-/obj/structure/railing{
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 3
+/obj/structure/window/reinforced{
+	pixel_y = -5
 	},
 /obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 4
+	color = "#00FFFF"
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/item/tank/internals/generic,
-/obj/item/tank/internals/generic,
-/obj/item/tank/internals/generic,
-/obj/item/tank/internals/generic,
-/obj/item/tank/internals/generic,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/iron,
 /area/space)
 "laX" = (
@@ -20117,11 +20321,21 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
 "lbM" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/structure/railing{
+	layer = 3.1;
+	pixel_y = -4
+	},
+/obj/structure/window/reinforced{
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron,
 /area/space)
 "lcb" = (
 /obj/machinery/door/airlock/maintenance{
@@ -20139,10 +20353,17 @@
 /turf/open/floor/wood,
 /area/service/library)
 "lcn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/tile/green{
+	color = "#00FFFF";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/space)
 "lcD" = (
 /obj/machinery/camera/directional/west{
@@ -20153,12 +20374,22 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "lcF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Distro to Waste"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/space)
+"lcI" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "ldl" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/chair/pew/right,
@@ -20355,17 +20586,12 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "lhx" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 6;
-	name = "engineering yellow"
-	},
-/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "lil" = (
@@ -20476,9 +20702,17 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
 "llp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/space)
 "llw" = (
@@ -20505,15 +20739,19 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "lmn" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/camera/directional/east{
+	c_tag = "Atmospherics East";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
 	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Mix"
-	},
+/obj/structure/fireaxecabinet/directional/east,
 /turf/open/floor/iron,
 /area/space)
 "lmC" = (
@@ -20674,15 +20912,15 @@
 	},
 /area/science/mixing)
 "lpf" = (
-/obj/machinery/computer/atmos_control/tank/nitrous_tank,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 1;
 	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Waste In"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "lph" = (
@@ -20716,6 +20954,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
 "lqm" = (
@@ -20820,13 +21059,11 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ltD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Exterior Airlock";
-	req_access_txt = "24"
+/obj/effect/turf_decal/tile/yellow/half{
+	color = "#FFD700"
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "ltF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -20944,12 +21181,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/science/research)
-"lxs" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron,
-/area/space/nearstation)
 "lxC" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "CellMed";
@@ -21050,7 +21281,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "lzH" = (
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -21073,7 +21304,7 @@
 	req_one_access_txt = "33"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/engine/atmos)
 "lAP" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/clothing/mask/gas,
@@ -21166,9 +21397,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "lCH" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 6;
+	name = "engineering yellow"
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/space)
 "lCN" = (
 /obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
 	pixel_x = -24
@@ -21183,21 +21424,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"lCW" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Engine";
-	req_access_txt = "24"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space/nearstation)
 "lDe" = (
 /obj/machinery/vending/modularpc,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -21309,6 +21535,17 @@
 	dir = 4
 	},
 /area/service/chapel)
+"lGp" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "lGr" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 4
@@ -21417,8 +21654,11 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "lJR" = (
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
 "lJW" = (
 /obj/effect/turf_decal/trimline/neutral/end{
 	dir = 1
@@ -21768,7 +22008,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "lQM" = (
-/turf/open/floor/engine/co2,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Air to Ports"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "lQN" = (
 /obj/effect/turf_decal/siding/brown{
@@ -21858,23 +22104,13 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "lSw" = (
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
 	},
-/obj/effect/turf_decal/trimline/blue/line{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/smooth_large,
+/turf/closed/wall/r_wall,
 /area/space)
 "lSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22013,17 +22249,21 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "lVR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics West";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Atmospherics - Testing Room E";
-	name = "atmospherics camera"
-	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "lVW" = (
 /obj/structure/bed,
@@ -22137,9 +22377,12 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "lXr" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/space)
 "lXB" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -22268,6 +22511,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "mbY" = (
@@ -22393,7 +22637,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "mdq" = (
 /obj/structure/chair{
 	name = "Defense"
@@ -22441,17 +22685,8 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "met" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 9;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
 /area/space)
 "mev" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22476,18 +22711,11 @@
 	},
 /area/service/abandoned_gambling_den)
 "mfe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/computer/atmos_control/tank/carbon_tank,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255;
-	color = "#000000"
-	},
-/turf/open/floor/iron,
 /area/space)
 "mfn" = (
 /obj/structure/cable,
@@ -22547,12 +22775,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "mhl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/space)
 "mhq" = (
@@ -22568,12 +22794,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "mhD" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
 /turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/area/space)
 "mic" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood/parquet,
@@ -22658,7 +22884,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/engine/atmos)
 "mkh" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -22670,10 +22896,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "mkv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to Distro"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Engine"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -22768,11 +22993,10 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "mmr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/space)
 "mmC" = (
 /obj/structure/chair/office/light,
@@ -22805,10 +23029,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"mmY" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input,
-/turf/open/floor/engine/o2,
-/area/space)
 "mne" = (
 /obj/machinery/camera/autoname/directional/north{
 	c_tag = "Holodeck - Fore";
@@ -22867,10 +23087,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"moV" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/plasma,
-/area/space)
 "mpa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -22892,6 +23108,9 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"mpx" = (
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "mpD" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -22951,6 +23170,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"mrW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Auxiliary Port";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "msb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -22970,10 +23197,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"msP" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/co2,
-/area/space)
 "mtf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22983,13 +23206,14 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "mtn" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/structure/table,
+/obj/item/stack/sheet/iron{
+	amount = 50
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/multitool,
+/obj/item/multitool,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "mto" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23038,9 +23262,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "muo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to Distro"
+	},
+/turf/open/floor/iron,
 /area/space)
 "muz" = (
 /obj/structure/chair{
@@ -23160,12 +23387,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "mwU" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Ports"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/space)
 "mxw" = (
@@ -23215,13 +23437,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"myC" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
 "myV" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -23368,15 +23583,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "mBS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/sign/poster/official/there_is_no_gas_giant,
+/turf/closed/wall/r_wall,
 /area/space)
 "mBU" = (
 /obj/effect/turf_decal/tile/red/half{
@@ -23520,13 +23728,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"mCZ" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "N2 To Pure"
-	},
-/turf/open/floor/iron,
-/area/space)
 "mDl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -23691,10 +23892,9 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "mHk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/bluespace_sender,
+/obj/item/toy/figure/atmos,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "mHA" = (
 /obj/effect/turf_decal/bot,
@@ -23705,6 +23905,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/service/hydroponics/garden)
+"mIj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "mIG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -24017,8 +24223,11 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/engine/atmos)
 "mNp" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/blue{
@@ -24055,6 +24264,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"mNS" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/storage)
 "mOc" = (
 /obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron/dark,
@@ -24079,11 +24293,12 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "mOy" = (
-/obj/machinery/button/door/atmos_test_room_mainvent_2,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "mOE" = (
 /obj/structure/bodycontainer/crematorium{
@@ -24092,6 +24307,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"mOJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "mPn" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -24115,17 +24336,30 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"mPC" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Mix 1 Input"
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "mPV" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/yellow/half{
-	color = "#FFD700";
+/obj/structure/railing{
+	layer = 3.1;
+	pixel_y = -4
+	},
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/tank/internals/generic,
-/obj/item/tank/internals/generic,
-/obj/item/tank/internals/generic,
-/turf/open/floor/iron/smooth_large,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
 /area/space)
 "mQb" = (
 /obj/effect/turf_decal/siding/blue{
@@ -24181,6 +24415,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"mRh" = (
+/obj/structure/cable,
+/obj/machinery/power/turbine{
+	dir = 8;
+	luminosity = 2
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "mRB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -24192,10 +24437,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mRN" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "mSk" = (
@@ -24211,11 +24455,17 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "mSv" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
 	},
-/obj/structure/cable,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC"
+	},
+/turf/open/floor/iron,
 /area/space)
 "mSw" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
@@ -24279,6 +24529,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
+"mTT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Auxiliary Port";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "mTY" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
@@ -24436,8 +24695,29 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "mZg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 1;
+	layer = 3.1;
+	pixel_y = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 3.1;
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/table,
+/obj/item/storage/belt/utility/atmostech,
+/obj/item/storage/belt/utility/atmostech,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
+/obj/item/t_scanner,
 /turf/open/floor/iron,
 /area/space)
 "mZm" = (
@@ -24495,8 +24775,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "mZX" = (
-/obj/machinery/air_sensor/atmos/plasma_tank,
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
 /area/space)
 "nah" = (
 /obj/effect/turf_decal/tile/yellow/half,
@@ -24614,10 +24897,10 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ncz" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Mix 2 to Filter"
-	},
-/turf/open/floor/iron,
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "ncK" = (
 /obj/effect/turf_decal/tile/brown{
@@ -24682,13 +24965,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
-"nep" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
 "neq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -24756,14 +25032,9 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "ngs" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/obj/machinery/suit_storage_unit/atmos,
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "ngw" = (
 /obj/structure/closet/crate/silvercrate,
@@ -24788,12 +25059,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "nhh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/space)
-"nhB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output,
-/turf/open/floor/engine/n2o,
+/obj/structure/window/reinforced,
+/obj/machinery/computer/atmos_control{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "nhW" = (
 /obj/machinery/disposal/bin,
@@ -24816,8 +25086,21 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "niu" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_y = -32
+	},
+/obj/machinery/shower{
+	dir = 1;
+	name = "emergency shower"
+	},
+/turf/open/floor/iron/dark,
 /area/space)
 "niH" = (
 /obj/machinery/iv_drip,
@@ -24858,10 +25141,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security)
-"njy" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/engine/plasma,
-/area/space)
 "njB" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -30
@@ -24882,6 +25161,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
+"nkJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "nkQ" = (
 /obj/machinery/flasher/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -24968,9 +25252,12 @@
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
 "nnY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
 /area/space)
 "noe" = (
 /obj/machinery/modular_computer/console/preset/research{
@@ -24985,18 +25272,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "nor" = (
-/obj/effect/turf_decal/tile/green{
-	color = "#00FFFF";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "noy" = (
 /obj/structure/table/reinforced,
@@ -25140,12 +25423,12 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "nrR" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/space)
 "nsb" = (
 /obj/effect/turf_decal/tile/brown{
@@ -25155,13 +25438,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "nsk" = (
-/obj/effect/turf_decal/siding/yellow{
+/obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
-	name = "engineering yellow"
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
+"nsw" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "nsG" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -25267,14 +25554,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
-"nvB" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Mixing Chamber";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/engine/plasma,
-/area/space)
 "nwa" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -25361,6 +25640,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"nxR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "nxX" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -25489,11 +25772,17 @@
 /turf/closed/wall,
 /area/security/checkpoint/medical)
 "nzC" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/obj/structure/closet/secure_closet/atmospherics,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/space)
 "nzG" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -25551,16 +25840,13 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "nBb" = (
-/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 1;
+	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/pipedispenser/disposal,
 /turf/open/floor/iron,
 /area/space)
 "nBB" = (
@@ -25579,10 +25865,11 @@
 /turf/open/floor/iron/white/textured_large,
 /area/medical/medbay/lobby)
 "nBR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
 "nCb" = (
@@ -25651,10 +25938,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
-"nDB" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "nDP" = (
 /turf/closed/wall/r_wall,
 /area/service/library)
@@ -25686,9 +25969,13 @@
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "nEs" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/space)
 "nFs" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
@@ -25700,11 +25987,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"nFv" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/turf/open/floor/iron,
-/area/space)
 "nFz" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -25850,6 +26132,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"nKW" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "nLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25878,21 +26164,11 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "nMJ" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/door/window/brigdoor/eastright{
-	name = "Canister Racks";
-	req_one_access_txt = "24"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/side,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/space)
 "nNe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -26033,10 +26309,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "nQV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "nRi" = (
@@ -26410,6 +26686,15 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"obq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Quarter Solar Access";
+	req_access_txt = "10"
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/fore)
 "obv" = (
 /obj/machinery/button/door/directional/east{
 	id = "mechbay";
@@ -26435,15 +26720,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/range)
 "odv" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow/half{
-	color = "#FFD700";
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
 /area/space)
 "odE" = (
 /obj/machinery/computer/secure_data{
@@ -26521,21 +26799,18 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "oeH" = (
-/obj/machinery/airalarm/directional/east{
-	frequency = 1459;
-	name = "Incinerator Chamber Air control"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/space)
+"oeL" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "ofj" = (
 /obj/effect/landmark/event_spawn,
 /obj/item/beacon,
@@ -26592,10 +26867,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ogg" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
 /area/space)
 "ogr" = (
 /obj/machinery/door/airlock/mining{
@@ -26605,6 +26882,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
 "ogJ" = (
@@ -26658,6 +26936,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"oiI" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "oiT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26728,12 +27010,8 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "okH" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
 /area/space)
 "oli" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26758,8 +27036,13 @@
 /turf/open/floor/wood,
 /area/service/library)
 "omE" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 10;
+	name = "engineering yellow"
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron,
 /area/space)
 "omJ" = (
 /obj/effect/turf_decal/stripes/line,
@@ -26811,9 +27094,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "onM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/turf/open/floor/plating,
 /area/space)
 "onO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26890,6 +27173,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"opi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "opB" = (
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/purple/half{
@@ -26930,16 +27220,12 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tcomms)
 "oqB" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/structure/sign/warning/radiation,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/space)
 "oqC" = (
 /obj/effect/turf_decal/siding/wood{
@@ -26947,6 +27233,10 @@
 	},
 /turf/open/floor/carpet,
 /area/security/courtroom)
+"oqH" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "oqL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -26999,7 +27289,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ori" = (
 /obj/structure/sign/warning/docking{
 	pixel_x = 30
@@ -27082,16 +27372,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ovP" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/engine/atmos)
 "owe" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
 /area/space)
 "owp" = (
 /obj/structure/cable,
@@ -27307,14 +27597,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "oBo" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 6;
 	name = "engineering yellow"
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "oBA" = (
@@ -27451,17 +27739,16 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "oCX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/door/window/brigdoor/westright{
+	name = "Atmospherics Monitoring";
+	req_one_access_txt = "24"
 	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255;
-	color = "#000000"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "oDa" = (
 /obj/structure/plasticflaps,
@@ -27508,14 +27795,13 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "oEp" = (
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/yellow/anticorner{
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 1
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
 /area/space)
 "oEr" = (
 /obj/structure/sign/poster/official/random{
@@ -27539,14 +27825,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oFg" = (
-/obj/effect/turf_decal/siding/yellow{
+/obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/machinery/space_heater,
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "oFh" = (
 /obj/structure/chair{
 	dir = 8
@@ -27616,8 +27901,13 @@
 	},
 /area/holodeck/rec_center)
 "oGl" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/smooth_large,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
 /area/space)
 "oGq" = (
 /obj/machinery/light/directional/north,
@@ -27673,15 +27963,13 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "oHM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output,
-/turf/open/floor/engine/vacuum,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
 /area/space)
 "oHR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "CO2 Outlet"
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -27692,10 +27980,12 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
 "oIc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 1
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/machinery/meter,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "oIe" = (
@@ -27705,7 +27995,25 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "oIK" = (
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics SE";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+	},
+/turf/open/floor/iron,
 /area/space)
 "oJf" = (
 /obj/effect/mapping_helpers/dead_body_placer,
@@ -27799,6 +28107,15 @@
 /obj/machinery/computer/station_alert,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"oKZ" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Mix 2 Input"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "oLb" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -27830,10 +28147,11 @@
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
 "oLE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "oLP" = (
@@ -27919,6 +28237,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"oPM" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "oQv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -27941,24 +28263,24 @@
 /area/hallway/secondary/exit/departure_lounge)
 "oQM" = (
 /obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 20;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/sheet/rglass{
-	amount = 20;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/sheet/iron/fifty,
-/obj/effect/turf_decal/tile/yellow/anticorner{
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 4
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/space)
 "oQQ" = (
 /obj/structure/cable,
@@ -27972,14 +28294,8 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "oRd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF6700"
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Mix 2 to Turbine"
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -28002,16 +28318,24 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "oRt" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Turbine Outlet"
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
 /area/space)
 "oRE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28081,12 +28405,15 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "oSZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
+/obj/effect/turf_decal/siding/yellow/corner{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/space)
 "oTf" = (
 /obj/structure/table/reinforced,
@@ -28109,6 +28436,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "oTy" = (
@@ -28119,6 +28447,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"oUa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "oUA" = (
 /obj/structure/closet/crate/grave,
 /obj/structure/sign/poster/official/ian{
@@ -28221,8 +28557,26 @@
 	},
 /area/science/research)
 "oWV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/table,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/analyzer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "oXh" = (
@@ -28327,9 +28681,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"pas" = (
-/turf/open/floor/engine/o2,
-/area/space)
 "pat" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28339,12 +28690,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
 "paz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/structure/table,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/space)
 "paN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28377,12 +28731,9 @@
 "pbR" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
+/obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
 /area/space)
 "pci" = (
@@ -28419,10 +28770,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "pcU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 6;
+	name = "engineering yellow"
 	},
-/turf/closed/wall/r_wall,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/iron,
 /area/space)
 "pdl" = (
 /turf/open/floor/carpet,
@@ -28437,9 +28793,10 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "peF" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space,
+/area/space/nearstation)
 "peK" = (
 /obj/structure/bookcase,
 /turf/open/floor/wood,
@@ -28540,12 +28897,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "pgB" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/turf/open/floor/iron/solarpanel/airless,
+/area/maintenance/solars/port/fore)
 "pgE" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Hydroponics";
@@ -28708,11 +29063,10 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "plJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/maintenance/solars/port/fore)
 "plN" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -28750,16 +29104,6 @@
 	dir = 8
 	},
 /area/science/research)
-"pmG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "pmM" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/smooth,
@@ -28781,6 +29125,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"pnB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "pnG" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/siding/purple{
@@ -28823,15 +29173,13 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "poI" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "foreport";
+	name = "Fore-Port Solar Array"
 	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/iron/solarpanel/airless,
+/area/maintenance/solars/port/fore)
 "poP" = (
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 4
@@ -28883,25 +29231,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"psV" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
 "ptd" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/table/glass,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"ptg" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "ptn" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/red/line,
@@ -28957,25 +29297,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "puH" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Mix 1 Output"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
-"puL" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/maintenance/solars/port/fore)
 "puP" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
@@ -28996,9 +29320,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "pwZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "pxf" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -29045,17 +29369,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "pyH" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/solars/port/fore)
 "pyY" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -29085,21 +29401,11 @@
 	},
 /area/service/chapel)
 "pzQ" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - Testing Room N";
-	name = "atmospherics camera"
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF"
 	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "pAF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29148,13 +29454,8 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "pBp" = (
-/obj/machinery/power/turbine{
-	dir = 4;
-	luminosity = 2
-	},
-/obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/space)
+/area/engineering/atmos)
 "pBD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29267,14 +29568,21 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pFM" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+"pFJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/main)
+"pFM" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "pFS" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -29308,28 +29616,17 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "pGA" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/light/directional/west,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "pGC" = (
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pGF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "pGR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29340,12 +29637,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"pHa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "pIx" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
+"pJd" = (
+/obj/structure/cable,
+/obj/machinery/igniter/incinerator_atmos,
+/obj/machinery/air_sensor/atmos/incinerator_tank{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "pJe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29388,7 +29699,12 @@
 /turf/open/floor/iron/smooth,
 /area/security/warden)
 "pKC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "pKO" = (
@@ -29433,10 +29749,8 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "pLD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "pLN" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -29452,6 +29766,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"pLY" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics HFR Room";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "pMp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -29463,9 +29785,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "pMI" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/space)
 "pMJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29554,12 +29877,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "pPx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Mix 2 to Filter"
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/space)
 "pPR" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -29589,11 +29910,9 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "pPW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "pPY" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -29630,40 +29949,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "pRq" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "pRt" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/camera/directional/east{
-	c_tag = "Atmospherics East";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
-	},
-/obj/structure/fireaxecabinet/directional/east,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "pRG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29678,15 +29969,19 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "pRL" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "pRO" = (
 /turf/open/floor/iron,
 /area/engineering/storage)
 "pRX" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/air,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "pSe" = (
 /obj/structure/disposalpipe/segment,
@@ -29857,8 +30152,16 @@
 /turf/closed/wall,
 /area/cargo/qm)
 "pYk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -29889,14 +30192,6 @@
 "pYM" = (
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"pYW" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron,
-/area/space)
 "pYZ" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -29986,6 +30281,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "qdm" = (
@@ -29999,12 +30295,9 @@
 /turf/open/floor/iron/recharge_floor,
 /area/science/robotics/mechbay)
 "qdF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/maintenance/solars/port/fore)
 "qdJ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
@@ -30077,12 +30370,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "qfQ" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A handy sign praising the engineering department.";
-	icon_state = "safety";
-	name = "engineering plaque"
-	},
-/turf/closed/wall/r_wall,
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "qgi" = (
 /obj/structure/table/glass,
@@ -30096,21 +30385,13 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "qgk" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "qgo" = (
 /obj/structure/table,
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101,
@@ -30197,9 +30478,12 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "qic" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "qid" = (
 /obj/structure/cable,
 /obj/item/kirbyplants{
@@ -30254,21 +30538,14 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "qkI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Plasma Outlet"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
 "qkK" = (
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
-	dir = 4;
-	name = "Mix to Port 1"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/portable_atmospherics/canister/tier_3,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "qkQ" = (
 /obj/item/toy/figure/geneticist,
 /turf/open/floor/grass,
@@ -30306,12 +30583,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qlZ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance";
-	req_one_access_txt = "10; 24"
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
 	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "qmj" = (
 /turf/closed/wall/r_wall,
 /area/security/processing)
@@ -30372,17 +30650,9 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "qnG" = (
-/obj/machinery/power/compressor{
-	comp_id = "incineratorturbine";
-	dir = 8;
-	luminosity = 2
-	},
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum{
-	pixel_y = -32
-	},
-/turf/open/floor/engine/vacuum,
-/area/space)
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "qnZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30429,6 +30699,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+"qpH" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics HFR Room";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "qpI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -30534,8 +30814,12 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "qtY" = (
-/obj/effect/turf_decal/arrows/white,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/turf/open/floor/iron/smooth_large,
 /area/space)
 "qum" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30545,11 +30829,13 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "qus" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
 	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "quQ" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/airalarm/directional/north,
@@ -30572,10 +30858,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qvn" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "qwq" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/central)
@@ -30605,6 +30890,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"qxz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "qxH" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
@@ -30746,11 +31038,13 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "qCa" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
 	},
-/turf/closed/wall/r_wall,
-/area/space)
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "qCy" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
@@ -30869,6 +31163,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison)
+"qEC" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/project)
 "qET" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -30886,26 +31183,25 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "qFL" = (
+/obj/effect/turf_decal/tile/green/anticorner{
+	color = "#00FFFF"
+	},
+/turf/open/floor/iron/smooth_large,
+/area/space)
+"qFN" = (
+/obj/structure/closet/radiation,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
-	dir = 1;
+	dir = 4;
 	name = "engineering yellow"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
-"qFN" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/space)
 "qFQ" = (
 /obj/structure/rack,
@@ -30971,10 +31267,15 @@
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
 "qGL" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/space)
 "qGP" = (
 /obj/effect/turf_decal/tile/blue,
@@ -31080,18 +31381,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"qID" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Waste In"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"qIC" = (
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
+"qID" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "qIF" = (
 /obj/machinery/button/door/directional/north{
 	id = "roboticsshut";
@@ -31165,11 +31462,9 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "qJf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "qJQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -31183,6 +31478,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/security/processing)
+"qKS" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "qLd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -31366,9 +31670,17 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "qQI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
+/obj/effect/turf_decal/tile/green{
+	color = "#00FFFF";
+	dir = 1
 	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "qQM" = (
@@ -31468,6 +31780,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage)
+"qVh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "qWk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -31478,11 +31797,12 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "qWC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
+/obj/machinery/air_sensor/atmos/mix_tank{
+	id_tag = "mix_sensor2";
+	name = "mix 2 tank gas sensor"
 	},
-/turf/closed/wall/r_wall,
-/area/space)
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "qWM" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -31526,12 +31846,9 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
 "qXI" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
-/area/space)
+/area/engineering/atmos)
 "qXL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -31627,27 +31944,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/lawoffice)
-"rav" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics Engine";
-	req_access_txt = "24"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+"rad" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron,
-/area/space)
+/area/maintenance/department/electrical)
+"rav" = (
+/obj/machinery/air_sensor/atmos/mix_tank{
+	name = "mix 1 tank gas sensor"
+	},
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "raA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31688,15 +31994,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"rcg" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
 "rcC" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -31796,9 +32093,9 @@
 	},
 /area/engineering/gravity_generator)
 "rfm" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "rfr" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
@@ -31846,11 +32143,9 @@
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
 "rgW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "rhf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31858,9 +32153,9 @@
 /turf/open/floor/carpet/green,
 /area/service/library/private)
 "rho" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "rhq" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -31878,9 +32173,9 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "rhY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/plasma_output,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "rim" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -31999,6 +32294,14 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"rms" = (
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK"
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/fore)
 "rmz" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -32084,11 +32387,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "roC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/air_sensor/atmos/plasma_tank,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "roU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32168,9 +32469,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "rrd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/plasma_input,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "rre" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser/practice{
@@ -32215,8 +32516,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "rrL" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -32296,6 +32597,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ruZ" = (
@@ -32402,6 +32704,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"rxG" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "ryi" = (
 /obj/structure/rack,
 /obj/structure/window{
@@ -32412,10 +32726,16 @@
 /obj/item/storage/box/teargas,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"ryF" = (
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "ryQ" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_one_access_txt = "10; 24"
+	},
+/turf/open/floor/plating,
+/area/space)
 "ryT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -32526,6 +32846,11 @@
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"rBG" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rBJ" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/grass,
@@ -32549,14 +32874,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "rCq" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "rCr" = (
 /obj/structure/chair/comfy/brown{
 	color = "#EFB341";
@@ -32568,14 +32888,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
-"rCu" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Mixing Chamber";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/engine/n2,
-/area/space)
 "rCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32607,7 +32919,7 @@
 "rDl" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/engine/atmos)
 "rDz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32720,12 +33032,9 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "rFL" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "rFR" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4169E1";
@@ -32760,12 +33069,9 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "rGo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "rGG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32773,12 +33079,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rGQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "rGX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -32809,17 +33112,19 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "rHq" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
+	dir = 8;
 	name = "engineering yellow"
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "rIe" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -32909,13 +33214,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"rJH" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "rJM" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -32927,13 +33225,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"rJO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/turf/closed/wall/r_wall,
-/area/space)
 "rKg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -32950,6 +33241,14 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/checkpoint)
+"rKj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "rKn" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
@@ -32966,10 +33265,6 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"rKr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output,
-/turf/open/floor/engine/air,
-/area/space)
 "rKx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33233,10 +33528,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rSA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 5
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
 "rSC" = (
@@ -33304,6 +33602,10 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"rTt" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/storage)
 "rTu" = (
 /turf/open/floor/iron/dark/corner,
 /area/command/gateway)
@@ -33361,8 +33663,10 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "rUF" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
-/turf/open/floor/engine/air,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/space)
 "rUI" = (
 /turf/open/floor/iron,
@@ -33385,10 +33689,9 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "rVo" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "rVr" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -33485,7 +33788,14 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "rXh" = (
-/obj/effect/landmark/event_spawn,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
+	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "rXm" = (
@@ -33688,11 +33998,16 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "sbh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 10;
+	name = "engineering yellow"
 	},
-/turf/open/space/basic,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/space)
 "sbo" = (
 /obj/structure/holohoop{
@@ -33701,34 +34016,36 @@
 /turf/open/floor/wood,
 /area/security/prison/workout)
 "sbs" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine/n2,
-/area/space)
-"sbW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
-"scd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/space)
+"sbw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
+"sbW" = (
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/space)
+"scd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "scV" = (
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33837,15 +34154,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
 "seZ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Engineering Escape Pod";
-	req_access_txt = "32"
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"sfa" = (
+/turf/closed/wall,
+/area/maintenance/department/engine/atmos)
 "sfp" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -33862,10 +34177,10 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "sgj" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/dark/smooth_large,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sgq" = (
 /obj/item/trash/popcorn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33888,11 +34203,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "sgQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "sgR" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -33900,23 +34212,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "shd" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/status_display/evac/directional/west,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix 2 to Distro"
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Air Distribution";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "shp" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/plasticflaps,
@@ -33974,8 +34271,8 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "siA" = (
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
+/turf/open/floor/iron,
 /area/space)
 "siV" = (
 /obj/machinery/door/poddoor/shutters{
@@ -34102,10 +34399,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"sne" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "snr" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
@@ -34216,9 +34509,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "soN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "soV" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700";
@@ -34408,28 +34701,25 @@
 /turf/open/floor/iron/white,
 /area/security)
 "stj" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input,
-/turf/open/floor/engine/co2,
-/area/space)
-"stL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF6700"
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/space)
-"suB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
-	dir = 8
+"stL" = (
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
 	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/space)
+"suB" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "suG" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -34663,14 +34953,15 @@
 	},
 /area/security/range)
 "szr" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
+"szy" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "szz" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
@@ -34743,13 +35034,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "sCL" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#c45c57";
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sCW" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -34791,6 +35081,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"sEP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "sEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34868,6 +35162,15 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"sHA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/engineering/atmos/project)
 "sHZ" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34907,15 +35210,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "sKi" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow/half{
-	color = "#FFD700";
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/coffee,
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "sKs" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
@@ -34964,31 +35265,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "sMt" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste Release"
-	},
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 5;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "sMw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/structure/railing{
-	layer = 3.1;
-	pixel_y = -4
-	},
-/obj/structure/window/reinforced{
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "sMy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -35002,7 +35285,10 @@
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
 "sMF" = (
-/turf/open/floor/engine/vacuum,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/space)
 "sMG" = (
 /turf/open/floor/iron/dark,
@@ -35085,11 +35371,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sPT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "sQm" = (
 /obj/structure/table,
 /obj/item/holosign_creator/robot_seat/restaurant,
@@ -35104,16 +35389,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "sQz" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_one_access_txt = "10;24"
 	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "sQG" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/purple{
@@ -35191,20 +35475,15 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "sSv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
-/obj/structure/railing{
-	layer = 3.1;
-	pixel_y = -4
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_one_access_txt = "10;24"
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -5
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "sSB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35285,18 +35564,13 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/trash/soap,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/engine/atmos)
 "sUf" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "sUm" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -35640,8 +35914,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "tdY" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine/co2,
+/turf/open/floor/iron,
 /area/space)
 "tej" = (
 /obj/structure/disposalpipe/segment,
@@ -35745,6 +36018,10 @@
 /obj/item/paicard,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
+"thU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "til" = (
 /mob/living/carbon/human/species/monkey/punpun,
 /obj/structure/cable,
@@ -35843,15 +36120,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tjI" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/space/basic,
+/area/maintenance/solars/port/fore)
 "tjS" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -35866,12 +36138,19 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tkh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/structure/tank_dispenser/oxygen{
+	pixel_x = -1;
+	pixel_y = 2
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
+"tkj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "tkk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -35966,6 +36245,12 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"tmY" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "tmZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -36061,8 +36346,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "tqI" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/space)
 "tqJ" = (
 /obj/effect/turf_decal/bot_white/left,
@@ -36090,6 +36382,20 @@
 	dir = 1
 	},
 /area/medical/treatment_center)
+"trM" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/engineering/atmos/project)
 "trU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -36187,10 +36493,11 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "ttQ" = (
-/obj/machinery/atmospherics/components/unary/bluespace_sender,
-/obj/item/toy/figure/atmos,
-/turf/open/floor/iron/dark/smooth_large,
-/area/space)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "ttS" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -36243,13 +36550,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "tuJ" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "tuK" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/structure/sign/warning/pods{
@@ -36326,16 +36631,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "twb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall/r_wall,
 /area/space)
 "twy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36350,20 +36647,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "txl" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
-	},
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 1;
-	name = "Mix 2 Input"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "txq" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -36399,6 +36688,7 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/science/storage)
 "tyb" = (
@@ -36638,22 +36928,8 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "tDj" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	name = "air mixer";
-	node1_concentration = 0.8;
-	node2_concentration = 0.2;
-	on = 1;
-	target_pressure = 4500
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
-"tDB" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF";
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/hfr_room)
 "tDH" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -36677,9 +36953,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "tDN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/structure/railing{
+	dir = 1;
+	layer = 3.1;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/space)
 "tDP" = (
@@ -36748,9 +37038,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "tEZ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/hfr_room)
 "tFb" = (
 /obj/structure/reagent_dispensers/wall/peppertank{
 	pixel_y = 32
@@ -36768,6 +37058,15 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"tFZ" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos/storage)
 "tGh" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -36789,9 +37088,11 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
 "tGW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "tHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -36808,14 +37109,9 @@
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "tHX" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "tIl" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -36871,12 +37167,16 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "tJQ" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
-/area/space/nearstation)
+/area/space)
 "tKs" = (
 /obj/effect/turf_decal/bot_white{
 	color = "#606060"
@@ -36972,10 +37272,12 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "tNu" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/structure/window/reinforced,
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "tNI" = (
 /turf/closed/wall,
@@ -37032,13 +37334,9 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "tPx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "tPE" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
@@ -37066,15 +37364,12 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "tQu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/tile/green/anticorner{
+	color = "#00FFFF";
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "tQB" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
@@ -37132,15 +37427,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"tRH" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 10;
-	name = "engineering yellow"
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
-/area/space)
 "tRJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -37173,22 +37459,9 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "tRS" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics West";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/engine_smes)
 "tSa" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -37245,16 +37518,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"tTm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "tTw" = (
-/obj/item/lightreplacer,
-/obj/item/lightreplacer,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "tTy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37297,8 +37568,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "tUf" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/engine/n2o,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/turf/open/floor/iron,
 /area/space)
 "tUj" = (
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -37332,12 +37607,12 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "tUR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	name = "engineering yellow"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/turf/open/floor/iron,
 /area/space)
 "tUT" = (
 /obj/machinery/telecomms/bus/preset_four,
@@ -37365,14 +37640,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
-"tVL" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron,
-/area/space)
 "tVU" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37383,11 +37650,15 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"tWu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+"tVW" = (
 /turf/open/floor/iron,
-/area/space)
+/area/maintenance/department/electrical)
+"tWu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "tWA" = (
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
@@ -37412,14 +37683,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tWV" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "tXd" = (
 /obj/machinery/door/airlock/mining{
 	name = "Quartermaster Office";
@@ -37432,6 +37700,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "tXp" = (
@@ -37474,6 +37743,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
+"tXz" = (
+/obj/structure/cable,
+/obj/machinery/power/smes,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "tXA" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#73c2fb";
@@ -37503,69 +37780,29 @@
 /turf/open/floor/carpet/royalblack,
 /area/engineering/lobby)
 "tYq" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1;
-	pixel_y = 4
-	},
-/obj/structure/railing{
-	dir = 4;
-	layer = 3.1;
-	pixel_x = 3
-	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF";
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/item/storage/belt/utility/atmostech,
-/obj/item/storage/belt/utility/atmostech,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/obj/item/t_scanner,
-/turf/open/floor/iron,
-/area/space)
-"tYA" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"tYA" = (
+/obj/machinery/light/directional/north,
+/obj/structure/sign/poster/official/build{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "tYF" = (
 /turf/closed/wall/r_wall,
 /area/security/lockers)
 "tZj" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics - Testing Room W";
-	name = "atmospherics camera"
-	},
-/obj/machinery/status_display/evac/directional/west,
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/obj/effect/turf_decal/arrows/white,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "tZt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
 /area/space)
 "tZG" = (
 /obj/machinery/vending/coffee,
@@ -37754,11 +37991,13 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "ucB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 8
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics - HFR Main Room";
+	name = "atmospherics camera"
 	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "ucK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -37940,20 +38179,22 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "uhe" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/iron/smooth_large,
-/area/space)
-"uhf" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
+"uhf" = (
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "uhg" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
+"uhh" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uhs" = (
 /obj/structure/table,
 /obj/item/mop,
@@ -38093,6 +38334,11 @@
 "ukl" = (
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"ukm" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "ukz" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage";
@@ -38101,6 +38347,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "ukA" = (
@@ -38110,15 +38357,9 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "ukN" = (
-/obj/machinery/computer/turbine_computer{
-	id = "incineratorturbine"
-	},
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "ukP" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 10
@@ -38274,8 +38515,11 @@
 /turf/open/floor/iron/dark/side,
 /area/security/range)
 "unY" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/space/basic,
 /area/space)
 "uob" = (
 /obj/machinery/camera/directional/north{
@@ -38377,8 +38621,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "upD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -38401,9 +38644,11 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
 "upV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
+	dir = 4
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "upX" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -38417,24 +38662,9 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "uqa" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Canister Racks";
-	req_one_access_txt = "24"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/space)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "uqs" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -38448,8 +38678,10 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
 "uqD" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine/o2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/space)
 "uqH" = (
 /obj/structure/cable,
@@ -38466,9 +38698,18 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ura" = (
-/obj/structure/tank_dispenser/plasma,
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "External Solar Access";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/maintenance/solars/port/fore)
 "urb" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -38507,12 +38748,11 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "urg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
+/obj/effect/turf_decal/arrows/white{
+	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "urm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38677,6 +38917,7 @@
 /area/commons/dorms)
 "uuQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "uuR" = (
@@ -38829,16 +39070,21 @@
 	dir = 4
 	},
 /area/engineering/gravity_generator)
+"uyj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "uyA" = (
 /obj/structure/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uyW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
 	},
-/turf/closed/wall/r_wall,
-/area/space)
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "uzd" = (
 /obj/item/storage/briefcase/lawyer,
 /obj/structure/rack,
@@ -39015,6 +39261,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"uDN" = (
+/turf/open/floor/plating,
+/area/engineering/atmos/project)
 "uDV" = (
 /obj/structure/rack,
 /obj/item/bouquet,
@@ -39142,12 +39391,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"uGv" = (
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
 "uGJ" = (
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 1
@@ -39170,12 +39413,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"uHe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/space)
 "uHf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -39251,13 +39488,20 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "uIl" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "engineering yellow"
 	},
-/turf/open/floor/iron,
-/area/space/nearstation)
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics - Testing Room W";
+	name = "atmospherics camera"
+	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "uIo" = (
 /obj/item/radio/intercom/prison/directional/east,
 /obj/effect/turf_decal/siding/brown{
@@ -39329,18 +39573,15 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "uKl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/green/corner{
-	color = "#00FFFF";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/iron/dark,
-/area/space)
-"uKs" = (
-/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
+"uKs" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "uKW" = (
 /obj/item/toy/cards/deck{
 	pixel_x = -8;
@@ -39465,18 +39706,12 @@
 	},
 /area/command/gateway)
 "uNt" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_x = -15
 	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "uNv" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 7
@@ -39522,11 +39757,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uNY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "uOb" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -39651,6 +39884,13 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet/red,
 /area/service/lawoffice)
+"uQH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "uQO" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/warning,
@@ -39664,9 +39904,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "uRi" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "uRm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Prosecution Maintenance";
@@ -39748,20 +39988,10 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
 "uSs" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 5;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Mix 1 Input"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/storage/tcomms)
 "uSv" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -39878,14 +40108,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"uVu" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron,
-/area/space/nearstation)
 "uVI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
@@ -39919,9 +40141,9 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "uWd" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 8;
-	name = "plasma mixer"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -40188,6 +40410,8 @@
 /area/maintenance/starboard)
 "vdi" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "vdo" = (
@@ -40223,11 +40447,12 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "vdF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
 	},
-/turf/open/floor/engine/vacuum,
-/area/space/nearstation)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "vdG" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -40358,6 +40583,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
+"vhi" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "vho" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
@@ -40378,6 +40613,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"vhS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "vhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40469,15 +40710,12 @@
 /turf/open/floor/carpet/green,
 /area/service/library/private)
 "viF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "viJ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
@@ -40504,14 +40742,17 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "vjg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/space)
+"vji" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "vjo" = (
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
@@ -40543,16 +40784,12 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "vkz" = (
-/obj/machinery/atmospherics/components/binary/pump/off/general/visible{
-	dir = 4;
-	name = "Mix to Port 2"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	color = "#00FFFF"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "vkH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40634,15 +40871,14 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "vnK" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Incinerator Output Pump";
+	target_pressure = 4500
 	},
-/obj/machinery/door/airlock/external{
-	name = "Engineering Escape Pod";
-	req_access_txt = "32"
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/turf/open/space,
+/area/maintenance/disposal/incinerator)
 "vnV" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
@@ -40684,12 +40920,12 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "vpX" = (
-/obj/effect/turf_decal/siding/yellow/corner{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/maintenance/disposal/incinerator)
 "vpZ" = (
 /turf/closed/wall,
 /area/security/prison/safe)
@@ -40926,11 +41162,11 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "vuB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/maintenance/solars/port/fore)
 "vuF" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table,
@@ -41018,7 +41254,7 @@
 /obj/effect/spawner/random/trash/box,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/engine/atmos)
 "vvV" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 8
@@ -41220,12 +41456,12 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "vAt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engineering/atmos/hfr_room)
 "vAC" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -41241,6 +41477,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"vAK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "vAT" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
@@ -41300,10 +41543,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "vCh" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating,
+/area/engineering/atmos/hfr_room)
 "vCk" = (
 /mob/living/simple_animal/mouse/brown/tom,
 /obj/machinery/duct,
@@ -41313,11 +41556,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "vCG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "vDj" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41379,12 +41621,13 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "vEN" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	color = "#FFD700";
-	dir = 1
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "vFn" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41422,24 +41665,6 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
-"vHs" = (
-/obj/structure/rack,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 6;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
 "vHz" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -41481,9 +41706,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vIl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space/nearstation)
 "vIp" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
@@ -41498,6 +41724,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vIy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"vIW" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "vJe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -41520,9 +41754,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "vJE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "vJH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -41604,6 +41838,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"vLx" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 4;
+	name = "Turbine Outlet"
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "vLz" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -41660,25 +41901,11 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "vMc" = (
-/obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
+	dir = 4
 	},
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "vMB" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/light/directional/south,
@@ -41687,16 +41914,6 @@
 "vME" = (
 /turf/open/floor/iron,
 /area/engineering/main)
-"vMH" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/turf/open/floor/iron,
-/area/space)
 "vMM" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -41723,8 +41940,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vNt" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/n2o,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Mix"
+	},
+/turf/open/floor/iron,
 /area/space)
 "vNO" = (
 /obj/structure/table/wood,
@@ -42035,13 +42260,11 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "vVv" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "vVw" = (
 /obj/structure/table,
 /obj/item/taperecorder,
@@ -42160,8 +42383,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "vYz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output,
-/turf/open/floor/engine/o2,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Filter"
+	},
+/turf/open/floor/iron,
 /area/space)
 "vYD" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
@@ -42188,24 +42414,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "vZg" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
-/obj/machinery/navbeacon/wayfinding/atmos,
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "vZh" = (
 /obj/structure/table,
 /turf/open/floor/iron/dark,
@@ -42277,21 +42491,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vZV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
-/obj/machinery/meter,
-/obj/structure/railing{
-	layer = 3.1;
-	pixel_y = -4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
 	},
-/obj/structure/window/reinforced{
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/tile/green/half{
-	color = "#00FFFF"
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "wan" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42482,16 +42688,8 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "wdY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/engineering/main)
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "weo" = (
 /obj/item/storage/toolbox/emergency{
 	pixel_y = -4
@@ -42586,13 +42784,12 @@
 /turf/open/floor/iron/smooth,
 /area/security/warden)
 "wgb" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "wgl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -42704,11 +42901,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "wkn" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "wkC" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood,
@@ -42785,14 +42981,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "wnd" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 6;
-	name = "engineering yellow"
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "wnr" = (
 /obj/structure/rack,
 /obj/item/book/random,
@@ -43034,6 +43225,10 @@
 	dir = 1
 	},
 /area/medical/treatment_center)
+"wuy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "wuF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -43051,6 +43246,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
+"wvb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "wvn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43138,8 +43340,8 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "wwi" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
 /area/space)
 "wwq" = (
 /obj/structure/closet/crate,
@@ -43390,6 +43592,13 @@
 /obj/effect/spawner/random/contraband/narcotics,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wAF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "wAG" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon/wayfinding/med,
@@ -43491,11 +43700,20 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "wCf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "External Solar Access";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/maintenance/solars/port/fore)
 "wCg" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Lab";
@@ -43509,9 +43727,10 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "wCk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/space)
 "wCu" = (
 /obj/item/trash/boritos,
@@ -43540,12 +43759,12 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "wCC" = (
-/obj/machinery/button/door/atmos_test_room_mainvent_2,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "wCD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43650,16 +43869,8 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "wEG" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/fore)
 "wEK" = (
 /turf/closed/wall,
 /area/engineering/lobby)
@@ -43693,16 +43904,10 @@
 /turf/open/floor/carpet/purple,
 /area/command/heads_quarters/rd)
 "wFD" = (
-/obj/machinery/meter,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "wFQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43727,6 +43932,7 @@
 	name = "Cargo Bay";
 	req_one_access_txt = "31;48"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
 "wGV" = (
@@ -43748,9 +43954,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wHc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron,
 /area/space)
 "wHo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -43830,23 +44035,20 @@
 /turf/open/floor/carpet,
 /area/security/courtroom)
 "wJs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/space)
 "wJw" = (
 /obj/structure/closet/secure_closet/courtroom,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "wJB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "wJD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -43938,11 +44140,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
 "wLt" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Mix 2 to Turbine"
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "wLG" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -43991,12 +44191,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "wMn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
-	dir = 4
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 10;
+	name = "engineering yellow"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/space)
 "wMr" = (
 /obj/structure/cable,
@@ -44093,13 +44296,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wPQ" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "wPW" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/stripes/line,
@@ -44126,17 +44325,8 @@
 /area/command/heads_quarters/rd)
 "wQU" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/iron,
+/area/engineering/storage/tcomms)
 "wQW" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
@@ -44264,13 +44454,10 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "wTA" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/structure/reagent_dispensers/fueltank/large,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "wTD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -44452,11 +44639,10 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "wYZ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 10
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Mix 1 to Filter"
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/space)
 "wZb" = (
 /obj/effect/turf_decal/tile/purple{
@@ -44489,12 +44675,12 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wZt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
+/obj/machinery/computer/turbine_computer{
+	dir = 4;
+	id = "incineratorturbine"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "wZJ" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "AI Core - North Outer";
@@ -44536,9 +44722,22 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "xbA" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+/obj/structure/railing{
+	dir = 1;
+	layer = 3.1;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/green/half{
+	color = "#00FFFF";
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/space)
 "xcu" = (
@@ -44597,9 +44796,23 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "xdu" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "engineering yellow"
+	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
+/area/space)
 "xdH" = (
 /obj/structure/chair{
 	dir = 8
@@ -44613,10 +44826,10 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "xed" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "xev" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -44653,15 +44866,9 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "xeV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "xeW" = (
 /obj/machinery/light/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -44751,26 +44958,14 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "xgX" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics SE";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "xhu" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/morgue)
@@ -44897,15 +45092,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "xkV" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "engineering yellow"
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006
 	},
-/obj/machinery/pipedispenser/disposal,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "xll" = (
 /obj/structure/table,
 /obj/item/flashlight/lantern,
@@ -45015,24 +45207,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "xoQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 9;
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/tank/plasma{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "xpe" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
-	},
-/turf/open/floor/engine/vacuum,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/space)
 "xpO" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -45116,20 +45298,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "xsj" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "xst" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -45162,8 +45336,9 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "xuv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "xuE" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -45199,6 +45374,10 @@
 "xuK" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/workout)
+"xuL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "xvl" = (
 /turf/open/floor/plastic,
 /area/command/heads_quarters/captain/private)
@@ -45243,18 +45422,8 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "xwb" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
-	},
-/obj/machinery/computer/atmos_control/tank/mix_tank{
-	name = "Gas Mix 1 Tank Control"
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
 /area/space)
 "xwr" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -45320,23 +45489,27 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xxU" = (
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/space)
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "xxV" = (
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
+/obj/structure/cable,
+/obj/machinery/power/solar_control{
+	id = "foreport";
+	name = "Port Bow Solar Control"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Solar - Fore Port";
+	name = "solar camera"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "xyl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/open/floor/iron/dark,
@@ -45346,17 +45519,14 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "xyv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/full{
-	color = "#4169E1";
-	name = "Command blue full"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/space)
 "xyU" = (
 /turf/open/floor/iron,
@@ -45366,11 +45536,8 @@
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "xyZ" = (
-/obj/effect/turf_decal/tile/green/anticorner{
-	color = "#00FFFF"
-	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "xzq" = (
 /turf/closed/wall/r_wall,
 /area/command/meeting_room/council)
@@ -45404,16 +45571,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "xBh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
+/obj/machinery/atmospherics/components/binary/valve{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/space)
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "xBo" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/blue/half{
@@ -45493,23 +45655,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "xEP" = (
-/obj/structure/window/reinforced/plasma/spawner/east,
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics Gas Storage";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron/dark/smooth_large,
-/area/space)
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "xFv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -45521,27 +45671,10 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "xFT" = (
-/obj/machinery/button/door/incinerator_vent_atmos_aux{
-	pixel_x = -8;
-	pixel_y = 24
-	},
-/obj/machinery/button/door/incinerator_vent_atmos_main{
-	pixel_x = -8;
-	pixel_y = 36
-	},
-/obj/machinery/button/ignition/incinerator/atmos{
-	pixel_x = 8;
-	pixel_y = 36
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/green{
-	color = "#00FFFF";
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "xGd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -45577,13 +45710,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xGK" = (
-/obj/effect/turf_decal/siding/yellow{
+/obj/effect/turf_decal/tile/yellow/half{
 	color = "#FFD700";
-	dir = 9;
-	name = "engineering yellow"
+	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
-/area/maintenance/solars/port/fore)
+/area/space)
 "xGS" = (
 /obj/structure/altar_of_gods,
 /obj/item/storage/book/bible,
@@ -45647,16 +45779,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "xHD" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "engineering yellow"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/atmos/hfr_room)
 "xHU" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
@@ -45730,12 +45855,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "xJH" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics Mixing Chamber";
-	name = "Atmos Camera";
-	network = list("ss13","engineering","atmos")
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix 1 to Distro"
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/iron,
 /area/space)
 "xJQ" = (
 /turf/closed/wall,
@@ -45838,15 +45963,10 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xLW" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos/glass{
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine/vacuum,
-/area/space)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/hfr_room)
 "xMh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45872,6 +45992,9 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"xMB" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/office)
 "xNb" = (
 /turf/closed/wall,
 /area/cargo/miningdock)
@@ -45930,6 +46053,11 @@
 	},
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
+"xOc" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/project)
 "xOu" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -45951,11 +46079,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xOP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xOT" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -46078,13 +46204,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
 "xRT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	name = "Engineering Escape Pod";
+	req_access_txt = "32"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/main)
 "xSa" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Gateway Chamber";
@@ -46117,6 +46242,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"xSi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "xSk" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -46226,19 +46360,13 @@
 	},
 /area/command/heads_quarters/ce)
 "xUf" = (
-/obj/machinery/door/poddoor/atmos_test_room_mainvent_2,
-/turf/open/floor/engine/vacuum,
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
 /area/space)
 "xUk" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "Mix 1 Input"
-	},
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
-	},
-/turf/open/floor/iron/dark,
-/area/space)
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "xUA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -46280,6 +46408,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
+"xVx" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "xVC" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white/smooth_large,
@@ -46513,16 +46651,14 @@
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
 "yag" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
+/obj/effect/turf_decal/tile/purple/full{
+	color = "#4D0067"
 	},
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF6700"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "Mix 1 to Turbine"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/computer/atmos_control/tank/plasma_tank,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "yao" = (
@@ -46628,6 +46764,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"ycV" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Atmospherics Emergency Access";
+	req_one_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "ydp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -46656,7 +46799,14 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "yec" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/meter,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
 "yeO" = (
@@ -46683,24 +46833,16 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "yfg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "engineering yellow"
-	},
-/obj/effect/turf_decal/tile/blue/full{
-	color = "#4169E1";
-	name = "Command blue full"
-	},
-/turf/open/floor/iron,
-/area/space)
-"yfo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
 /area/space)
+"yfo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "yfA" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5
@@ -46801,6 +46943,10 @@
 "ygZ" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/safe)
+"yhd" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "yhf" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -46829,22 +46975,11 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "yhD" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/wtf_is_co2{
-	pixel_y = -32
-	},
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
+/obj/machinery/computer/atmos_control/incinerator{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "yhF" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -46972,13 +47107,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "ylh" = (
-/obj/effect/turf_decal/siding/yellow{
-	color = "#FFD700";
-	name = "engineering yellow"
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/disposal/incinerator)
 "yls" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -56411,11 +56545,11 @@ meC
 meC
 meC
 meC
+xOw
+xOw
 meC
-meC
-meC
-meC
-meC
+xOw
+xOw
 meC
 meC
 meC
@@ -56665,14 +56799,14 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+xOw
+xOw
+jiP
+oqH
+jiP
+xOw
 meC
 meC
 meC
@@ -56921,16 +57055,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+vVv
+xOw
+xOw
+wdY
+mRh
+wdY
+xOw
+xOw
 meC
 meC
 meC
@@ -57178,16 +57312,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+vdF
+vZg
+xOw
+wdY
+wdY
+axZ
+wdY
+wdY
+xOw
 meC
 meC
 meC
@@ -57435,16 +57569,16 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+viF
+xOw
+xOw
+xUk
+mIj
+pJd
+aMN
+wdY
+xOw
 meC
 meC
 meC
@@ -57692,17 +57826,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+viF
+xOw
+xOw
+wdY
+vji
+xVx
+wAF
+wdY
+xOw
+xOw
 meC
 meC
 meC
@@ -57949,18 +58083,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+vkz
+vZV
+wTA
+yfo
+rxG
+hXI
+fKG
+bzp
+opi
+xOw
+xOw
 meC
 meC
 meC
@@ -58190,6 +58324,13 @@ meC
 meC
 meC
 meC
+vIl
+bpu
+vIl
+bpu
+vIl
+vIl
+vIl
 meC
 meC
 meC
@@ -58199,25 +58340,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+viF
+wdY
+wdY
+wdY
+vji
+kqx
+wAF
+wdY
+oeL
+wdY
+xOw
 meC
 meC
 meC
@@ -58422,23 +58556,6 @@ meC
 meC
 meC
 meC
-dSP
-dSP
-dSP
-dSP
-dSP
-sbh
-gqE
-gqE
-gqE
-gqE
-gqE
-cxy
-uqa
-nMJ
-xEP
-gqE
-gqE
 meC
 meC
 meC
@@ -58460,21 +58577,38 @@ meC
 meC
 meC
 meC
+vIl
+vIl
+peF
+vIl
+vIl
+meC
+bpu
+meC
+bpu
+meC
+vIl
+vIl
+bpu
+vIl
+vIl
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+vnK
+wdY
+wZt
+yhD
+gGn
+xeV
+kyz
+vIW
+wuy
+wdY
+xOw
 meC
 meC
 meC
@@ -58679,23 +58813,6 @@ meC
 meC
 meC
 meC
-dSP
-sMF
-xJH
-oHM
-muo
-oSZ
-jIC
-xoQ
-bAr
-gIz
-shd
-hJA
-amG
-iXF
-iVZ
-tEZ
-vJE
 meC
 meC
 meC
@@ -58717,21 +58834,38 @@ meC
 meC
 meC
 meC
+vIl
+meC
+bpu
+meC
+bpu
+meC
+qdF
+poI
+plJ
+poI
+bpu
+meC
+bpu
+meC
+vIl
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+vpX
+wkn
+xed
+ylh
+vAK
+xeV
+kyz
+vIW
+wuy
+wdY
+xOw
 meC
 meC
 meC
@@ -58936,23 +59070,6 @@ meC
 meC
 meC
 meC
-dSP
-hdN
-fUt
-fKI
-unY
-sbh
-wZt
-fKX
-xed
-dEV
-cDo
-hrg
-oWV
-mkv
-imr
-cqx
-vJE
 meC
 meC
 meC
@@ -58974,19 +59091,36 @@ meC
 meC
 meC
 meC
+vIl
+meC
+xOw
+meC
+poI
+plJ
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
+meC
+bpu
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+wnd
+xeV
+pnB
+vIW
+vIW
+kyz
+vIW
+wuy
 ebr
 ebr
 ebr
@@ -59189,27 +59323,46 @@ meC
 meC
 meC
 meC
+bGs
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
 meC
 meC
 meC
 meC
-dSP
-sMF
-sMF
-dDf
-wCk
-pPx
-tUR
-txl
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+xOw
+meC
+xOw
+meC
+poI
 plJ
-uNY
-csy
-hWB
-niu
-uhf
-cnR
-kUm
-vJE
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
+meC
+vIl
 meC
 meC
 meC
@@ -59217,33 +59370,14 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+wnd
+xeV
+vLx
+vIW
+vIW
+kyz
+xeV
+tmY
 ebr
 kYu
 kYu
@@ -59446,27 +59580,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
+bMc
+cnR
+dje
+eSc
 dSP
-dSP
-dSP
-dSP
-dSP
+hGp
+imV
+iMm
+jci
 sbh
 eeu
-vMH
-agi
-bTC
-fnR
-cVo
-pwZ
-hEP
-ncz
-pFM
-gqE
+xwb
 meC
 meC
 meC
@@ -59480,6 +59605,21 @@ meC
 meC
 meC
 meC
+vIl
+xOw
+xOw
+xOw
+poI
+plJ
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
+bpu
+vIl
 meC
 meC
 meC
@@ -59487,20 +59627,14 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+wnd
+xgX
+dkY
+vIW
+vIW
+kyz
+xeV
+wuy
 ebr
 ltu
 kYu
@@ -59703,27 +59837,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+bGs
+cnV
+dtp
+eSw
+fLu
 sMF
 xJH
 oHM
 muo
 oSZ
 wMn
-dHC
-puH
-pLD
-pgB
-cgQ
-roC
-cID
-dje
-pFM
-gqE
+xwb
 meC
 meC
 meC
@@ -59737,6 +59862,21 @@ meC
 meC
 meC
 meC
+vIl
+meC
+meC
+meC
+poI
+plJ
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
+meC
+peF
 meC
 meC
 meC
@@ -59744,20 +59884,14 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+wnd
+xkV
+xeV
+xeV
+xeV
+jOl
+xeV
+wuy
 ebr
 kYu
 kYu
@@ -59960,27 +60094,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+bPI
+cqx
+dwu
+eTZ
+upD
 hdN
-fUt
+rrL
 ffg
-unY
-sbh
+jcm
+kGC
 lcF
 xwb
-rGo
-rrd
-upV
-fej
-hWB
-uNY
-aVD
-qID
-nhh
 meC
 meC
 meC
@@ -59993,6 +60118,22 @@ meC
 meC
 meC
 meC
+vIl
+peF
+meC
+vIl
+vIl
+poI
+plJ
+poI
+xOw
+plJ
+xOw
+poI
+plJ
+poI
+meC
+peF
 meC
 meC
 meC
@@ -60000,21 +60141,14 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+wnd
+xoQ
+mPC
+ffm
+dNC
+vhS
+igM
+wuy
 ebr
 pZL
 pZL
@@ -60217,26 +60351,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-sMF
-sMF
+bGs
+cri
+dzH
+eUr
+fMg
+hGt
+iom
 dDf
 wCk
 pPx
 tUR
-uSs
-sUf
-flU
-lmn
-flU
-xHD
-pbR
-flU
-lhx
 gqE
 meC
 meC
@@ -60250,28 +60375,37 @@ meC
 meC
 meC
 meC
+vIl
+xOw
+xOw
+bpu
+bpu
+bpu
+plJ
+bpu
+bpu
+plJ
+bpu
+bpu
+plJ
+bpu
+bpu
+bpu
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+uqa
+uqa
+uqa
+uqa
+wEG
+wEG
+wEG
+qEC
+hLH
+qEC
 ebr
 cIm
 kYu
@@ -60474,61 +60608,61 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-dSP
-dSP
-dSP
-dSP
+bMc
+csy
+dDF
+eZN
+fOu
+hJA
+ivo
+iQY
+jfV
 wYZ
-rJO
-ase
-aBb
-qvn
-tYA
-jFD
-paz
-tPx
-jFD
-gNY
-ayA
-hPR
-vZg
-bsI
+tUR
+gqE
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 vIl
+bpu
+pgB
+plJ
+plJ
+puH
+pyH
+puH
+puH
+puH
+pyH
+puH
+puH
+puH
+pyH
+tjI
+tjI
+tjI
+tjI
+tjI
+tjI
+ura
 vuB
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+wCf
+xsj
+qKS
+tXz
+rms
+ryF
+rKj
+ryF
 ebr
 kYu
 kYu
@@ -60731,32 +60865,18 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+bGs
+cxy
+dEJ
+fbg
+fUb
 idx
-khb
-nhB
-muo
+tdY
+rrL
+upD
 tZt
-wMn
+lpf
 met
-exO
-mhl
-eoC
-gcI
-jbW
-gQs
-eep
-tRS
-xkV
-pGA
-uNt
-hKm
-tRH
-gqE
 meC
 meC
 meC
@@ -60769,23 +60889,37 @@ meC
 meC
 meC
 meC
+vIl
+xOw
+xOw
+bpu
+bpu
+bpu
+plJ
+bpu
+bpu
+plJ
+bpu
+bpu
+plJ
+bpu
+xOw
 meC
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+uqa
+uqa
+uqa
+xxU
+thU
+ptg
+obq
+sbw
+dKh
+bwX
 ebr
 pZL
 pZL
@@ -60988,31 +61122,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+bPI
+cqx
+dEV
+fcT
+tUf
 vNt
 tUf
 tqI
-unY
-urx
-lcF
-lpf
-kKe
-fej
-llp
-fej
-hWB
-oIc
-pwZ
-aBB
-wLt
-tWu
-wFD
-nBR
-pYW
+jiM
+tUf
+lCH
 gqE
 meC
 meC
@@ -61026,23 +61146,37 @@ meC
 meC
 meC
 meC
+vIl
+vIl
+meC
+bpu
+bpu
+poI
+plJ
+poI
+xOw
+plJ
+xOw
+poI
+plJ
+poI
+xOw
+xOw
 meC
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+vAt
+wEG
+xxV
+evs
+xSi
+wEG
+ryF
+uQH
+bwX
 ebr
 cIm
 kYu
@@ -61245,32 +61379,23 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-idx
-idx
-hnI
-wCk
+bTC
+cDo
+dJv
+ffE
+fZH
+hJD
 onM
-tUR
+hnI
+jmc
+onM
+lSw
 twb
 img
 fej
 llp
-fej
+okH
 bXM
-mRN
-rhY
-eeR
-fjp
-dXd
-viF
-peF
-rCq
-gqE
 meC
 meC
 meC
@@ -61279,27 +61404,36 @@ meC
 meC
 meC
 meC
+vIl
+meC
+xOw
+meC
+poI
+plJ
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
+meC
+xOw
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+tDj
+tEZ
+tEZ
+tEZ
+vCh
+wEG
+wEG
+wEG
+wEG
+wEG
+ryF
+wvb
+qxz
 ebr
 kYu
 kYu
@@ -61502,31 +61636,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-dSP
-dSP
-dSP
-dSP
-urx
-eeu
+bZV
+csy
+dPm
+fgK
+gbZ
+hKm
+ixl
+iSh
+jnC
+kKe
+lVR
 nBb
 agi
-fej
+nzC
 hCO
-yec
-vAt
-nQV
-hqG
-kGC
-xxV
-hWB
-eDD
-eTZ
-tuJ
+omE
 gqE
 meC
 meC
@@ -61536,27 +61661,36 @@ meC
 meC
 meC
 meC
+vIl
+bpu
+xOw
+xOw
+poI
+plJ
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
 meC
+xOw
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+tDj
+tDj
+tYA
+tTw
+tTw
+vCG
+wFD
+xBh
+fse
+kqV
+hSi
+bQL
+uyj
+oKZ
 ebr
 pZL
 pZL
@@ -61759,31 +61893,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-hVF
-nvB
-gHX
-muo
-tZt
-wMn
+urx
+cxy
+dRY
+fhv
+tdY
+pRX
+tdY
+rrL
+jpD
+dDf
+lXr
 oRd
 qkI
 yec
 uWd
-fej
-ivo
-fZH
-dtp
-jCl
-mZg
-hWB
-scd
-jiM
-yhD
+oqB
 gqE
 meC
 meC
@@ -61793,27 +61918,36 @@ meC
 meC
 meC
 meC
+vIl
 meC
+xOw
 meC
+poI
+plJ
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
 meC
+pAG
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+tDj
+tTw
+tTw
+tTw
+urg
+tTw
+wJB
+xEP
+tTw
+kqV
+hSi
+ryF
+gEn
+oUa
 ebr
 cIm
 bWH
@@ -62016,31 +62150,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-moV
-njy
+cbh
+cqx
+dTy
+fjp
+tdY
+pRX
+tdY
 mZX
-unY
-urx
+jsH
+kLJ
 wJs
 yag
 oLE
 apG
 mwU
 pKC
-pKC
-jfV
-pKC
-cRz
-mZg
-rgW
-urg
-rGQ
-aLa
 gqE
 meC
 meC
@@ -62050,27 +62175,36 @@ meC
 meC
 meC
 meC
+bpu
 meC
+xOw
 meC
+poI
+plJ
+poI
+poI
+plJ
+poI
+poI
+plJ
+poI
+xOw
+pAG
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+tEZ
+tTw
+tTw
+uhe
+uyW
+ukN
+tTw
+tTw
+tTw
+pLY
+ryF
+iqM
+sbw
+glN
 ebr
 kYu
 kYu
@@ -62273,31 +62407,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-hVF
-hVF
+urx
+cri
+dXd
+eUr
+tdY
+hPR
+gpZ
 kKj
-wCk
-onM
-tUR
+jtT
+kLP
+mhl
 stL
 rrL
-fej
-llp
-fej
-qkK
-fej
-vkz
-laV
-aTW
-tYq
-cnV
-wJB
-iXo
+nBR
+odv
+owe
 gqE
 meC
 meC
@@ -62307,27 +62432,36 @@ meC
 meC
 meC
 meC
+cqo
 meC
+bpu
 meC
+bpu
 meC
+xOw
+poI
+plJ
+poI
+bpu
 meC
+xOw
 meC
+xOw
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+tEZ
+tTw
+tZj
+uhf
+uKl
+vEN
+tTw
+tTw
+qIC
+kqV
+ryF
+ryF
+gEn
+oUa
 ebr
 beA
 beA
@@ -62530,31 +62664,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-dSP
-dSP
-dSP
-dSP
-urx
-eeu
+bZV
+csy
+dXA
+fju
+gpZ
+hRS
+tdY
+iVZ
+jCg
+kML
+mkv
 kTe
-agi
-fej
+rrL
+nEs
 rSA
 niu
-sPT
-afW
-sSv
-nzC
-kXC
-ejZ
-pRq
-uNY
-mtn
 gqE
 meC
 meC
@@ -62564,27 +62689,36 @@ meC
 meC
 meC
 meC
+cqo
+cqo
+xOw
+cqo
+xOw
+meC
+xOw
+meC
+xOw
+meC
+xOw
+cqo
 meC
 meC
+xOw
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+tEZ
+tTw
+tTw
+ukN
+uKs
+uhe
+wLt
+xFT
+xFT
+qpH
+tTm
+sbw
+sbw
+oUa
 ebr
 kYu
 kYu
@@ -62787,32 +62921,23 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+urx
+cEE
+dXM
+flU
+gAG
 lQM
-fhc
 iZx
-muo
-tZt
-wMn
-dyA
+iZx
+jCl
+iZx
+mmr
+kTe
 oHR
-yec
+nMJ
 bxW
 afW
-fwZ
-afW
-vZV
-abu
-ckp
-jCg
-iSh
-jSg
-szr
-cGG
+gqE
 meC
 meC
 meC
@@ -62824,24 +62949,33 @@ meC
 meC
 meC
 meC
+cqo
+cqo
+cqo
+cqo
+cqo
+cqo
+cqo
+cqo
+cqo
+cqo
+xOw
+rCR
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+tDj
+tTw
+tTw
+tTw
+uNt
+tTw
+tTw
+xHD
+tTw
+kqV
+hSi
+ryF
+gEn
+buv
 ebr
 ltu
 kYu
@@ -63044,31 +63178,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-msP
+cbh
+cqx
+dXO
+fmr
+tdY
+pRX
 tdY
 jKq
-unY
-urx
+tdY
+kTt
 cuN
 mfe
-oLE
+mZg
 hen
-llp
-afW
-soN
-afW
-sSv
-fLu
-eaV
-gbZ
-pRq
-uNY
-frb
+oeH
+oBo
 gqE
 meC
 meC
@@ -63094,11 +63219,20 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
+tDj
+tDj
+ucB
+tTw
+tTw
+vJE
+wPQ
+xLW
+egb
+kqV
+hSi
+ryF
+gEn
+buv
 ebr
 kYu
 kYu
@@ -63301,31 +63435,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-lQM
-lQM
+urx
+cri
+eaV
+eUr
+tdY
+hWB
+ffg
 stj
-wCk
-onM
+wHc
+aYi
 tGW
 oCX
 tNu
-kaD
-llp
-afW
-soN
-fej
-aGP
-gpZ
-diz
-sgj
-pRq
-uNY
-tHX
+xbA
+upD
+oEp
 gqE
 meC
 meC
@@ -63352,10 +63477,19 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
+tDj
+tEZ
+tEZ
+tEZ
+tDj
+tDj
+tDj
+tDj
+tDj
+qEC
+xOc
+gEn
+cDs
 ebr
 pZL
 pZL
@@ -63558,32 +63692,23 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-dSP
-dSP
-dSP
-dSP
-urx
+bZV
+csy
+eep
+fnR
+gpZ
+iIw
+wHc
+iXo
+wHc
+kUm
 qfQ
 iCJ
-agi
+ncz
 tDN
-llp
-fej
+ogg
+oGl
 hIz
-rfm
-sMw
-hJD
-xeV
-kjc
-pRq
-uNY
-xgX
-gqE
 meC
 meC
 meC
@@ -63601,18 +63726,27 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+qEC
+qEC
+qEC
+trM
 ebr
 cIm
 kYu
@@ -63815,31 +63949,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-jqT
-ddF
-rKr
+urx
+cGG
+eeR
+flU
+uqD
+pRX
+wHc
+siA
 wHc
 aYi
 bOa
 gwa
 fAK
-uHe
-llp
+xbA
+upD
 rXh
-hIz
-rfm
-sMw
-ttQ
-ePJ
-ajy
-pRq
-uNY
-hGt
 gqE
 meC
 meC
@@ -63858,18 +63983,27 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+xOw
+xOw
+xOw
+xOw
+xOw
+qEC
+sHA
 ebr
 kYu
 kYu
@@ -64072,31 +64206,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+cbh
+cID
+egF
+fpe
+gIz
 pRX
-imO
+wHc
 siA
-unY
-urx
+tdY
+kXC
 xuv
 iGM
-agi
-fej
-llp
-niu
-qdF
-fej
-kTt
-bpF
-xeV
-eSc
-pRq
-uNY
-vMc
+ngs
+xbA
+upD
+oIc
 gqE
 meC
 meC
@@ -64115,18 +64240,27 @@ meC
 meC
 meC
 meC
+xOw
+pwZ
+shd
+sKi
+shd
+pwZ
+shd
+sKi
+shd
+pwZ
+shd
+sKi
+shd
+pwZ
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+xOw
+qEC
+sHA
 ebr
 pZL
 pZL
@@ -64329,31 +64463,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-jqT
-jqT
+urx
+cLM
+ejZ
+eUr
+sbs
+pRX
+tdY
 rUF
-wHc
-aYi
-bOa
-gwa
+jEp
+laV
+mtn
+xyv
 tkh
 xbA
 upD
-hen
-sgQ
-fej
-kTt
-okH
-dEJ
-daA
-pRq
-uNY
-ezi
+oIK
 gqE
 meC
 meC
@@ -64372,18 +64497,27 @@ meC
 meC
 meC
 meC
+xOw
+pwZ
+soN
+sMt
+shd
+pwZ
+soN
+tHX
+shd
+pwZ
+soN
+uNY
+shd
+pwZ
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+qEC
+qEC
+qEC
+sHA
 ebr
 cIm
 kYu
@@ -64586,32 +64720,23 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-dSP
-dSP
-dSP
-dSP
-urx
-gqE
-fpN
-agi
-tDN
-llp
-tDN
-sgQ
-fej
-aEh
-kLJ
+ccy
+cNB
+elD
+fpp
+gNY
+pRX
+iHm
+rUF
 jEp
-bae
-nor
-uNY
-asq
-eZN
+laV
+mHk
+fpN
+nhh
+xbA
+upD
+oQM
+gqE
 meC
 meC
 meC
@@ -64629,18 +64754,27 @@ meC
 meC
 meC
 meC
+xOw
+pwZ
+suB
+sMw
+sUf
+pwZ
+ttQ
+tPx
+tWu
+pwZ
+upV
+uRi
+vMc
+pwZ
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+bXw
+uDN
+gmk
+sHA
 ebr
 kYu
 kYu
@@ -64843,31 +64977,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-pas
-cpH
+urx
+cRz
+ema
+eUr
+tdY
+pRX
+ffg
 vYz
-muo
-tZt
+tdY
+lbM
 jIC
 xyv
 jfQ
-nFv
-llp
-tDN
-iom
-hRS
-boJ
-wCf
-xRT
-dXA
-elD
-uNY
-wTA
+xbA
+upD
+oRt
 gqE
 meC
 meC
@@ -64886,18 +65011,27 @@ meC
 meC
 meC
 meC
+xOw
+pwZ
+szr
+pwZ
+szr
+pwZ
+tuJ
+pwZ
+tWV
+pwZ
+tuJ
+pwZ
+tWV
+pwZ
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+qEC
+qEC
+qEC
+sHA
 ebr
 pZL
 pZL
@@ -65100,31 +65234,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+ccy
+cNB
+elD
+fpE
+gQs
 czs
 uqD
 pRL
-unY
-urx
-xuv
+tdY
+lbM
+mOy
 iPe
-agi
-iHM
-llp
-tDN
-mBS
-dDF
-pRt
-fhv
-dPm
-cNB
-ema
-ezO
-oBo
+nor
+xbA
+upD
+oWV
 gqE
 meC
 meC
@@ -65137,24 +65262,33 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+sCL
+xOw
+sCL
+xOw
+txl
+xOw
+tYq
+xOw
+txl
+xOw
+tYq
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+qEC
+sHA
 ebr
 cIm
 bWH
@@ -65357,32 +65491,23 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-pas
-pas
-mmY
-wCk
-onM
-tGW
+urx
+gqE
+emh
+eUr
+sbs
+pRX
+sbs
+pRL
+tdY
+lcn
+mPV
 yfg
 efq
 qQI
-bxW
-tDN
+upD
+paz
 mBS
-cri
-gqE
-gqE
-bPI
-dXM
-emh
-ezW
-gqE
-gqE
 meC
 meC
 meC
@@ -65394,24 +65519,33 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+xOw
+sgQ
+szr
+sgQ
+szr
+sgQ
+tuJ
+sgQ
+tWV
+sgQ
+tuJ
+sgQ
+tWV
+sgQ
+sgQ
+xOw
+xOw
+xOw
+xOw
+qEC
+sHA
 ebr
 kYu
 kYu
@@ -65614,31 +65748,23 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-dSP
-dSP
-dSP
-dSP
-urx
-gqE
-aaB
-agi
-fej
-mCZ
-tDN
-mBS
-ylh
-gqE
-ukN
-fDD
-eUr
+bZV
+cnR
 emj
-fql
-yfo
+fpJ
+gSH
+pRX
+sbs
+iXF
+jFD
+lhx
+mRN
+aaB
+nrR
+nQV
+upD
+pbR
+gqE
 meC
 meC
 meC
@@ -65650,33 +65776,41 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-lOf
-lOf
+xOw
+pwZ
+pBp
+qgk
+qJf
+rGQ
+seZ
+rGQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+qEC
+trM
 ebr
-beA
-beA
-beA
-beA
-ijz
-beA
-beA
+ebr
+ebr
+ebr
+ebr
+oPM
+ebr
+ebr
 ebr
 ada
 rhO
@@ -65871,31 +66005,23 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-bFn
-rCu
-ipr
-muo
-tZt
-jIC
+urx
+cRz
+emQ
+eUr
+gTT
+pRX
+sbs
+qGL
+jSg
+lmn
+mSv
 eLT
 fMW
 irQ
 pYk
-uHe
-mBS
-cri
+pcU
 gqE
-jpD
-bZV
-mmr
-gSH
-aBG
-yfo
 meC
 meC
 meC
@@ -65907,33 +66033,41 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pFM
+qkK
+qWC
+rVo
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+kxB
+uhh
+rBG
+uhh
+uhh
+ihJ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
 ebr
 omP
 fgx
@@ -66128,32 +66262,15 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
+cbh
+cID
+end
+fql
+gVC
 iIw
 sbs
-kjr
-unY
-urx
-xuv
-dzH
-agi
-fej
-fej
-fej
-mBS
-cri
-pyH
-dXO
-kwI
-oIK
-xUk
-iMm
-pcU
-xOP
+qGL
+jWs
 meC
 meC
 meC
@@ -66173,24 +66290,41 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pBp
+pBp
+qXI
+scd
+sgj
+scd
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aNh
 ebr
 ebr
 ebr
@@ -66385,32 +66519,15 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-bFn
-bFn
-bFv
-wCk
-onM
-tGW
-twb
-fcT
-vCG
-uKs
-qus
-mBS
-egF
-fju
-kod
-qJf
-ucB
-iQY
-uKl
-mHk
-yfo
+urx
+gqE
+eoC
+eUr
+tdY
+hXR
+sbs
+qGL
+kjc
 meC
 meC
 meC
@@ -66430,27 +66547,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aNh
+jEh
+jEh
+jEh
 xHU
 yjO
 eNE
@@ -66642,32 +66776,15 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-dSP
-dSP
-dSP
-dSP
-dSP
-vCh
-dgT
-sMt
-jbY
-wEG
-qgk
-xsj
-dwu
+bZV
+cnR
+ewL
+frb
+hqG
 ikC
-fju
-oRt
-oIK
-pPW
-oIK
-fbg
-fpe
-yfo
+gNY
+qGL
+jWs
 meC
 meC
 meC
@@ -66687,27 +66804,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pBp
+qgk
+qJf
+rGQ
+seZ
+rGQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aNh
+jEh
+jEh
+jEh
 xHU
 oDR
 cEu
@@ -66896,75 +67030,75 @@ meC
 meC
 meC
 meC
+meC
+meC
+meC
 urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-rJH
-rJH
-urx
-urx
-urx
-gqE
-bhP
-kLP
-uRi
+cRz
+exO
+eUr
+tdY
+tdY
+tdY
+qGL
+jWs
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+xOw
+pwZ
+pFM
+qkK
 rav
-hGp
-oqB
-tWV
-fFN
-xBh
-emQ
-pPW
-oIK
-fbg
-fpp
-yfo
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+rVo
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aNh
+mNS
+jEh
+jEh
 xHU
 fAT
 lgW
@@ -67152,36 +67286,19 @@ meC
 meC
 meC
 meC
-gqE
-gqE
-unY
-unY
-unY
-unY
-unY
-gqE
-gqE
+meC
+meC
+meC
+meC
+cbh
+cID
+dTy
+fsI
+hrg
 kHp
 vjg
 qGL
 nnY
-nnY
-nnY
-jci
-fmr
-wQU
-imV
-owe
-jtT
-jWs
-jcm
-xFT
-end
-oeH
-eNt
-eNt
-fpE
-yfo
 meC
 meC
 meC
@@ -67201,27 +67318,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pBp
+pBp
+qXI
+scd
+sgj
+scd
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+uhh
+uhh
+uhh
+uhh
+uhh
+uhh
+uhh
+tFZ
+rTt
+jEh
+jEh
 txV
 ewC
 lgW
@@ -67409,36 +67543,19 @@ meC
 meC
 meC
 meC
-gqE
-dJv
+meC
+meC
+meC
+meC
 gcI
-gcI
-gcI
-gcI
+cVo
 eAW
 jQu
 foA
 bnS
 qFN
-qFN
-qFN
-tjI
-tZj
-kML
-kDY
-kDY
-kDY
-kDY
-kDY
-lbM
-qCa
-qWC
-dcC
-lcn
-gqE
-blu
-fpJ
-uyW
+jbW
+kmx
 meC
 meC
 meC
@@ -67458,27 +67575,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+aQC
+aQC
+aQC
+aQC
+aQC
+aNh
+arU
+jEh
+jEh
 xHU
 sTk
 nFs
@@ -67667,34 +67801,18 @@ meC
 meC
 meC
 unY
-tVL
-lJR
-lJR
-iHy
-lJR
-lJR
+unY
+urx
+urx
+urx
+gqE
+eyq
 cAS
-xdu
+bpF
 gzh
 kYz
 ghG
 fZz
-kDY
-kDY
-kAc
-kDY
-kDY
-ghG
-fZz
-kDY
-lbM
-cgV
-bMc
-mSv
-qXI
-tEZ
-uyW
-iHm
 meC
 meC
 meC
@@ -67714,28 +67832,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pGA
+qlZ
+rfm
+rGQ
+seZ
+rGQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+aQC
+aQC
+aQC
+aQC
+aQC
+aNh
+jEh
+jEh
+jEh
 xHU
 maU
 nFs
@@ -67923,35 +68057,19 @@ meC
 meC
 meC
 meC
-unY
-tVL
+aBS
+bhP
 lJR
 pMI
-lxs
-qic
-lJR
+pMI
+pMI
+ezi
 rHq
-aQw
+hEP
 sbW
 tJQ
 hSR
 gQD
-rFL
-oGl
-tDj
-dTy
-rFL
-hSR
-gQD
-rFL
-uhe
-gqE
-qWC
-ngs
-lcn
-gqE
-gqE
-fgK
 meC
 meC
 meC
@@ -67971,28 +68089,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pGF
+qnG
+rgW
+rVo
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+uhh
+aQC
+aQC
+aQC
+aQC
+aQC
+aNh
+jEh
+jEh
+jEh
 xHU
 pPR
 mJT
@@ -68180,35 +68314,19 @@ meC
 meC
 meC
 meC
-unY
-tVL
+aEh
 qtY
-gmJ
+qtY
+qtY
 cyE
 uIl
-aZo
-aMh
-lCW
-hue
-jLJ
-myC
+ezO
+xyZ
+xyZ
+xyZ
+xyZ
+xyZ
 mhD
-jLJ
-kDY
-kDY
-kDY
-fOu
-beP
-aJL
-fOu
-poI
-unY
-ixl
-fMg
-suB
-kmx
-wwi
-wwi
 meC
 meC
 meC
@@ -68228,28 +68346,44 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pGA
+pGA
+rho
+scd
+sgj
+scd
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+ovP
+ovP
+ovP
+ovP
+ovP
 xHU
 xHU
 xHU
@@ -68438,34 +68572,18 @@ meC
 meC
 meC
 xdu
-uVu
-lJR
+xyZ
+pzQ
 qic
-bQQ
-pMI
-aZo
-puL
-nDB
-psV
-kYz
-fYu
-iGF
-ccy
-odv
-jnC
-sKi
-vVv
-ghG
-fZz
-kDY
-ffE
-gqE
-gqE
-qnG
-gqE
-gqE
-wwi
-wwi
+xyZ
+xyZ
+ezW
+xyZ
+xyZ
+pzQ
+qic
+xyZ
+mhD
 meC
 meC
 meC
@@ -68485,31 +68603,47 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-uJl
+xOw
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+bEh
+bEh
+bEh
+bEh
+bEh
+bEh
+bEh
+ovP
 mRE
 fnV
 bYz
@@ -68694,34 +68828,19 @@ meC
 meC
 meC
 meC
-xdu
+aGP
 wgb
-aZo
-aZo
-nep
-aZo
-aZo
-eGa
-sne
 qFL
-iNw
-iNw
-iNw
-gAG
-lOf
-lOf
-lOf
-vEN
-kDY
-kDY
-kDY
-lSw
-gqE
-gqE
-pBp
-gqE
-wwi
-wwi
+tQu
+wgb
+daA
+eDD
+eGa
+wgb
+qFL
+tQu
+wgb
+kod
 meC
 meC
 meC
@@ -68741,33 +68860,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
+xOw
+pwZ
+pLD
+qus
+rhY
+rGQ
+seZ
+rGQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ycV
+evh
+evh
+evh
+evh
+evh
+evh
+evh
 mNf
-atP
+bYz
 vBc
 bYz
 uJl
@@ -68952,32 +69086,18 @@ meC
 meC
 meC
 bAu
-fuP
-ccS
-ccS
-ccS
-ccS
-rcg
-vHs
-sne
+wCC
 jIq
-iNw
-iNw
-iNw
-eHR
-cbh
-rho
-oEp
-wPQ
-kDY
-kDY
-kDY
-dRY
-gqE
-gqE
-jsH
-gqE
-wwi
+bsI
+wCC
+xyZ
+xyZ
+xyZ
+wCC
+jIq
+bsI
+wCC
+kvc
 meC
 meC
 meC
@@ -68997,34 +69117,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-fnV
+xOw
+pwZ
+pPW
+qvn
+roC
+rVo
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+evh
+sfa
+sfa
+sfa
+sfa
+sfa
+sfa
+sfa
+nkJ
 dDP
 bYz
 uJl
@@ -69209,32 +69343,18 @@ meC
 meC
 meC
 aQw
-sne
-sne
-sne
-sne
-sne
-bAu
-bAu
-bAu
+xyZ
 pzQ
-iNw
-iNw
-iNw
-ccy
-eyq
-rho
-oQM
-vVv
-kDY
-kDY
-kDY
-tTw
-unY
-wwi
-wwi
-wwi
-wwi
+qic
+cgQ
+dcC
+eHR
+fwZ
+oFg
+pzQ
+qic
+xyZ
+kwI
 meC
 meC
 meC
@@ -69254,34 +69374,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-fnV
+xOw
+pwZ
+pLD
+pLD
+rrd
+scd
+sgj
+scd
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+evh
+sfa
+sEP
+rad
+xuL
+kuZ
+fEd
+sfa
+nkJ
 fpd
 bYz
 uJl
@@ -69465,29 +69599,19 @@ meC
 meC
 meC
 meC
-bqT
-bUt
-bUt
-bUt
+aQw
+xyZ
+xyZ
+xyZ
 ltD
-fUb
-lCH
-hXR
+lOf
+lOf
+lOf
 xGK
-jyE
-iNw
-iNw
-iNw
-gAG
-lOf
-lOf
-lOf
-vEN
-kDY
-kDY
-kDY
-xxU
-unY
+xyZ
+xyZ
+xyZ
+kAc
 meC
 meC
 meC
@@ -69507,38 +69631,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-fnV
+xOw
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+xOw
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+evh
+sfa
+sEP
+xuL
+xuL
+kuZ
+fEd
+sfa
+nkJ
 fpd
 bZf
 uJl
@@ -69723,28 +69857,18 @@ meC
 meC
 meC
 bAy
-bAy
-bAy
-bAy
-sne
-sne
-sne
-sne
+xyZ
+xyZ
+xyZ
+cgV
+dgo
+eNt
+fyN
 nsk
-iNw
-iNw
-uGv
+xyZ
+xyZ
+xyZ
 cOR
-eHR
-mPV
-kvc
-ble
-wPQ
-ghG
-fZz
-kDY
-lbM
-unY
 meC
 meC
 meC
@@ -69764,38 +69888,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-fnV
+xOw
+pwZ
+pRq
+qCa
+rCq
+rGQ
+seZ
+rGQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+evh
+mrW
+sEP
+fRX
+cCO
+tVW
+pHa
+mTT
+nkJ
 hSl
 bZf
 uJl
@@ -69979,80 +70113,80 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-sne
+aJL
+xyZ
+xyZ
+xyZ
+cgQ
+dgT
+eNt
+fDD
 oFg
-iNw
-hrx
+xyZ
+xyZ
 xyZ
 dnk
-tJQ
-kDY
-kDY
-kDY
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+xOw
+pwZ
+pRt
+qID
 rFL
-hSR
-gQD
-rFL
-lbM
-unY
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+rVo
+xOw
+sgQ
 aQC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-fnV
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+evh
+sfa
+kjk
+sEP
+nxR
+oiI
+pHa
+sfa
+vIy
 hSl
 bZf
 uJl
@@ -70236,80 +70370,80 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-sne
-nsk
-iNw
-gMT
-tDB
-kSA
-jLJ
-kDY
-kDY
-kDY
-fOu
-beP
-aJL
-fOu
-ffE
-gqE
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+aLa
+xyZ
+xyZ
+xyZ
+ltD
 lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-fnV
+lOf
+lOf
+xGK
+xyZ
+xyZ
+xyZ
+kSA
+wwi
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+xOw
+pwZ
+pRq
+pRq
+rGo
+scd
+sgj
+scd
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+aQC
+sgQ
+aQC
+gQr
+aQC
+aQC
+aQC
+ovP
+evh
+sfa
+eCY
+abG
+kuK
+sEP
+sEP
+sfa
+vIy
 vdi
 bZf
 uJl
@@ -70488,34 +70622,25 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-bAu
+wwi
+wwi
+wwi
+wwi
+abu
+xyZ
+xyZ
+pzQ
+qic
+cgV
+diz
+ePJ
+fFN
 nsk
-iNw
-iNw
-uGv
-cOR
-kYz
-kDY
-kDY
-vpX
-nrR
-sQz
-gTT
-nrR
-wnd
-gqE
+pzQ
+qic
+xyZ
+mhD
+wwi
 meC
 meC
 meC
@@ -70534,38 +70659,47 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
+xOw
+pwZ
+pwZ
+pwZ
+pwZ
+pwZ
+xOw
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+sgQ
+xMB
+xMB
+xMB
+chL
+hTs
+chL
+xMB
+xMB
+ovP
+evh
+sfa
+lcI
+jqb
+nxR
+tVW
+tVW
+sfa
 fnV
 mvG
 bZf
@@ -70748,31 +70882,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-bAu
-jAR
-fST
+wwi
+ajy
+xyZ
+wgb
+qFL
 tQu
-pmG
-kXs
-aSN
-cLM
-ogg
-lVR
-uRi
-gqE
-gqE
-qlZ
-gqE
-gqE
+wgb
+xyZ
+xyZ
+xyZ
+wgb
+qFL
+tQu
+wgb
+mhD
+wwi
 meC
 meC
 meC
@@ -70791,38 +70916,47 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-hSl
-hSl
-hSl
-fej
-fej
-hSl
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xMB
+mpx
+mpx
+mpx
+mOJ
+mpx
+mpx
+mpx
+ovP
+evh
+sfa
+sfa
+sfa
+sfa
+tVW
+tVW
+sfa
 fnV
 dEz
 bZf
@@ -71005,30 +71139,21 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-aQw
+wwi
+abu
+xyZ
 wCC
-fpg
-cGn
-nDB
-aQw
-aQw
-mOy
-xLW
-pGF
-gqE
-bGs
-fyN
-fyN
-fyN
+jIq
+bsI
+wCC
+xyZ
+xyZ
+xyZ
+wCC
+jIq
+bsI
+wCC
+kwI
 gqE
 meC
 meC
@@ -71048,38 +71173,47 @@ meC
 meC
 meC
 meC
+xOw
 meC
-sFC
-sFC
-sFC
-sFC
-sFC
-sFC
-sFC
-sFC
-sFC
-sFC
-sFC
-sFC
-cEE
 meC
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
+meC
+meC
+meC
+meC
+xOw
+xOw
+xOw
+sFC
+sFC
+sFC
+sFC
+sFC
+sFC
+sFC
+sFC
+sFC
+sFC
+sFC
+sFC
+xOw
+xOw
+xMB
+nKW
+mpx
+mpx
+mOJ
+mpx
+mpx
+mpx
+ovP
+evh
+sfa
 rDl
 rDl
-hSl
-hSl
-hSl
-hSl
+sfa
+sfa
+sfa
+sfa
 fnV
 mvG
 bZf
@@ -71262,30 +71396,21 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-aQw
+gqE
+abu
+xyZ
+xyZ
+pzQ
+qic
+xyZ
+xyZ
+xyZ
+fKI
 cGn
 aog
+iHy
 cGn
-xOw
-xOw
-xOw
-pGF
-ewL
-pGF
-gqE
-aBS
-fyN
-sCL
-sCL
+kDY
 gqE
 meC
 meC
@@ -71304,6 +71429,15 @@ meC
 meC
 meC
 meC
+meC
+xOw
+meC
+meC
+meC
+meC
+meC
+meC
+xOw
 sFC
 sFC
 sFC
@@ -71318,25 +71452,25 @@ iYV
 faN
 aYo
 sFC
-vnK
-uWV
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-lVr
-dEz
+xOw
+xOw
+xMB
+mpx
+mpx
+mpx
+mOJ
+mpx
+mpx
+mpx
+ovP
+evh
+sfa
+nsw
+enW
 sUb
-fpd
-fpd
-hSl
+ukm
+ukm
+sfa
 fnV
 hSl
 bZf
@@ -71519,48 +71653,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-aQw
-cGn
-eQg
-cGn
+gqE
+amG
+aTW
+ble
+boJ
+bAr
+ckp
+ble
+aTW
+fKX
+bpF
+gqE
+gqE
 ryQ
+gqE
+gqE
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 xOw
-aQw
-pGF
-gVC
-pGF
-gqE
-gqE
-gqE
-gqE
-gqE
-gqE
 meC
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
 sFC
 gWC
 eKO
@@ -71570,30 +71704,30 @@ pNr
 pNr
 pNr
 fDT
-uua
+uSs
 eeg
 iyM
 nHk
 sFC
-vME
-rVo
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-dDP
+xOw
+xOw
+xMB
+yhd
+mpx
+mpx
+mOJ
+mpx
+mpx
+mpx
+ovP
+evh
+sfa
+etu
 bvL
 bvL
 bvL
 bvL
-hSl
+sfa
 fnV
 hSl
 bZf
@@ -71776,48 +71910,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-aQw
-vdF
+gqE
+ase
+aVD
+asq
+bpF
+gqE
+gqE
+ase
+aVD
+asq
+gqE
 bGD
 xpe
-aQw
+xpe
+xpe
+gqE
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 xOw
-aQw
-fsI
-sMF
-wkn
-omE
 meC
 meC
 meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
 sFC
 pNr
 exL
@@ -71832,24 +71966,24 @@ dHc
 wuF
 dcm
 sFC
-seZ
 uWV
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-tek
-tek
-atP
+uWV
+xMB
+mpx
+mpx
+mpx
+mOJ
+mpx
+mpx
+mpx
+ovP
+evh
+sfa
+tkj
+tkj
+szy
 vvS
-tek
+tkj
 mjL
 tek
 tek
@@ -72033,26 +72167,22 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-unY
-sMF
-sMF
-sMF
-unY
+gqE
+asq
+bae
+asq
 urx
-unY
-sMF
-sMF
-sMF
-unY
+urx
+urx
+asq
+eQg
+asq
+gqE
+imr
+xpe
+jbY
+jbY
+gqE
 meC
 meC
 meC
@@ -72071,10 +72201,14 @@ meC
 meC
 meC
 meC
+xOw
 meC
 meC
 meC
 meC
+meC
+meC
+xOw
 sFC
 jur
 lrA
@@ -72088,26 +72222,26 @@ sFC
 xdq
 sFC
 sFC
-sFC
+hQH
 vME
 vME
-lOf
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-tek
-hSl
-hSl
-hSl
-hSl
-hSl
+xMB
+mpx
+mpx
+mpx
+mOJ
+mpx
+mpx
+mpx
+ovP
+qVh
+vhi
+tkj
+sfa
+sfa
+sfa
+sfa
+sfa
 eZy
 bPR
 fnV
@@ -72290,25 +72424,21 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
 gqE
-sMF
-sMF
-sMF
-gqE
+asq
+beP
+asq
+xUf
 urx
 gqE
-sMF
-sMF
-sMF
+asq
+beP
+asq
+gqE
+gqE
+gqE
+gqE
+gqE
 gqE
 meC
 meC
@@ -72323,15 +72453,19 @@ meC
 meC
 meC
 meC
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
+meC
+meC
+meC
+meC
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
 sFC
 fDT
 lEJ
@@ -72343,28 +72477,28 @@ bTh
 xst
 mwa
 nWh
-kGA
+wQU
 wXX
-sFC
-vME
-vME
+hQH
+cGm
+cGm
 jmr
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-fej
-hSl
-tek
-hSl
+inY
+inY
+inY
+mOJ
+mpx
+mpx
+mpx
+ovP
+bEh
+sfa
+tkj
+sfa
 akd
 lRD
 mca
-hSl
+sfa
 hSl
 hSl
 hSl
@@ -72547,26 +72681,26 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
 gqE
-xUf
-xUf
-xUf
+ayA
+aBb
+blu
 gqE
 urx
 gqE
+ayA
+aBb
+blu
 xUf
-xUf
-xUf
-gqE
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
 meC
 meC
 meC
@@ -72581,14 +72715,14 @@ meC
 meC
 meC
 nbT
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
 sFC
 tQV
 lrA
@@ -72602,22 +72736,22 @@ sFC
 nWh
 nWh
 vHS
-sFC
+hQH
 cGm
 xOI
-jmr
-fej
-fej
-fej
-fej
-fej
+chL
+mpx
+mpx
+mpx
+mpx
+mpx
 qSj
 qSj
 qSj
 qSj
-hSl
-tek
-hSl
+ovP
+tkj
+sfa
 akd
 akd
 akd
@@ -72804,48 +72938,48 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-gqE
 wwi
+aBb
+aBb
+aBb
 wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-gqE
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-asz
-neq
-neq
-neq
-neq
-neq
-asz
-asz
-asz
 urx
+wwi
+aBb
+aBb
+aBb
+wwi
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+meC
+asz
+neq
+neq
+neq
+neq
+neq
+asz
+asz
+asz
+xOw
 sFC
 pNr
 tzt
@@ -72858,22 +72992,22 @@ vho
 egx
 kwE
 wlW
-dgo
-sFC
+nWh
+lGp
 cGm
 vME
-lOf
-fej
-fej
-fej
-fej
-fej
+xMB
+mpx
+mpx
+mpx
+mpx
+mpx
 qSj
 pnV
 pnV
 wxK
-uJl
-tek
+ovP
+tkj
 lAg
 akd
 akd
@@ -73061,6 +73195,17 @@ meC
 meC
 meC
 meC
+gqE
+aBb
+aBb
+aBb
+gqE
+urx
+gqE
+aBb
+aBb
+aBb
+gqE
 meC
 meC
 meC
@@ -73069,17 +73214,6 @@ meC
 meC
 meC
 meC
-meC
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
 meC
 meC
 meC
@@ -73102,7 +73236,7 @@ gQQ
 gfY
 gfY
 asz
-urx
+xOw
 sFC
 jKg
 eZF
@@ -73119,19 +73253,19 @@ nWh
 laM
 cGm
 vME
-yaU
-yaU
-yaU
-yaU
-yaU
-yaU
+qSj
+qSj
+qSj
+qSj
+qSj
+qSj
 qSj
 wjY
 pRO
 wxK
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 akd
 hEG
 wCv
@@ -73318,17 +73452,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+gqE
+aBB
+aBB
+aBB
+gqE
+urx
+gqE
+aBB
+aBB
+aBB
+gqE
 meC
 meC
 meC
@@ -73386,9 +73520,9 @@ qSj
 wjY
 fYf
 adR
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 qdJ
 akd
 mcB
@@ -73575,17 +73709,17 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+gqE
+aBG
+aBG
+aBG
+aBG
+aBG
+aBG
+aBG
+aBG
+aBG
+gqE
 meC
 meC
 meC
@@ -73629,8 +73763,8 @@ sFC
 sFC
 sFC
 sFC
-sFC
-sFC
+hQH
+hQH
 cGm
 vME
 yaU
@@ -73643,9 +73777,9 @@ qfe
 uFj
 rio
 adR
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 lJK
 akd
 mcy
@@ -73877,17 +74011,17 @@ vbE
 dMz
 deS
 asz
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-pAF
+xOw
+xOw
+xOw
+xOw
+meC
+meC
+meC
+meC
+meC
+spf
+igx
 cGm
 vME
 yaU
@@ -73900,9 +74034,9 @@ mjF
 jye
 jye
 jye
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 akd
 akd
 mcy
@@ -74134,17 +74268,17 @@ kTT
 kTT
 lyJ
 adi
+umU
+umU
+umU
 dqq
-dqq
-dqq
-dqq
-dqq
-urx
-urx
-urx
-urx
-urx
-pAF
+lEM
+meC
+meC
+meC
+gzV
+xRT
+vME
 cGm
 vME
 yaU
@@ -74157,9 +74291,9 @@ fVk
 fVk
 fVk
 fVk
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 vry
 akd
 mcy
@@ -74394,16 +74528,16 @@ oZZ
 qET
 fCb
 iDJ
-ura
 dqq
-urx
-urx
-urx
+meC
+meC
+meC
+meC
+meC
 spf
-spf
-spf
-wdY
-spf
+vME
+cGm
+vME
 yaU
 qNl
 gzx
@@ -74414,9 +74548,9 @@ fVk
 tEJ
 mcZ
 vQY
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 akd
 akd
 xIP
@@ -74650,17 +74784,17 @@ lyJ
 oZZ
 rDU
 wet
-wet
-ura
+tRS
 dqq
-urx
-urx
+dqq
+xOw
+xOw
 spf
 spf
-eSw
-jmc
-hDO
-nEs
+spf
+spf
+pFJ
+spf
 yaU
 jvb
 gzx
@@ -74671,9 +74805,9 @@ fVk
 vTW
 gXo
 rfr
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 akd
 hEG
 iqY
@@ -74910,14 +75044,14 @@ nOn
 nOn
 gdX
 dqq
-urx
-urx
+xOw
+xOw
 pAF
 gZP
 vME
 vME
 hDO
-lXr
+vME
 yaU
 yaU
 ukz
@@ -74928,9 +75062,9 @@ fVk
 fVk
 qmX
 fVk
-uJl
-tek
-hSl
+ovP
+tkj
+sfa
 qdJ
 akd
 akd
@@ -75167,14 +75301,14 @@ dmH
 nOn
 ttS
 dqq
-urx
-urx
+xOw
+xOw
 pAF
 gZP
 uWe
 jOs
 hDO
-vME
+xOI
 yaU
 vME
 ptq
@@ -75185,9 +75319,9 @@ pgl
 qQj
 gXo
 fWl
-hSl
-tek
-hSl
+sfa
+tkj
+sfa
 akd
 akd
 akd
@@ -75442,9 +75576,9 @@ gXo
 gXo
 gXo
 jLD
-hSl
-tek
-hSl
+sfa
+tkj
+sfa
 akd
 akd
 akd
@@ -75699,9 +75833,9 @@ fEA
 fEA
 nNe
 waR
-hSl
-tek
-hSl
+sfa
+tkj
+sfa
 akd
 akd
 rTv
@@ -75956,9 +76090,9 @@ fEA
 gXo
 gXo
 pVE
-hSl
+sfa
 mjL
-hSl
+sfa
 wvS
 wvS
 xlq
@@ -76957,10 +77091,10 @@ vmG
 dMz
 dMz
 uAD
-dMz
+vmG
 uuQ
-nLH
-oZZ
+sPT
+etA
 hfT
 tDP
 vfE
@@ -77214,9 +77348,9 @@ vmG
 vmG
 vmG
 wYH
-vmG
-vmG
-vmG
+dMz
+asz
+sQz
 etA
 swf
 swf
@@ -77461,7 +77595,7 @@ meC
 meC
 meC
 meC
-urx
+xOw
 asz
 eSf
 eSf
@@ -77473,7 +77607,7 @@ eSf
 bCR
 eSf
 asz
-asz
+dMz
 adi
 brU
 ilj
@@ -77718,19 +77852,19 @@ meC
 meC
 meC
 meC
-urx
-urx
-wwi
-urx
+xOw
+xOw
+jyU
+xOw
 mda
 fmF
 lzD
 fmF
 lzD
 mda
-urx
-wwi
-urx
+xOw
+asz
+sSv
 adi
 wgC
 wgC
@@ -77975,20 +78109,20 @@ meC
 meC
 meC
 meC
-urx
-urx
-wwi
-urx
+xOw
+xOw
+jyU
+xOw
 mda
 mda
 mda
 mda
 mda
 mda
-urx
-wwi
-urx
-urx
+xOw
+xOw
+jyU
+xOw
 wgC
 jAo
 oHn
@@ -78232,20 +78366,20 @@ meC
 meC
 meC
 meC
-urx
-urx
-wwi
-urx
+xOw
+xOw
+jyU
+xOw
 mda
 mda
 mda
 mda
 mda
 mda
-urx
-wwi
-urx
-urx
+xOw
+xOw
+jyU
+xOw
 wgC
 bjS
 umh
@@ -78489,20 +78623,20 @@ meC
 meC
 meC
 meC
-urx
-urx
-wwi
-urx
+xOw
+xOw
+jyU
+xOw
 mda
 mda
 mda
 mda
 mda
 mda
-urx
-wwi
-urx
-urx
+xOw
+xOw
+jyU
+xOw
 wgC
 bjS
 dgk
@@ -78746,20 +78880,20 @@ meC
 meC
 meC
 meC
-urx
-urx
-wwi
-urx
+xOw
+xOw
+jyU
+xOw
 mda
 mda
 mda
 mda
 mda
 mda
-urx
-wwi
-urx
-urx
+xOw
+xOw
+jyU
+xOw
 wgC
 bjS
 fgN
@@ -79003,20 +79137,20 @@ meC
 meC
 meC
 meC
-urx
-urx
-wwi
-urx
+xOw
+xOw
+jyU
+xOw
 oqZ
 ctO
 oqZ
 ctO
 oqZ
 ctO
-urx
-wwi
-urx
-urx
+xOw
+xOw
+jyU
+xOw
 wgC
 hTd
 tUr
@@ -79260,20 +79394,20 @@ meC
 meC
 meC
 meC
-urx
-urx
-wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-wwi
-urx
-urx
+xOw
+xOw
+jyU
+jyU
+jyU
+jyU
+jyU
+jyU
+jyU
+jyU
+jyU
+jyU
+jyU
+xOw
 wgC
 wgC
 wgC
@@ -79518,19 +79652,19 @@ meC
 meC
 meC
 meC
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -79775,9 +79909,9 @@ meC
 meC
 meC
 meC
-urx
-urx
-urx
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -79785,9 +79919,9 @@ meC
 meC
 meC
 meC
-urx
-urx
-urx
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -80032,9 +80166,9 @@ meC
 meC
 meC
 meC
-urx
-urx
-urx
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -80042,9 +80176,9 @@ meC
 meC
 meC
 meC
-urx
-urx
-urx
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -80289,18 +80423,18 @@ meC
 meC
 meC
 meC
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
-urx
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -80554,10 +80688,10 @@ lFM
 rjB
 rjB
 lFM
-urx
-urx
-urx
-urx
+xOw
+xOw
+xOw
+xOw
 meC
 meC
 meC


### PR DESCRIPTION
Adds atmos, atmos maints (and an atmos maint room), adds atmos itself, mostly just the outline.
This includes each gas chamber, and a full HFR/turbine, and the last solar panel array since we deleted the old one.  This one is in atmos

Also added external airlocks to the SM and fixed more areas.

What it looks like so far:
![solitaireatmos](https://user-images.githubusercontent.com/53777086/156915081-c84658be-5551-4cf7-a983-093e8ebe1376.png)
