### PR TITLE
Disposals/Decals/Areas

### DIFF
--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -247,10 +247,6 @@
 "aiZ" = (
 /turf/open/floor/wood,
 /area/security/prison/workout)
-"ajc" = (
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "ajd" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -623,6 +619,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"avn" = (
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "awl" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -1120,6 +1119,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
+"aJQ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue half"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "aJV" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/science/xenobiology)
@@ -1183,10 +1190,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
-"aMI" = (
-/obj/structure/mopbucket,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "aMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
@@ -1451,9 +1454,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
-"aVQ" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/bridge)
 "aVR" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
@@ -1467,10 +1467,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"aWz" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "aXe" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -1503,13 +1499,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"aYd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "aYi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -1801,10 +1790,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"bhf" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "bhP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/dark/textured_large,
@@ -2063,13 +2048,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"boU" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/head/hardhat/red,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "boW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -2324,6 +2302,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/project)
+"buB" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "bvC" = (
 /obj/structure/chair{
 	dir = 8
@@ -2416,10 +2401,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"bzE" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "bzI" = (
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -2630,9 +2611,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
-"bGl" = (
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "bGs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -3511,12 +3489,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
-"cjR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "cjS" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -4075,6 +4047,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"cCe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "cCl" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/tequila{
@@ -4506,6 +4484,13 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/iron,
 /area/security/processing)
+"cQc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cQr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
@@ -5103,11 +5088,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"dgF" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "dgT" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -5339,16 +5319,17 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dmG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "dmH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"dna" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "dnk" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 1
@@ -5695,10 +5676,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"dys" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "dzo" = (
 /obj/structure/closet/bombcloset,
 /obj/item/clothing/mask/gas,
@@ -6179,13 +6156,6 @@
 "dMz" = (
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"dMB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "dMZ" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
@@ -6280,6 +6250,13 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"dQn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "dQu" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -7094,11 +7071,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"eky" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "ekX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -7229,6 +7201,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"emP" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "emQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/end,
 /obj/machinery/space_heater,
@@ -7723,6 +7700,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"eyQ" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "eyY" = (
 /obj/item/target/alien,
 /turf/open/floor/engine,
@@ -7886,15 +7867,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/service/theater)
-"eEt" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "eEw" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/siding/yellow{
@@ -9642,12 +9614,6 @@
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/open/floor/carpet,
 /area/service/bar)
-"fLD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
 "fLH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9717,6 +9683,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"fPB" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "fPS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -9899,12 +9869,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"fSS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "fTj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -10144,11 +10108,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"gbp" = (
-/obj/effect/spawner/random/structure/table,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "gbI" = (
 /obj/machinery/modular_computer/console/preset/cargochat/cargo{
 	dir = 4
@@ -10351,6 +10310,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"giJ" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "gjm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/half{
@@ -10863,15 +10826,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"gtT" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "guY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/vehicle/sealed/mecha/working/ripley/cargo,
@@ -11001,10 +10955,6 @@
 	dir = 8
 	},
 /area/service/chapel)
-"gxL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "gxQ" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -11053,11 +11003,6 @@
 "gyC" = (
 /turf/open/floor/iron,
 /area/security/processing)
-"gyK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "gzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
@@ -11428,6 +11373,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"gKq" = (
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "gKG" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/iron,
@@ -11472,15 +11422,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"gMb" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Radstorm Shelter"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "gMo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -11562,6 +11503,11 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"gQl" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "gQm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -11809,6 +11755,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/lockers)
+"gYa" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "gYY" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
@@ -12160,11 +12110,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"hlp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12181,6 +12126,12 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"hnA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "hnE" = (
 /obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
@@ -12256,6 +12207,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"hqV" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "hqY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/lattice,
@@ -13189,12 +13144,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"hPl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "hPm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
@@ -13269,13 +13218,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
-"hQV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
 "hRu" = (
 /turf/closed/wall,
 /area/service/lawoffice/upper)
@@ -13721,6 +13663,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/security/processing)
+"icS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "icT" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
@@ -14165,6 +14113,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"iox" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "ioH" = (
 /obj/structure/punching_bag,
 /obj/machinery/light/directional/north,
@@ -14359,6 +14316,20 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"isZ" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
+"itr" = (
+/obj/machinery/door/morgue{
+	name = "Mass Driver";
+	req_access_txt = "27"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "itE" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cargo Lobby"
@@ -14604,18 +14575,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"izT" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
-"izV" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "iAj" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700";
@@ -14850,6 +14809,13 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"iHu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "iHz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15275,9 +15241,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"iQa" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/central)
 "iQm" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer{
 	dir = 8
@@ -15651,10 +15614,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
-"iZC" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "iZW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -16484,6 +16443,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
+"jBA" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "jBN" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/cyborg,
@@ -18196,13 +18158,6 @@
 "kwG" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"kwI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "kwN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/south,
@@ -19866,13 +19821,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"lmB" = (
-/obj/machinery/door/morgue{
-	name = "Mass Driver";
-	req_access_txt = "27"
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "lmC" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20186,6 +20134,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"luD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "luI" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -21819,10 +21773,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/office)
-"mgf" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "mgo" = (
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
@@ -23823,6 +23773,11 @@
 "nbh" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central/fore)
+"nbo" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "nbG" = (
 /obj/structure/window/reinforced,
 /obj/item/beacon,
@@ -23954,10 +23909,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"nfy" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "nfA" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -23972,6 +23923,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/security/processing)
+"nfQ" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "nfU" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24000,6 +23955,11 @@
 /obj/machinery/processor,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"nhb" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "nhu" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 8
@@ -24124,6 +24084,12 @@
 "nlz" = (
 /turf/closed/wall,
 /area/service/hydroponics)
+"nmw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "nmS" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -24792,14 +24758,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
-"nDg" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue half"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "nDm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -24844,6 +24802,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"nER" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/extinguisher/mini,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "nFs" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
@@ -26165,6 +26132,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"otc" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "otI" = (
 /obj/machinery/prisongate,
 /obj/machinery/door/firedoor,
@@ -26224,11 +26200,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
-"ovH" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "ovP" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine/atmos)
@@ -26499,6 +26470,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"oCk" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "oCr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
@@ -27029,13 +27005,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"oQE" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "oQQ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -27164,15 +27133,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"oTR" = (
-/obj/structure/table,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/extinguisher/mini,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "oUa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -27482,12 +27442,6 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
-"peO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "pfm" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -28115,6 +28069,11 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"pAH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "pBh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28289,6 +28248,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"pFX" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "pGa" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067";
@@ -28334,11 +28302,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
-"pIm" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "pIx" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -28366,6 +28329,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"pJu" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "pJW" = (
 /obj/structure/table,
 /obj/item/toy/figure/warden{
@@ -28490,10 +28457,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"pNo" = (
-/obj/structure/closet/firecloset,
+"pMZ" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/mop,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/department/security)
+/area/maintenance/starboard)
 "pNr" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
@@ -28557,6 +28531,10 @@
 	dir = 8
 	},
 /area/medical/treatment_center)
+"pPs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "pPt" = (
 /obj/effect/turf_decal/loading_area/red{
 	dir = 1
@@ -28865,6 +28843,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"pZt" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "pZL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29320,6 +29306,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+"qpD" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/hardhat/red,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "qpH" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics HFR Room";
@@ -29643,6 +29636,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
+"qBn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "qBS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -30065,6 +30064,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/security/processing)
+"qKE" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "qKS" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -30431,6 +30435,10 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"qXR" = (
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "qXY" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/barricade/wooden,
@@ -30575,11 +30583,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"rcu" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "rcC" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -31029,15 +31032,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"rpQ" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "rpV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -31795,6 +31789,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"rJo" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/bridge)
 "rJG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
@@ -31897,9 +31894,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"rKR" = (
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "rLq" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
@@ -32015,12 +32009,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"rNU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "rNY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/north,
@@ -32440,6 +32428,10 @@
 "rXN" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"rXQ" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "rXV" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/roboticist,
@@ -32611,13 +32603,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"scW" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "scZ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -32653,11 +32638,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"sdD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "sdF" = (
 /obj/machinery/modular_computer/console/preset/cargochat/science,
 /obj/effect/turf_decal/tile/brown/full,
@@ -32791,6 +32771,12 @@
 "shd" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
+"shj" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "shp" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/plasticflaps,
@@ -32804,6 +32790,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms)
+"shu" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/science/central)
 "shE" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
 /obj/structure/cable,
@@ -33521,6 +33510,11 @@
 	dir = 1
 	},
 /area/security/range)
+"szj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "szr" = (
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
@@ -33654,6 +33648,7 @@
 	name = "Medical blue corner"
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "sFa" = (
@@ -33754,6 +33749,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"sIW" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "sJI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -34024,6 +34023,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/office)
+"sSn" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Radstorm Shelter"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "sSq" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
@@ -34149,6 +34157,11 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"sUO" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "sUZ" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -34364,17 +34377,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
-"tak" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/mop,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "tal" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -34882,6 +34884,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room)
+"too" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "toB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -37154,6 +37161,11 @@
 /obj/item/pen,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
+"upT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "upV" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 4
@@ -37319,10 +37331,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
-"usy" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "usW" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -37599,6 +37607,10 @@
 /obj/item/clothing/glasses/sunglasses/big,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
+"uzf" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "uzC" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
@@ -39059,9 +39071,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "vgB" = (
-/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/area/service/bar/atrium)
 "vgC" = (
 /obj/structure/bookcase,
 /obj/machinery/light/directional/west,
@@ -39367,6 +39384,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"vmn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "vmr" = (
 /obj/effect/wisp,
 /turf/open/floor/plating{
@@ -39578,12 +39601,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"vtd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
 "vtf" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -39886,8 +39903,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "vxR" = (
@@ -39966,12 +39982,6 @@
 "vzS" = (
 /turf/closed/wall/r_wall,
 /area/security/brig/upper)
-"vzY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "vAd" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/purple{
@@ -40225,10 +40235,6 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
-"vHh" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "vHz" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -40317,11 +40323,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"vJz" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
+"vJw" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "vJE" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -40867,6 +40877,13 @@
 	},
 /turf/open/floor/grass,
 /area/science/genetics)
+"vWF" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "vWR" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/poster/contraband/random{
@@ -42090,6 +42107,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"wzs" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "wzt" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Research Hallway - Server Access";
@@ -43562,15 +43582,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tcomms)
-"xkv" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "xkz" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/camera/directional/south{
@@ -43649,11 +43660,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"xni" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "xnm" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
@@ -44027,11 +44033,6 @@
 "xzq" = (
 /turf/closed/wall/r_wall,
 /area/command/meeting_room/council)
-"xzr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "xzB" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/pew,
@@ -44128,13 +44129,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "xDy" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/service/bar/atrium)
+/area/hallway/primary/central/fore)
 "xDI" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -44297,6 +44295,15 @@
 "xHU" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
+"xIm" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "xIq" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -44812,10 +44819,6 @@
 "xSR" = (
 /turf/closed/wall,
 /area/security/courtroom)
-"xSS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "xTa" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -45104,6 +45107,10 @@
 "xYW" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"xYZ" = (
+/obj/structure/mopbucket,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "xZc" = (
 /turf/open/space/basic,
 /area/maintenance/department/medical/central)
@@ -45199,6 +45206,12 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"yaM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "yaQ" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -45279,14 +45292,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
-"ydE" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ydG" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
@@ -45602,10 +45607,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "yki" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/maintenance/department/electrical)
 "yko" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -63591,7 +63595,7 @@ wqG
 nrd
 ykr
 sZC
-dgF
+emP
 mgu
 mgu
 vlD
@@ -66416,7 +66420,7 @@ hXq
 hXq
 hXq
 hXq
-hlp
+too
 sZC
 orr
 gCS
@@ -67156,10 +67160,10 @@ bEh
 bEh
 bEh
 ovP
-eky
-rKR
+oCk
+wzs
 bYz
-iQa
+shu
 uXi
 tLO
 sHa
@@ -67416,7 +67420,7 @@ mNf
 bYz
 vBc
 bYz
-iQa
+shu
 vlK
 wcs
 xtk
@@ -67673,7 +67677,7 @@ sfa
 nkJ
 dDP
 bYz
-iQa
+shu
 hab
 qeC
 eDr
@@ -67928,9 +67932,9 @@ kuZ
 fEd
 sfa
 nkJ
-vJz
+gQl
 bYz
-iQa
+shu
 vuq
 vhv
 nnF
@@ -68185,9 +68189,9 @@ kuZ
 fEd
 sfa
 nkJ
-vJz
+gQl
 bZf
-iQa
+shu
 vXJ
 nja
 vXJ
@@ -68438,13 +68442,13 @@ mrW
 sEP
 fRX
 cCO
-gxL
+yki
 pHa
 mTT
 nkJ
 hSl
 bZf
-iQa
+shu
 fJK
 vhv
 vhv
@@ -68701,7 +68705,7 @@ sfa
 vIy
 hSl
 bZf
-iQa
+shu
 mTr
 xtk
 pXH
@@ -68953,12 +68957,12 @@ eCY
 abG
 kuK
 sEP
-sdD
+szj
 sfa
 vIy
 vdi
 bZf
-iQa
+shu
 mTE
 nar
 noe
@@ -69210,12 +69214,12 @@ lcI
 jqb
 nxR
 tVW
-dMB
+iHu
 sfa
-rKR
+wzs
 mvG
 bZf
-iQa
+shu
 tji
 naD
 noy
@@ -69466,13 +69470,13 @@ sfa
 sfa
 sfa
 sfa
-pIm
-vHh
+qKE
+eyQ
 sfa
-rKR
-dys
+wzs
+fPB
 bZf
-iQa
+shu
 vXL
 fWI
 gHG
@@ -69726,10 +69730,10 @@ sfa
 sfa
 sfa
 sfa
-rKR
+wzs
 mvG
 bZf
-iQa
+shu
 thy
 xtk
 fqj
@@ -69983,10 +69987,10 @@ sUb
 ukm
 ukm
 sfa
-rKR
+wzs
 hSl
 bZf
-iQa
+shu
 gdq
 xtk
 xac
@@ -70240,18 +70244,18 @@ bvL
 bvL
 bvL
 sfa
-rKR
+wzs
 hSl
 bZf
-iQa
-iQa
-iQa
-iQa
-iQa
-iQa
-iQa
-iQa
-iQa
+shu
+shu
+shu
+shu
+shu
+shu
+shu
+shu
+shu
 rXm
 agu
 rFs
@@ -70756,16 +70760,16 @@ sfa
 sfa
 eZy
 bPR
-rKR
+wzs
 lVr
-rKR
-iQa
-iQa
-iQa
-iQa
+wzs
+shu
+shu
+shu
+shu
 nRR
-iQa
-iQa
+shu
+shu
 pci
 xCL
 oFN
@@ -71016,7 +71020,7 @@ hSl
 hSl
 hSl
 hSl
-iQa
+shu
 gkd
 bWl
 qZl
@@ -71829,10 +71833,10 @@ ybf
 lMU
 nSZ
 ybf
-bGl
-bGl
-bGl
-bGl
+avn
+avn
+avn
+avn
 ybf
 lpN
 tCT
@@ -72082,7 +72086,7 @@ vdG
 lDe
 ybf
 mFk
-bGl
+avn
 lMU
 nWT
 ybf
@@ -72338,8 +72342,8 @@ kEY
 kEY
 lDo
 ybf
-bGl
-bGl
+avn
+avn
 lMU
 ybf
 ybf
@@ -72347,7 +72351,7 @@ ybf
 ybf
 ybf
 ybf
-iZC
+hqV
 vjJ
 xQY
 umW
@@ -72596,15 +72600,15 @@ uMm
 kLY
 ybf
 mMO
-bGl
+avn
 lMU
 ofS
 vYO
 wSK
 xda
 ybf
-bGl
-bGl
+avn
+avn
 vjJ
 xQY
 unJ
@@ -72853,7 +72857,7 @@ hpn
 hpn
 ybf
 ybf
-bGl
+avn
 lMU
 ybf
 oSh
@@ -73367,14 +73371,14 @@ pYM
 pYM
 lRW
 ybf
-bGl
+avn
 lMU
 ybf
 oUA
 wST
 qOc
 ybf
-bGl
+avn
 ybf
 vjJ
 xQY
@@ -73631,7 +73635,7 @@ ybf
 ybf
 qOv
 ybf
-bGl
+avn
 ybf
 vjJ
 xQY
@@ -73883,10 +73887,10 @@ vvi
 vKH
 vYt
 ikJ
-iZC
+hqV
 ybf
 pfu
-bGl
+avn
 ybf
 shp
 ybf
@@ -74143,9 +74147,9 @@ wka
 qFQ
 ybf
 bQx
-bGl
-bGl
-bGl
+avn
+avn
+avn
 ybf
 trU
 xQY
@@ -74652,7 +74656,7 @@ pYM
 pYM
 uaD
 ybf
-bGl
+avn
 eqU
 eqU
 eqU
@@ -75153,7 +75157,7 @@ vwp
 vwp
 vwp
 vwp
-aYd
+dmG
 vwp
 vUK
 tsC
@@ -75168,7 +75172,7 @@ sHl
 ybf
 bQx
 xJy
-bGl
+avn
 oUM
 xQY
 qQq
@@ -75393,16 +75397,16 @@ kNM
 nYv
 etF
 xkq
-nDg
+aJQ
 ljd
-nDg
-nDg
-nDg
-nDg
-nDg
+aJQ
+aJQ
+aJQ
+aJQ
+aJQ
 hgJ
-nDg
-nDg
+aJQ
+aJQ
 kYH
 xyU
 crc
@@ -75424,7 +75428,7 @@ csH
 csH
 ybf
 mYj
-bGl
+avn
 ols
 ndG
 xQY
@@ -75433,7 +75437,7 @@ cZb
 hny
 xQY
 uVS
-pNo
+pJu
 xQY
 uNR
 usm
@@ -75681,12 +75685,12 @@ bzc
 csH
 ybf
 mgP
-bGl
-bGl
-pNo
+avn
+avn
+pJu
 xQY
 qYh
-bGl
+avn
 slR
 rYp
 uVS
@@ -77210,7 +77214,7 @@ sAG
 goK
 lCt
 nAn
-mzd
+buB
 vUK
 xyU
 xSR
@@ -78730,8 +78734,8 @@ nzy
 nzy
 nzy
 nzy
-ovH
-bzE
+nbo
+uzf
 hzS
 ays
 oCv
@@ -79531,7 +79535,7 @@ tWI
 tuh
 xyU
 neS
-vgB
+xyU
 xyU
 mdY
 qLO
@@ -80786,7 +80790,7 @@ rZW
 uXP
 wux
 xNK
-mgf
+rXQ
 dFe
 hzS
 qpX
@@ -82341,7 +82345,7 @@ irs
 irs
 xsz
 irs
-kwI
+cQc
 irs
 pMJ
 pMJ
@@ -82828,7 +82832,7 @@ rBl
 vdE
 vdE
 vdE
-yki
+xDy
 mBf
 xPg
 qwq
@@ -83611,9 +83615,9 @@ oCe
 oCe
 oCe
 oCe
-xkv
+vJw
 weB
-hPl
+hnA
 nYv
 ojk
 oYo
@@ -83861,8 +83865,8 @@ mBf
 mIG
 oCe
 mlr
-eEt
-hPl
+xIm
+hnA
 nYv
 nYv
 wtY
@@ -84108,7 +84112,7 @@ vdE
 cmZ
 kVH
 cmZ
-xDy
+vxF
 kVH
 cmZ
 cmZ
@@ -84379,7 +84383,7 @@ vBM
 qeX
 nYv
 nYv
-fSS
+icS
 nYv
 nYv
 bwY
@@ -84876,7 +84880,7 @@ lVP
 lVP
 lVP
 vdE
-vxF
+vgB
 cmZ
 cmZ
 gsn
@@ -84931,8 +84935,8 @@ iur
 pUC
 qOf
 qKw
-xzr
-xzr
+upT
+upT
 qKw
 qKw
 sgR
@@ -85188,7 +85192,7 @@ iur
 vXU
 mKo
 qKw
-xzr
+upT
 nri
 usZ
 rTb
@@ -85702,7 +85706,7 @@ iur
 qEz
 qKw
 rbE
-xzr
+upT
 rzT
 iur
 rTe
@@ -85959,7 +85963,7 @@ iur
 dNB
 qKw
 qKw
-xzr
+upT
 czb
 iur
 qKw
@@ -86216,7 +86220,7 @@ iur
 iur
 iur
 qKw
-xzr
+upT
 rAf
 iur
 icT
@@ -86469,11 +86473,11 @@ ycI
 ycI
 xOw
 iur
-oTR
-vzY
+nER
+yaM
 iur
 iur
-xzr
+upT
 iur
 iur
 bZp
@@ -86726,11 +86730,11 @@ iJa
 yaG
 xOw
 jXz
-boU
-xzr
-gtT
-xzr
-xzr
+qpD
+upT
+otc
+upT
+upT
 qKw
 iur
 iur
@@ -86983,11 +86987,11 @@ qta
 yaG
 xOw
 iur
-bhf
-rNU
+nfQ
+qBn
 iur
 qKw
-xzr
+upT
 qKw
 iur
 meC
@@ -87243,8 +87247,8 @@ iur
 iur
 iur
 iur
-xzr
-xzr
+upT
+upT
 vXU
 iur
 meC
@@ -87497,10 +87501,10 @@ lUs
 yaG
 xOw
 iur
-ydE
-tak
+pZt
+pMZ
 iur
-xzr
+upT
 iur
 iur
 iur
@@ -87754,10 +87758,10 @@ yaG
 yaG
 xOw
 jXz
-xSS
-gyK
-gtT
-xzr
+pPs
+pAH
+otc
+upT
 iur
 meC
 meC
@@ -88011,8 +88015,8 @@ xOw
 xOw
 xOw
 iur
-aMI
-usy
+xYZ
+sIW
 iur
 qKw
 iur
@@ -88771,14 +88775,14 @@ hRI
 xXV
 iBd
 xXV
-rpQ
+iox
 xAv
 yaG
 yaG
 yaG
 yaG
-aVQ
-aVQ
+rJo
+rJo
 xOw
 meC
 meC
@@ -89007,7 +89011,7 @@ bPB
 bcA
 ljp
 tTz
-rcu
+nhb
 wKe
 yjs
 qyU
@@ -89030,12 +89034,12 @@ hCP
 hCP
 dLV
 jWU
-gMb
-cjR
-izV
-xni
-aWz
-aVQ
+sSn
+vmn
+pFX
+sUO
+gYa
+rJo
 xOw
 meC
 meC
@@ -89288,11 +89292,11 @@ xHl
 glK
 jYo
 yiq
-ajc
-peO
-izT
-oQE
-aVQ
+qXR
+luD
+jBA
+isZ
+rJo
 xOw
 meC
 meC
@@ -89545,11 +89549,11 @@ bpn
 bpf
 bpn
 bpn
-gbp
-scW
-dna
-nfy
-aVQ
+gKq
+vWF
+shj
+giJ
+rJo
 xOw
 meC
 meC
@@ -89802,11 +89806,11 @@ iMq
 eAD
 kel
 bpn
-aVQ
-aVQ
-aVQ
-aVQ
-aVQ
+rJo
+rJo
+rJo
+rJo
+rJo
 xOw
 meC
 meC
@@ -96728,7 +96732,7 @@ qMW
 qMW
 oAf
 vWT
-vtd
+nmw
 gvh
 wXw
 wXw
@@ -97244,8 +97248,8 @@ meC
 caa
 iRe
 prs
-fLD
-hQV
+cCe
+dQn
 pBD
 cql
 sHh
@@ -97504,7 +97508,7 @@ caa
 caa
 caa
 caa
-lmB
+itr
 caa
 caa
 caa

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -323,14 +323,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"amn" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue half"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "amt" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -387,13 +379,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"aot" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/engineering/main)
 "aoP" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/table,
@@ -617,10 +602,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"awc" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "awl" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -1000,6 +981,13 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"aGr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "aGw" = (
 /obj/structure/holohoop,
 /turf/open/floor/wood,
@@ -1122,6 +1110,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
+"aKs" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/flasher/directional/east{
+	id = "supcell"
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "aKy" = (
 /obj/item/food/grown/banana,
 /turf/open/floor/grass,
@@ -1428,6 +1425,15 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"aUS" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "aVD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
@@ -1634,11 +1640,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room)
-"bek" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/cargo/office)
 "beA" = (
 /turf/closed/wall,
 /area/science/xenobiology)
@@ -1923,6 +1924,9 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"bmj" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "bmA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1987,22 +1991,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"bnX" = (
-/obj/structure/table,
-/obj/machinery/button/door/directional/east{
-	id = "celock";
-	name = "CE Office Lockdown Button";
-	pixel_x = 40;
-	req_access_txt = "56"
-	},
-/obj/item/stamp/denied,
-/obj/item/stamp/ce{
-	pixel_x = -2;
-	pixel_y = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
 "boe" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -2099,13 +2087,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"bpP" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "bql" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -2284,11 +2265,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"btm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "btO" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
@@ -2563,13 +2539,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"bEP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "bEX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3134,6 +3103,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"bYX" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/ce)
 "bZe" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste Release"
@@ -3271,15 +3249,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"cbU" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "ccf" = (
 /obj/machinery/air_sensor/atmos/plasma_tank,
 /turf/open/floor/engine/plasma,
@@ -3389,6 +3358,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"cgo" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/bridge)
 "cgw" = (
 /obj/structure/table/glass,
 /obj/machinery/requests_console/directional/south{
@@ -3545,18 +3517,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
-"clH" = (
-/obj/structure/chair/comfy/brown{
-	color = "#EFB341";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
 "clS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3589,13 +3549,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
-"cmr" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/radio,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "cmt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3899,6 +3852,11 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"cww" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "cwV" = (
 /obj/machinery/power/solar{
 	id = "aftstarboard";
@@ -3907,10 +3865,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/starboard/aft)
-"cxj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "cxm" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -4293,6 +4247,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"cHi" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "cHm" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -4397,6 +4361,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"cLT" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "cMe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -4427,11 +4398,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cNF" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "cOo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -4521,11 +4487,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"cQu" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "cQD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -5072,13 +5033,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"dfu" = (
-/obj/machinery/computer/security{
-	dir = 8
+"dfa" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
-/area/security/checkpoint/supply)
+/area/hallway/primary/central/fore)
 "dfw" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light/small/directional/east,
@@ -5231,6 +5192,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"djJ" = (
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "dkk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/textured_large,
@@ -5349,12 +5314,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"dna" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "dnk" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -5451,6 +5410,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dql" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "dqq" = (
 /turf/closed/wall,
 /area/engineering/engine_smes)
@@ -5602,6 +5566,13 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/science/lab)
+"duF" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "duN" = (
 /turf/closed/wall,
 /area/maintenance/solars/starboard/aft)
@@ -5668,6 +5639,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"dwK" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/office)
 "dxb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes,
@@ -6967,10 +6943,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"eiL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/cargo/office)
 "eiU" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -7301,10 +7273,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"epD" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "epF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/nuclearbomb/beer,
@@ -7417,10 +7385,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"ets" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "etu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -7705,6 +7669,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"eyO" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "eyY" = (
 /obj/item/target/alien,
 /turf/open/floor/engine,
@@ -7734,15 +7710,6 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"ezo" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "ezJ" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -7801,15 +7768,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
-"eBi" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "eBC" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -7911,15 +7869,6 @@
 /obj/structure/closet/crate/mail/full,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eGg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "eGM" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -7975,16 +7924,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"eIs" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/iron,
-/area/cargo/office)
 "eIA" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -8144,10 +8083,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"eLS" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "eLW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8296,15 +8231,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"eRA" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"eRt" = (
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/service/bar/atrium)
+/area/security/checkpoint/supply)
 "eSf" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -8331,6 +8263,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"eSz" = (
+/obj/machinery/door_timer{
+	id = "engcell";
+	name = "Engineering Cell";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "eSJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -8464,10 +8407,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"eYC" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "eYE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -8991,17 +8930,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"fpe" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/mop,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "fpl" = (
 /obj/machinery/door/airlock{
 	name = "Service Lathe Access";
@@ -9022,20 +8950,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"fpr" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "mechbay";
-	name = "Mech Bay Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/robotics/mechbay)
 "fpx" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/effect/turf_decal/stripes/line,
@@ -9413,13 +9327,12 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
-"fCW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
+"fCN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "fCZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9462,6 +9375,10 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room)
+"fDI" = (
+/obj/structure/table,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "fDS" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -9690,11 +9607,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/security/warden)
-"fLk" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "fLn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -10092,9 +10004,6 @@
 	},
 /turf/open/floor/glass,
 /area/command/heads_quarters/rd)
-"fWW" = (
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "fWY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -10114,12 +10023,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
-"fXL" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "fXP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/grille,
@@ -10402,6 +10305,13 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"giH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mail Maintenance";
+	req_one_access_txt = "48;50"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gjm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/half{
@@ -10476,10 +10386,6 @@
 /obj/item/gps/mining,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"gkF" = (
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "gkI" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -10770,14 +10676,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"gqH" = (
-/obj/machinery/computer/cargo{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "gqI" = (
 /obj/structure/rack,
 /obj/item/storage/box/smart_metal_foam,
@@ -11090,15 +10988,6 @@
 "gyC" = (
 /turf/open/floor/iron,
 /area/security/processing)
-"gyJ" = (
-/obj/structure/table,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/extinguisher/mini,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "gzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
@@ -11489,17 +11378,6 @@
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /turf/open/floor/wood,
 /area/service/bar)
-"gLw" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Engineering";
-	req_access_txt = "63"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "gLy" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/neutral/line,
@@ -11772,16 +11650,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gWx" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/science/research)
 "gWy" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -11839,17 +11707,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/lockers)
-"gYj" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/cargo/office)
 "gYY" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
@@ -11901,10 +11758,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"haR" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "hbd" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -12197,15 +12050,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"hjU" = (
-/obj/machinery/computer/apc_control{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/command/heads_quarters/ce)
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12217,6 +12061,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
+"hnr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "hny" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -12360,6 +12211,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"hth" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "htt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -12604,6 +12461,16 @@
 /obj/structure/mirror/directional/north,
 /turf/open/floor/eighties,
 /area/service/theater)
+"hAx" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/iron,
+/area/cargo/office)
 "hAG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -12867,6 +12734,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"hFO" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "hFP" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -12953,11 +12824,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"hIX" = (
-/obj/effect/spawner/random/structure/table,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "hJg" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,
@@ -13130,10 +12996,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"hMN" = (
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "hNc" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Vacant Offices A"
@@ -13144,9 +13006,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hNf" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/bridge)
 "hNi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -13246,6 +13105,13 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hPH" = (
+/obj/machinery/door/morgue{
+	name = "Mass Driver";
+	req_access_txt = "27"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "hPT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13297,14 +13163,24 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
-"hRi" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "hRu" = (
 /turf/closed/wall,
 /area/service/lawoffice/upper)
+"hRw" = (
+/obj/structure/table,
+/obj/item/cartridge/engineering{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 3
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "hRI" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -13352,6 +13228,13 @@
 /obj/structure/punching_bag,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"hST" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "hSX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/white/line,
@@ -13431,16 +13314,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"hWC" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "hWD" = (
 /turf/closed/wall,
 /area/cargo/storage)
@@ -13689,11 +13562,6 @@
 /obj/structure/closet/secure_closet/detective,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"ibo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "ibr" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -13765,6 +13633,14 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"idB" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue half"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "idJ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
@@ -14273,6 +14149,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"iqe" = (
+/obj/structure/table,
+/obj/item/toy/figure/ce,
+/obj/item/storage/box/matches{
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "iqv" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -14391,6 +14275,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"itz" = (
+/obj/structure/cable,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/cargo/office)
 "itE" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cargo Lobby"
@@ -14479,6 +14368,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"iva" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "ivt" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -14691,14 +14584,6 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"iBw" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Cargo";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "iBB" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit,
@@ -14737,15 +14622,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"iCH" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/light/directional/west,
+"iCM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/maintenance/department/electrical)
 "iCW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14766,6 +14646,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"iDN" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "iEv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -14785,6 +14669,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
+"iEN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "iEP" = (
 /obj/structure/closet/secure_closet,
 /turf/open/floor/iron,
@@ -14792,13 +14681,6 @@
 "iEU" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
-"iEY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
 "iEZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/red/full{
@@ -14828,6 +14710,15 @@
 /obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"iFW" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Radstorm Shelter"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "iGb" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -14913,6 +14804,13 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"iHC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/main)
 "iHL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15363,14 +15261,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"iQH" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "iRe" = (
 /obj/structure/noticeboard/directional/north{
 	dir = 2;
@@ -15837,19 +15727,6 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
-"jeU" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
-"jfp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/flasher/directional/east{
-	id = "supcell"
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "jft" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -16279,6 +16156,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"jtV" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "jtX" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -16319,6 +16200,13 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
+"juO" = (
+/obj/structure/table,
+/obj/item/paper_bin/carbon,
+/obj/item/paper/monitorkey,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "juU" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -16371,6 +16259,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"jwz" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "jwH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17189,11 +17086,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"jSQ" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "jTa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17259,10 +17151,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"jUd" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "jUo" = (
 /obj/structure/chair/wood,
 /obj/machinery/light/small/directional/west,
@@ -17415,10 +17303,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"jYM" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "jZb" = (
 /obj/machinery/door/airlock/engineering{
 	id_tag = "EngiAccessInner";
@@ -17747,6 +17631,10 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"khO" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "khZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17806,6 +17694,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"kkt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "kkG" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -18091,9 +17983,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
-"kth" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "kts" = (
 /obj/machinery/camera/xray/directional/east{
 	c_tag = "AI Chamber W";
@@ -18281,9 +18170,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"kyg" = (
-/turf/open/floor/plating,
-/area/maintenance/department/security)
+"kxU" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "mechbay";
+	name = "Mech Bay Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/robotics/mechbay)
 "kyv" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -18647,10 +18547,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
-"kJP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
 "kKg" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
@@ -18982,6 +18878,12 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"kRc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "kRo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -19156,6 +19058,16 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+"kUz" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "kUA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -19711,12 +19623,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"lgN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "lgW" = (
 /turf/open/floor/iron/dark,
 /area/science/storage)
@@ -19877,6 +19783,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"lmf" = (
+/obj/machinery/button/flasher{
+	id = "supcell";
+	pixel_x = 24;
+	req_access_txt = "2"
+	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "lmC" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20590,12 +20507,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"lEG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "lEH" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
@@ -20614,6 +20525,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"lFj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "lFH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -20712,6 +20629,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"lIh" = (
+/obj/machinery/computer/security,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "lIi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -20925,17 +20848,6 @@
 	icon_state = "chapel"
 	},
 /area/ai_monitored/turret_protected/ai_upload)
-"lLK" = (
-/obj/machinery/button/flasher{
-	id = "supcell";
-	pixel_x = 24;
-	req_access_txt = "2"
-	},
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/radio,
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "lMv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -21137,6 +21049,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"lQJ" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "lQK" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -21759,6 +21679,18 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"mdP" = (
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "mdY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red/half{
@@ -21790,6 +21722,13 @@
 "meC" = (
 /turf/open/space/basic,
 /area/space)
+"meD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "meQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
@@ -21846,6 +21785,15 @@
 "mgu" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
+"mgw" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "mgG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22260,18 +22208,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"mtn" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "mto" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22340,13 +22276,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"muM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mail Maintenance";
-	req_one_access_txt = "48;50"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "muW" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -22360,6 +22289,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"mvz" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "mvG" = (
 /obj/structure/window/reinforced/fulltile/unanchored,
 /turf/open/floor/plating,
@@ -22839,6 +22772,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
+"mEx" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "mEG" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -22929,6 +22869,11 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing)
+"mHl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "mHA" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
@@ -23198,16 +23143,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
-"mMJ" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
 "mMO" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
@@ -23313,13 +23248,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
-"mNB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "mNS" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -23434,6 +23362,32 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"mQE" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_y = 10;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_x = -36;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door/directional/west{
+	desc = "A remote control switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_y = -6;
+	req_access_txt = "10"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "mQQ" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
@@ -23538,10 +23492,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
-"mTB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "mTD" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/grimy,
@@ -23554,6 +23504,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
+"mTK" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "mTT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/atmos{
@@ -23768,10 +23722,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"mZI" = (
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/coldroom)
 "mZJ" = (
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
@@ -24007,15 +23957,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"nfi" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Radstorm Shelter"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "nfA" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -24182,6 +24123,10 @@
 "nlz" = (
 /turf/closed/wall,
 /area/service/hydroponics)
+"nlF" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "nmS" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -24342,6 +24287,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
+"npC" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron,
+/area/engineering/main)
 "nqf" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 8
@@ -24950,13 +24902,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
-"nHs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "nHz" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Detective";
@@ -25052,10 +24997,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"nKs" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "nKW" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/n2o,
@@ -25160,6 +25101,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
+"nOH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "nOP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25373,10 +25318,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"nVb" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
+"nVG" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/door_timer{
+	id = "cargocell";
+	name = "Cargo Cell";
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "nVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/glass,
@@ -25529,32 +25479,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"nZt" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/effect/turf_decal/siding/thinplating/dark/end{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/west{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_y = 10;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door/directional/west{
-	id = "engstorage";
-	name = "Engineering Secure Storage Control";
-	pixel_x = -36;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door/directional/west{
-	desc = "A remote control switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_y = -6;
-	req_access_txt = "10"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
 "nZu" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067"
@@ -25955,6 +25879,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"ojW" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "okf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/bar,
@@ -26419,6 +26347,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"ozv" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "ozH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26740,10 +26671,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"oEZ" = (
-/obj/structure/closet/mini_fridge,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "oFh" = (
 /obj/structure/chair{
 	dir = 8
@@ -26914,14 +26841,6 @@
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"oJM" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "oJR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/slot_machine,
@@ -27083,15 +27002,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
-"oNU" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "oOC" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -27100,13 +27010,6 @@
 /obj/structure/chair/pew,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"oOD" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "oOO" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 4
@@ -27418,12 +27321,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/security/courtroom)
-"oXH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
 "oXM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -27446,13 +27343,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"oXV" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/head/hardhat/red,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "oYo" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/blue/half{
@@ -27522,11 +27412,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/library)
-"paO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "paU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27591,6 +27476,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"pcK" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "pdl" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
@@ -27756,6 +27646,15 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"phQ" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/extinguisher/mini,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "phT" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -27779,12 +27678,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"piY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
 "pju" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -28027,6 +27920,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central/aft)
+"pqb" = (
+/obj/machinery/computer/station_alert,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "prj" = (
 /obj/structure/bed/dogbed/mcgriff,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
@@ -28065,6 +27963,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"psK" = (
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "ptd" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/table/glass,
@@ -28415,14 +28318,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
-"pGu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	req_access_txt = "31"
-	},
-/turf/open/floor/plating,
-/area/cargo/office)
 "pGw" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/directional/north{
@@ -28452,6 +28347,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
+"pId" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "pIx" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -28594,6 +28495,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"pMS" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "pMY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -28630,12 +28536,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"pOi" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "pOu" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -28817,6 +28717,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pUD" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "pUF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
@@ -28860,12 +28764,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"pVR" = (
-/obj/machinery/computer/security,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "pWg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -28909,6 +28807,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pXG" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/science/central)
 "pXH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/neon/simple/purple,
@@ -29191,6 +29092,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"qhe" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "qhj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29468,6 +29375,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"qqp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/cargo/office)
 "qqz" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -29486,10 +29397,6 @@
 /obj/item/grenade/barrier,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"qro" = (
-/obj/structure/mopbucket,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "qrQ" = (
 /obj/machinery/button/door/directional/north{
 	id = "Prosecution1";
@@ -29753,11 +29660,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"qAD" = (
-/obj/machinery/computer/station_alert,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "qAZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/directional/north,
@@ -30031,6 +29933,11 @@
 	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
 /area/maintenance/port/fore)
+"qHz" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "qHD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30357,6 +30264,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"qQf" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "qQj" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
@@ -30390,10 +30306,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"qSc" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "qSj" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage)
@@ -30473,18 +30385,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
-"qVS" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
 "qWk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -30959,6 +30859,11 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"rkH" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "rkX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -31014,15 +30919,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"rmg" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/door_timer{
-	id = "cargocell";
-	name = "Cargo Cell";
-	pixel_x = -32
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "rms" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -31161,6 +31057,22 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/science/genetics)
+"rqi" = (
+/obj/structure/table,
+/obj/machinery/button/door/directional/east{
+	id = "celock";
+	name = "CE Office Lockdown Button";
+	pixel_x = 40;
+	req_access_txt = "56"
+	},
+/obj/item/stamp/denied,
+/obj/item/stamp/ce{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "rqu" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
@@ -31332,6 +31244,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"ruO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "ruZ" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/disposal/bin,
@@ -31457,6 +31375,14 @@
 "ryF" = (
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/project)
+"ryJ" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Cargo";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "ryT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -31557,6 +31483,14 @@
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"rBE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	req_access_txt = "31"
+	},
+/turf/open/floor/plating,
+/area/cargo/office)
 "rBG" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
@@ -32568,11 +32502,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"rYk" = (
-/obj/structure/cable,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/cargo/office)
 "rYp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -32646,6 +32575,13 @@
 	dir = 1
 	},
 /area/construction/mining/aux_base)
+"rZT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "rZW" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -32670,12 +32606,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"sah" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "say" = (
 /obj/effect/mob_spawn/corpse/human/assistant,
 /turf/open/floor/plating{
@@ -32737,6 +32667,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"scX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/office)
 "scZ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -32831,6 +32767,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"seP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "seQ" = (
 /obj/item/radio/intercom/prison/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -32974,6 +32916,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"skK" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "skL" = (
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 8
@@ -33329,6 +33275,15 @@
 	},
 /turf/open/floor/carpet,
 /area/security/courtroom)
+"ssg" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "ssh" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "73"
@@ -33350,6 +33305,12 @@
 /obj/structure/easel,
 /turf/open/floor/iron,
 /area/security/prison)
+"ssp" = (
+/obj/machinery/computer/department_orders/engineering{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "ssv" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood,
@@ -33385,13 +33346,6 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
-"ssU" = (
-/obj/structure/table,
-/obj/item/paper_bin/carbon,
-/obj/item/paper/monitorkey,
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
 "stc" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/half{
@@ -33583,6 +33537,11 @@
 	dir = 8
 	},
 /area/service/chapel)
+"sxk" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "sxz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -33734,6 +33693,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"sDD" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "sDK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33839,6 +33804,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"sHx" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "sHA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -34133,12 +34106,6 @@
 /obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
 /area/cargo/office)
-"sSl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "sSq" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
@@ -34195,6 +34162,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"sTc" = (
+/obj/structure/mopbucket,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "sTk" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -34220,21 +34191,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"sTL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "mechbay";
-	name = "Mech Bay Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/robotics/mechbay)
 "sTO" = (
 /obj/structure/cable,
 /obj/machinery/disposal/bin,
@@ -34366,6 +34322,10 @@
 "sXj" = (
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
+"sXz" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/main)
 "sXL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -34640,6 +34600,10 @@
 	dir = 4
 	},
 /area/medical/treatment_center)
+"teM" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "tff" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
@@ -34909,6 +34873,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
+"tmc" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "tmr" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -34916,17 +34884,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"tmt" = (
-/obj/machinery/door_timer{
-	id = "engcell";
-	name = "Engineering Cell";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "tmH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35748,15 +35705,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
-"tGH" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "tHH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -35974,6 +35922,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"tOZ" = (
+/obj/machinery/disposal/delivery_chute{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/cargo/sorting)
 "tPf" = (
 /obj/effect/turf_decal/tile/green/anticorner{
 	dir = 1
@@ -36247,13 +36201,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"tUL" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "tUT" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -36461,6 +36408,11 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"ual" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "uau" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/red{
@@ -36692,6 +36644,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ueb" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "uel" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -37395,6 +37353,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"usd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "ush" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -37484,14 +37448,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
-"utC" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "uua" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -37517,6 +37473,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"uuP" = (
+/obj/machinery/computer/apc_control{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/command/heads_quarters/ce)
 "uuQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
@@ -37565,13 +37530,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
-"uvW" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "uwg" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -38739,10 +38697,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"uVz" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "uVI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
@@ -38798,6 +38752,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"uWE" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "uWG" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -38815,13 +38781,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"uXd" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "uXf" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38845,12 +38804,6 @@
 "uXr" = (
 /turf/closed/wall,
 /area/science/breakroom)
-"uXs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
 "uXE" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -38924,11 +38877,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"uZy" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "uZY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -39004,6 +38952,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vcm" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "vcR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39147,12 +39099,6 @@
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
-"veR" = (
-/obj/machinery/computer/department_orders/engineering{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "vfx" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/chair/pew/left,
@@ -39322,6 +39268,17 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/interrogation)
+"vil" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Engineering";
+	req_access_txt = "63"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "vio" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/closed/wall,
@@ -39576,11 +39533,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"vpc" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/captain)
 "vpg" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -40061,12 +40013,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"vyA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/security/checkpoint/supply)
 "vyD" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -40077,6 +40023,14 @@
 /obj/item/storage/box/disks,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"vzg" = (
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "vzl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -40201,6 +40155,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"vBk" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "vBp" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -40265,11 +40227,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
-"vDA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "vDD" = (
 /obj/structure/bed/dogbed/lia,
 /mob/living/simple_animal/hostile/carp/lia,
@@ -40312,17 +40269,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
-"vEp" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
-"vEE" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "vEK" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -40358,6 +40304,13 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
+"vFC" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "vFG" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
@@ -40377,12 +40330,6 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
-"vHe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "vHz" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -40456,6 +40403,11 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"vJB" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "vJE" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -40466,6 +40418,13 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"vJJ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "vJO" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -40654,14 +40613,6 @@
 /obj/item/trash/energybar,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vNo" = (
-/obj/structure/table,
-/obj/item/toy/figure/ce,
-/obj/item/storage/box/matches{
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
 "vNO" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/blue{
@@ -40694,6 +40645,10 @@
 /obj/item/paper,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"vNP" = (
+/obj/effect/spawner/random/clothing/bowler_or_that,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vOd" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -40815,6 +40770,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"vQV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "vQY" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/command_all,
@@ -41161,21 +41125,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vZF" = (
-/obj/structure/table,
-/obj/item/cartridge/engineering{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 3
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
 "vZI" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -41370,9 +41319,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"wcK" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/central)
 "wcP" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -41408,6 +41354,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"wdV" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "wdY" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -41497,14 +41452,21 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
-"wft" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "wfu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/service/bar)
+"wfw" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/mop,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "wga" = (
 /turf/open/floor/iron/smooth,
 /area/security/warden)
@@ -41714,6 +41676,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"wmv" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/hardhat/red,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "wmO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -42019,6 +41988,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/bridge)
+"wvt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "wvu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -42065,10 +42040,6 @@
 	dir = 8
 	},
 /area/service/chapel)
-"wvO" = (
-/obj/effect/spawner/random/clothing/bowler_or_that,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "wvS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -42148,12 +42119,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"wxh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "wxl" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -42484,13 +42449,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"wCj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron,
-/area/engineering/main)
 "wCu" = (
 /obj/item/trash/boritos,
 /obj/effect/mob_spawn/corpse/human/assistant,
@@ -42534,6 +42492,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"wCQ" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "wCZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -42641,6 +42606,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"wFw" = (
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "wFB" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
@@ -42671,6 +42639,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wGB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "wGP" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -42883,6 +42856,21 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"wLJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mechbay";
+	name = "Mech Bay Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/robotics/mechbay)
 "wLT" = (
 /obj/item/flashlight,
 /obj/item/flashlight,
@@ -43084,15 +43072,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"wRv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "celock";
-	name = "CE Office Lockdown Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
+"wRO" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/command/heads_quarters/ce)
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "wRU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -43222,10 +43205,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"wVp" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/engineering/main)
 "wVx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -43450,16 +43429,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"xcQ" = (
-/obj/structure/table,
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
-"xcZ" = (
-/obj/machinery/disposal/delivery_chute{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/cargo/sorting)
+"xcP" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/captain)
 "xda" = (
 /obj/structure/table/wood,
 /obj/item/food/burger/corgi,
@@ -43691,11 +43665,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
-"xid" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "xij" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science/research)
@@ -44085,6 +44054,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
+"xuR" = (
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/coldroom)
 "xvl" = (
 /obj/machinery/duct,
 /turf/open/floor/plastic,
@@ -44266,6 +44239,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"xBb" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/science/research)
 "xBh" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1
@@ -44374,6 +44357,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
+"xFa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "xFv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -44594,6 +44583,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"xKt" = (
+/obj/machinery/door/airlock/mining{
+	name = "Cargo Bay";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/cargo/office)
 "xKy" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Core";
@@ -44710,6 +44710,10 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"xND" = (
+/obj/structure/closet/mini_fridge,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xNF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -45033,6 +45037,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"xTD" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "xTI" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;28;35"
@@ -45303,13 +45316,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"xYV" = (
-/obj/machinery/door/morgue{
-	name = "Mass Driver";
-	req_access_txt = "27"
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "xYW" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -45819,12 +45825,6 @@
 "ykr" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"ykD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "ylh" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -62997,7 +62997,7 @@ kiu
 hNG
 aJV
 xYW
-eGg
+vQV
 cqb
 rSQ
 sQG
@@ -63798,7 +63798,7 @@ wqG
 nrd
 ykr
 sZC
-uZy
+pcK
 mgu
 mgu
 vlD
@@ -66623,7 +66623,7 @@ hXq
 hXq
 hXq
 hXq
-paO
+wGB
 sZC
 orr
 gCS
@@ -67363,10 +67363,10 @@ bEh
 bEh
 bEh
 ovP
-xid
-fWW
+rkH
+bmj
 bYz
-wcK
+pXG
 uXi
 tLO
 sHa
@@ -67623,7 +67623,7 @@ mNf
 bYz
 vBc
 bYz
-wcK
+pXG
 vlK
 wcs
 xtk
@@ -67880,7 +67880,7 @@ sfa
 nkJ
 dDP
 bYz
-wcK
+pXG
 hab
 qeC
 eDr
@@ -68135,9 +68135,9 @@ kuZ
 fEd
 sfa
 nkJ
-hRi
+qHz
 bYz
-wcK
+pXG
 vuq
 vhv
 nnF
@@ -68392,9 +68392,9 @@ kuZ
 fEd
 sfa
 nkJ
-hRi
+qHz
 bZf
-wcK
+pXG
 vXJ
 nja
 vXJ
@@ -68645,13 +68645,13 @@ mrW
 sEP
 fRX
 cCO
-mTB
+iCM
 pHa
 mTT
 nkJ
 hSl
 bZf
-wcK
+pXG
 fJK
 vhv
 vhv
@@ -68908,7 +68908,7 @@ sfa
 vIy
 hSl
 bZf
-wcK
+pXG
 mTr
 xtk
 pXH
@@ -69160,12 +69160,12 @@ eCY
 abG
 kuK
 sEP
-btm
+cww
 sfa
 vIy
 vdi
 bZf
-wcK
+pXG
 mTE
 nar
 noe
@@ -69417,12 +69417,12 @@ lcI
 jqb
 nxR
 tVW
-bEP
+hnr
 sfa
-fWW
+bmj
 mvG
 bZf
-wcK
+pXG
 tji
 naD
 noy
@@ -69673,13 +69673,13 @@ sfa
 sfa
 sfa
 sfa
-vEp
-jeU
+vJB
+wRO
 sfa
-fWW
-uVz
+bmj
+mTK
 bZf
-wcK
+pXG
 vXL
 fWI
 gHG
@@ -69933,10 +69933,10 @@ sfa
 sfa
 sfa
 sfa
-fWW
+bmj
 mvG
 bZf
-wcK
+pXG
 thy
 xtk
 fqj
@@ -70190,10 +70190,10 @@ sUb
 ukm
 ukm
 sfa
-fWW
+bmj
 hSl
 bZf
-wcK
+pXG
 gdq
 xtk
 xac
@@ -70447,18 +70447,18 @@ bvL
 bvL
 bvL
 sfa
-fWW
+bmj
 hSl
 bZf
-wcK
-wcK
-wcK
-wcK
-wcK
-wcK
-wcK
-wcK
-wcK
+pXG
+pXG
+pXG
+pXG
+pXG
+pXG
+pXG
+pXG
+pXG
 rXm
 agu
 rFs
@@ -70963,16 +70963,16 @@ sfa
 sfa
 eZy
 bPR
-fWW
+bmj
 lVr
-fWW
-wcK
-wcK
-wcK
-wcK
+bmj
+pXG
+pXG
+pXG
+pXG
 nRR
-wcK
-wcK
+pXG
+pXG
 pci
 xCL
 oFN
@@ -71223,7 +71223,7 @@ hSl
 hSl
 hSl
 hSl
-wcK
+pXG
 gkd
 bWl
 qZl
@@ -72036,10 +72036,10 @@ ybf
 lMU
 nSZ
 ybf
-kyg
-kyg
-kyg
-kyg
+wFw
+wFw
+wFw
+wFw
 ybf
 lpN
 tCT
@@ -72265,7 +72265,7 @@ xij
 cuF
 xij
 qpz
-gWx
+xBb
 xij
 xij
 xij
@@ -72289,7 +72289,7 @@ vdG
 lDe
 ybf
 mFk
-kyg
+wFw
 lMU
 nWT
 ybf
@@ -72545,8 +72545,8 @@ kEY
 kEY
 lDo
 ybf
-kyg
-kyg
+wFw
+wFw
 lMU
 ybf
 ybf
@@ -72554,7 +72554,7 @@ ybf
 ybf
 ybf
 ybf
-jYM
+hFO
 vjJ
 xQY
 umW
@@ -72742,7 +72742,7 @@ meC
 spf
 igx
 cGm
-wCj
+npC
 yaU
 gmF
 vov
@@ -72803,15 +72803,15 @@ uMm
 kLY
 ybf
 mMO
-kyg
+wFw
 lMU
 ofS
 vYO
 wSK
 xda
 ybf
-kyg
-kyg
+wFw
+wFw
 vjJ
 xQY
 unJ
@@ -72999,7 +72999,7 @@ gzV
 xRT
 vME
 cGm
-bpP
+wCQ
 yaU
 veB
 fdu
@@ -73060,7 +73060,7 @@ hpn
 hpn
 ybf
 ybf
-kyg
+wFw
 lMU
 ybf
 oSh
@@ -73256,7 +73256,7 @@ meC
 spf
 vME
 cGm
-bpP
+wCQ
 yaU
 qNl
 gzx
@@ -73574,14 +73574,14 @@ pYM
 pYM
 lRW
 ybf
-kyg
+wFw
 lMU
 ybf
 oUA
 wST
 qOc
 ybf
-kyg
+wFw
 ybf
 vjJ
 xQY
@@ -73838,7 +73838,7 @@ ybf
 ybf
 qOv
 ybf
-kyg
+wFw
 ybf
 vjJ
 xQY
@@ -74090,10 +74090,10 @@ vvi
 vKH
 vYt
 ikJ
-jYM
+hFO
 ybf
 pfu
-kyg
+wFw
 ybf
 shp
 ybf
@@ -74288,7 +74288,7 @@ gKQ
 hDO
 hDO
 hDO
-veR
+ssp
 oHA
 oCI
 gXo
@@ -74350,9 +74350,9 @@ wka
 qFQ
 ybf
 bQx
-kyg
-kyg
-kyg
+wFw
+wFw
+wFw
 ybf
 trU
 xQY
@@ -74835,8 +74835,8 @@ nbh
 nbh
 uXE
 uXE
-sTL
-fpr
+wLJ
+kxU
 uXE
 uXE
 jkT
@@ -74859,7 +74859,7 @@ pYM
 pYM
 uaD
 ybf
-kyg
+wFw
 eqU
 eqU
 eqU
@@ -75360,7 +75360,7 @@ vwp
 vwp
 vwp
 vwp
-nHs
+hST
 vwp
 vUK
 tsC
@@ -75375,7 +75375,7 @@ sHl
 ybf
 bQx
 xJy
-kyg
+wFw
 oUM
 xQY
 qQq
@@ -75568,12 +75568,12 @@ pEK
 aQb
 vHz
 xIF
-qVS
-ssU
+uWE
+juO
 hSp
 hSp
-wVp
-aot
+sXz
+iHC
 oHA
 hZl
 jQP
@@ -75600,16 +75600,16 @@ kNM
 nYv
 etF
 xkq
-amn
+idB
 ljd
-amn
-amn
-amn
-amn
-amn
+idB
+idB
+idB
+idB
+idB
 hgJ
-amn
-amn
+idB
+idB
 kYH
 xyU
 crc
@@ -75631,7 +75631,7 @@ csH
 csH
 ybf
 mYj
-kyg
+wFw
 ols
 ndG
 xQY
@@ -75640,7 +75640,7 @@ cZb
 hny
 xQY
 uVS
-nVb
+skK
 xQY
 uNR
 usm
@@ -75825,10 +75825,10 @@ pEK
 iMF
 vZM
 xOu
-vZF
-vNo
-nZt
-wRv
+hRw
+iqe
+mQE
+bYX
 vME
 ptq
 oHA
@@ -75888,12 +75888,12 @@ bzc
 csH
 ybf
 mgP
-kyg
-kyg
-nVb
+wFw
+wFw
+skK
 xQY
 qYh
-kyg
+wFw
 slR
 rYp
 uVS
@@ -76082,10 +76082,10 @@ pEK
 aSy
 nXR
 xVQ
-bnX
-clH
-mMJ
-wRv
+rqi
+mdP
+kUz
+bYX
 vME
 ptq
 bGx
@@ -76339,11 +76339,11 @@ pEK
 uSa
 nXR
 xVQ
-xcQ
+fDI
 flJ
-hjU
-wRv
-kJP
+uuP
+bYX
+kkt
 ptq
 ptq
 lvO
@@ -77365,8 +77365,8 @@ aui
 ira
 rff
 wgC
-meC
-meC
+xOw
+xOw
 kIK
 tsQ
 lqm
@@ -77417,7 +77417,7 @@ sAG
 goK
 lCt
 nAn
-oOD
+vJJ
 vUK
 xyU
 xSR
@@ -77622,8 +77622,8 @@ vtK
 eJY
 jKE
 wgC
-meC
-meC
+xOw
+xOw
 kIK
 tsQ
 mMY
@@ -77879,8 +77879,8 @@ mlb
 awq
 wgC
 wgC
-meC
-meC
+xOw
+xOw
 kIK
 nuI
 xUc
@@ -78135,13 +78135,13 @@ wgC
 wgC
 wgC
 wgC
-meC
-meC
-meC
+xOw
+xOw
+xOw
 kIK
-qAD
+pqb
 iCW
-tmt
+eSz
 kIK
 kIK
 aqa
@@ -78384,23 +78384,23 @@ xOw
 xOw
 xOw
 xOw
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
+xOw
 kIK
-pVR
-oNU
+lIh
+ssg
 iCW
 iCW
-gLw
+vil
 aqa
 tYo
 bDy
@@ -78653,9 +78653,9 @@ meC
 meC
 meC
 kIK
-haR
-cmr
-vEE
+iDN
+vFC
+kRc
 oKX
 kIK
 yaQ
@@ -78937,8 +78937,8 @@ nzy
 nzy
 nzy
 nzy
-cQu
-eYC
+dql
+ojW
 hzS
 ays
 oCv
@@ -80993,7 +80993,7 @@ rZW
 uXP
 wux
 xNK
-wft
+jtV
 dFe
 hzS
 qpX
@@ -81224,9 +81224,9 @@ gOt
 tmr
 hUA
 iBF
-eIs
+hAx
 ofK
-eiL
+qqp
 pJe
 rRb
 ybZ
@@ -81481,13 +81481,13 @@ wkC
 ybb
 tBW
 djC
-lgN
+lFj
 rRb
 rRb
 pJe
 rRb
 rcR
-pGu
+rBE
 uXW
 nYv
 nYv
@@ -81736,13 +81736,13 @@ urm
 uXf
 bAG
 mCS
-gYj
+xKt
 uRv
 wGQ
 wGQ
 wGQ
 pJe
-oXH
+scX
 oXr
 rXF
 nsb
@@ -81997,7 +81997,7 @@ hUA
 uRI
 ogr
 eJL
-rYk
+itz
 rRb
 rRb
 rRb
@@ -82259,9 +82259,9 @@ muW
 muW
 itF
 lpQ
-tUL
-ets
-ets
+dfa
+nlF
+nlF
 qkn
 itE
 bvV
@@ -82513,12 +82513,12 @@ hUA
 hUA
 hUA
 hUA
-bek
+dwK
 hJO
 hJO
 lxE
-hWC
-mtn
+cHi
+eyO
 xpO
 wuJ
 nYv
@@ -82548,7 +82548,7 @@ irs
 irs
 xsz
 irs
-mNB
+meD
 irs
 pMJ
 pMJ
@@ -82764,12 +82764,12 @@ laX
 vdZ
 uiY
 yiO
-iBw
+ryJ
 vbn
-hMN
+teM
 kaE
 vbn
-rmg
+nVG
 iKl
 uqs
 iKl
@@ -83022,7 +83022,7 @@ vgB
 hWD
 hWD
 jda
-vyA
+wvt
 vbn
 hix
 vbn
@@ -83035,7 +83035,7 @@ vdE
 oee
 sQJ
 vdE
-fLk
+sxk
 mBf
 xPg
 qwq
@@ -83280,14 +83280,14 @@ gbI
 kAs
 jda
 jda
-gqH
-dfu
-fXL
-lLK
+vzg
+mEx
+sDD
+lmf
 iKl
-sah
-jfp
-sah
+eRt
+aKs
+eRt
 vdE
 sQJ
 sQJ
@@ -83793,7 +83793,7 @@ xIH
 lzH
 lzH
 lzH
-muM
+giH
 sQJ
 sQJ
 sQJ
@@ -83818,9 +83818,9 @@ oCe
 oCe
 oCe
 oCe
-iCH
+xTD
 weB
-vHe
+ueb
 nYv
 ojk
 oYo
@@ -84053,7 +84053,7 @@ iRD
 vdE
 sQJ
 sQJ
-oEZ
+xND
 vdE
 vdE
 vdE
@@ -84068,8 +84068,8 @@ mBf
 mIG
 oCe
 mlr
-cbU
-vHe
+qQf
+ueb
 nYv
 nYv
 wtY
@@ -84306,16 +84306,16 @@ uAP
 iqb
 iqb
 iqb
-xcZ
+tOZ
 vdE
 sQJ
 sQJ
-wvO
+vNP
 vdE
 cmZ
 kVH
 cmZ
-iQH
+lQJ
 kVH
 cmZ
 cmZ
@@ -84586,7 +84586,7 @@ vBM
 qeX
 nYv
 nYv
-sSl
+hth
 nYv
 nYv
 bwY
@@ -85083,7 +85083,7 @@ lVP
 lVP
 lVP
 vdE
-eRA
+wdV
 cmZ
 cmZ
 gsn
@@ -85138,8 +85138,8 @@ iur
 pUC
 qOf
 qKw
-vDA
-vDA
+iEN
+iEN
 qKw
 qKw
 sgR
@@ -85340,7 +85340,7 @@ vdE
 gjD
 vdE
 vdE
-oJM
+sHx
 nNG
 nNG
 mEn
@@ -85395,7 +85395,7 @@ iur
 vXU
 mKo
 qKw
-vDA
+iEN
 nri
 usZ
 rTb
@@ -85909,7 +85909,7 @@ iur
 qEz
 qKw
 rbE
-vDA
+iEN
 rzT
 iur
 rTe
@@ -86166,7 +86166,7 @@ iur
 dNB
 qKw
 qKw
-vDA
+iEN
 czb
 iur
 qKw
@@ -86423,7 +86423,7 @@ iur
 iur
 iur
 qKw
-vDA
+iEN
 rAf
 iur
 icT
@@ -86676,11 +86676,11 @@ ycI
 ycI
 xOw
 iur
-gyJ
-wxh
+phQ
+xFa
 iur
 iur
-vDA
+iEN
 iur
 iur
 bZp
@@ -86933,11 +86933,11 @@ iJa
 yaG
 xOw
 jXz
-oXV
-vDA
-tGH
-vDA
-vDA
+wmv
+iEN
+mgw
+iEN
+iEN
 qKw
 iur
 iur
@@ -87190,11 +87190,11 @@ qta
 yaG
 xOw
 iur
-qSc
-dna
+tmc
+seP
 iur
 qKw
-vDA
+iEN
 qKw
 iur
 meC
@@ -87450,8 +87450,8 @@ iur
 iur
 iur
 iur
-vDA
-vDA
+iEN
+iEN
 vXU
 iur
 meC
@@ -87704,10 +87704,10 @@ lUs
 yaG
 xOw
 iur
-utC
-fpe
+vBk
+wfw
 iur
-vDA
+iEN
 iur
 iur
 iur
@@ -87906,7 +87906,7 @@ pxw
 wBF
 wCG
 hEC
-fCW
+aGr
 rvZ
 ikf
 vjo
@@ -87961,10 +87961,10 @@ yaG
 yaG
 xOw
 jXz
-cxj
-ibo
-tGH
-vDA
+nOH
+mHl
+mgw
+iEN
 iur
 meC
 meC
@@ -88166,7 +88166,7 @@ hEC
 rvZ
 rvZ
 qOA
-mZI
+xuR
 aVI
 rvZ
 anB
@@ -88208,7 +88208,7 @@ bfy
 uTD
 yhF
 rsm
-vpc
+xcP
 yaG
 uie
 wnr
@@ -88218,8 +88218,8 @@ xOw
 xOw
 xOw
 iur
-qro
-jUd
+sTc
+iva
 iur
 qKw
 iur
@@ -88978,14 +88978,14 @@ hRI
 xXV
 iBd
 xXV
-ezo
+aUS
 xAv
 yaG
 yaG
 yaG
 yaG
-hNf
-hNf
+cgo
+cgo
 xOw
 meC
 meC
@@ -89214,7 +89214,7 @@ bPB
 bcA
 ljp
 tTz
-cNF
+ual
 bFl
 yjs
 qyU
@@ -89237,12 +89237,12 @@ hCP
 hCP
 dLV
 jWU
-nfi
-ykD
-eBi
-jSQ
-nKs
-hNf
+iFW
+usd
+jwz
+pMS
+vcm
+cgo
 xOw
 meC
 meC
@@ -89495,11 +89495,11 @@ xHl
 glK
 jYo
 yiq
-gkF
-lEG
-kth
-uXd
-hNf
+djJ
+fCN
+ozv
+duF
+cgo
 xOw
 meC
 meC
@@ -89752,11 +89752,11 @@ bpn
 bpf
 bpn
 bpn
-hIX
-uvW
-pOi
-epD
-hNf
+psK
+cLT
+qhe
+pUD
+cgo
 xOw
 meC
 meC
@@ -90009,11 +90009,11 @@ iMq
 eAD
 kel
 bpn
-hNf
-hNf
-hNf
-hNf
-hNf
+cgo
+cgo
+cgo
+cgo
+cgo
 xOw
 meC
 meC
@@ -90758,7 +90758,7 @@ bgK
 jGO
 yjs
 wKe
-eLS
+mvz
 uwA
 xOw
 xSQ
@@ -91786,7 +91786,7 @@ aCu
 jGO
 yjs
 wKe
-eLS
+mvz
 uwA
 meC
 xOw
@@ -93843,7 +93843,7 @@ tWO
 tWO
 tWO
 dPu
-awc
+khO
 gvh
 lil
 vgC
@@ -96935,7 +96935,7 @@ qMW
 qMW
 oAf
 vWT
-piY
+ruO
 gvh
 wXw
 wXw
@@ -97451,8 +97451,8 @@ meC
 caa
 iRe
 prs
-uXs
-iEY
+pId
+rZT
 pBD
 cql
 sHh
@@ -97711,7 +97711,7 @@ caa
 caa
 caa
 caa
-xYV
+hPH
 caa
 caa
 caa

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -146,6 +146,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
+"afB" = (
+/obj/machinery/door/morgue{
+	name = "Mass Driver";
+	req_access_txt = "27"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "afW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -368,8 +375,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "anB" = (
-/obj/machinery/deepfryer,
 /obj/machinery/light/directional/north,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "anN" = (
@@ -478,6 +485,15 @@
 /obj/structure/easel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aqP" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "arf" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -619,9 +635,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"avn" = (
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "awl" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -1119,14 +1132,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"aJQ" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue half"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "aJV" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/science/xenobiology)
@@ -1568,6 +1573,12 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"bcw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bcA" = (
 /obj/machinery/door/airlock{
 	name = "Service Lathe Access";
@@ -2302,13 +2313,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/project)
-"buB" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "bvC" = (
 /obj/structure/chair{
 	dir = 8
@@ -2436,10 +2440,14 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bAZ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bBc" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -2481,11 +2489,7 @@
 /area/service/chapel/office)
 "bCL" = (
 /obj/structure/cable,
-/obj/structure/sink{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = -8
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "bCR" = (
@@ -2576,6 +2580,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/science/genetics)
+"bFe" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "bFl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2870,12 +2880,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/project)
 "bQO" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bQX" = (
@@ -3065,11 +3071,11 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "bXd" = (
-/obj/machinery/disposal/bin{
-	name = "Space Disposal"
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
+	},
+/obj/machinery/disposal/bin{
+	name = "Mail Unit"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
@@ -3258,6 +3264,14 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"cbK" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ccf" = (
 /obj/machinery/air_sensor/atmos/plasma_tank,
 /turf/open/floor/engine/plasma,
@@ -3497,6 +3511,10 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"ckb" = (
+/obj/structure/mopbucket,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "cko" = (
 /obj/structure/reflector/single,
 /obj/effect/turf_decal/siding/yellow{
@@ -3526,9 +3544,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "clx" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
+	},
+/obj/machinery/disposal/bin{
+	name = "Space Disposal"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
@@ -3717,6 +3737,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"crt" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "crV" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -4047,12 +4071,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
-"cCe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
 "cCl" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/tequila{
@@ -4121,6 +4139,11 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
+"cCS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "cDi" = (
 /obj/machinery/power/emitter,
 /obj/structure/cable,
@@ -4484,13 +4507,6 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/iron,
 /area/security/processing)
-"cQc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "cQr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
@@ -4528,6 +4544,13 @@
 	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
 /area/maintenance/port/fore)
+"cRl" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/hardhat/red,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "cRr" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
@@ -4685,6 +4708,15 @@
 	dir = 1
 	},
 /area/science/research)
+"cUR" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "cUW" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -4747,6 +4779,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"cVG" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "cVW" = (
 /obj/structure/reflector/double/anchored{
 	dir = 6
@@ -4844,9 +4881,12 @@
 	},
 /area/science/research)
 "cYK" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cZb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
 	dir = 4
@@ -4879,7 +4919,8 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "cZD" = (
-/obj/structure/closet/firecloset,
+/obj/structure/table,
+/obj/item/pinpointer/wayfinding,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cZF" = (
@@ -5072,7 +5113,7 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "dfS" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dgk" = (
@@ -5319,13 +5360,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"dmG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "dmH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -5442,6 +5476,9 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
+"dqW" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "drb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
 /turf/open/floor/engine/n2o,
@@ -6250,13 +6287,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"dQn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
 "dQu" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -6688,9 +6718,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "edN" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "edR" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -7071,6 +7102,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"ekO" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "ekX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -7201,11 +7236,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"emP" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "emQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/end,
 /obj/machinery/space_heater,
@@ -7700,10 +7730,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"eyQ" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "eyY" = (
 /obj/item/target/alien,
 /turf/open/floor/engine,
@@ -7969,6 +7995,13 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room)
+"eJf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "eJi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8116,6 +8149,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
+"eMi" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "eMl" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -8554,11 +8591,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fcP" = (
-/obj/structure/table,
-/obj/item/storage/fancy/candle_box,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fdm" = (
@@ -8831,6 +8867,15 @@
 "fkv" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
+"fkH" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "fkO" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -8883,6 +8928,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"fmd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "fmi" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -9683,10 +9733,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"fPB" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "fPS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -10310,10 +10356,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"giJ" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "gjm" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue/half{
@@ -11163,6 +11205,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gDQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "gDY" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/corner{
@@ -11373,11 +11420,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"gKq" = (
-/obj/effect/spawner/random/structure/table,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "gKG" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/iron,
@@ -11410,8 +11452,10 @@
 /area/service/bar)
 "gLy" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/trimline/neutral/line,
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
 "gLC" = (
@@ -11503,11 +11547,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
-"gQl" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "gQm" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -11755,10 +11794,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/lockers)
-"gYa" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "gYY" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
@@ -11846,9 +11881,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 10
+	},
+/obj/structure/closet{
+	name = "Evidence Closet"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
@@ -12126,12 +12163,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"hnA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "hnE" = (
 /obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
@@ -12207,10 +12238,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"hqV" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "hqY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/lattice,
@@ -13663,12 +13690,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/security/processing)
-"icS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "icT" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
@@ -14113,15 +14134,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"iox" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "ioH" = (
 /obj/structure/punching_bag,
 /obj/machinery/light/directional/north,
@@ -14316,20 +14328,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"isZ" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
-"itr" = (
-/obj/machinery/door/morgue{
-	name = "Mass Driver";
-	req_access_txt = "27"
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "itE" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cargo Lobby"
@@ -14809,13 +14807,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"iHu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "iHz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15903,6 +15894,7 @@
 	dir = 9;
 	name = "research purple"
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "jjN" = (
@@ -16074,6 +16066,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"jnV" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "joj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16211,6 +16207,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"jtW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "jtX" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -16405,7 +16405,7 @@
 /turf/open/floor/carpet/red,
 /area/service/lawoffice)
 "jAA" = (
-/obj/machinery/disposal/bin,
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "jBc" = (
@@ -16443,9 +16443,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"jBA" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "jBN" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/cyborg,
@@ -17209,10 +17206,11 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "jUt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "jUN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall,
@@ -17399,6 +17397,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"kaf" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "kah" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/grimy,
@@ -17640,6 +17645,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"kga" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "kgf" = (
 /obj/structure/chair{
 	dir = 8
@@ -17878,6 +17889,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"koa" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "kox" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -18226,6 +18241,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"kxL" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "kxS" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -18507,6 +18527,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"kGT" = (
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "kGU" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -18658,20 +18681,9 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "kLg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "mechbay";
-	name = "Mech Bay Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/robotics/mechbay)
+/obj/machinery/atmospherics/components/trinary/filter,
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "kLs" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Base Airlock"
@@ -19221,8 +19233,13 @@
 	color = "#990099";
 	name = "research purple"
 	},
-/obj/machinery/disposal/bin,
 /obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/ecto_sniffer{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/toy/figure/roboticist,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "kXJ" = (
@@ -19406,6 +19423,20 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
+"lbm" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "mechbay";
+	name = "Mech Bay Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/robotics/mechbay)
 "lbp" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -20134,12 +20165,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"luD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "luI" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -20272,6 +20297,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"lxM" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "lxT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20367,6 +20396,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"lAI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "lAP" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/clothing/mask/gas,
@@ -21163,6 +21199,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
+"lSO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "lSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21730,6 +21772,12 @@
 	icon_state = "wood-broken3"
 	},
 /area/service/abandoned_gambling_den)
+"mfi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "mfn" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -21781,12 +21829,11 @@
 /turf/closed/wall,
 /area/hallway/primary/port)
 "mgG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "mgL" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -22346,6 +22393,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"mwy" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "mwG" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -22862,6 +22914,9 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing)
+"mHn" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/science/central)
 "mHA" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
@@ -23246,6 +23301,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
+"mNT" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "mOc" = (
 /obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron/dark,
@@ -23759,10 +23818,12 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
 "nbd" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "nbe" = (
 /obj/structure/window/reinforced,
 /obj/item/kirbyplants{
@@ -23773,11 +23834,6 @@
 "nbh" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central/fore)
-"nbo" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "nbG" = (
 /obj/structure/window/reinforced,
 /obj/item/beacon,
@@ -23923,10 +23979,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/security/processing)
-"nfQ" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "nfU" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23955,11 +24007,6 @@
 /obj/machinery/processor,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"nhb" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "nhu" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 8
@@ -24084,12 +24131,6 @@
 "nlz" = (
 /turf/closed/wall,
 /area/service/hydroponics)
-"nmw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
 "nmS" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -24339,6 +24380,13 @@
 	dir = 4
 	},
 /area/medical/treatment_center)
+"ntz" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "ntE" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -24782,6 +24830,15 @@
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plating,
 /area/service/chapel/office)
+"nDW" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/extinguisher/mini,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "nEc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal/bin,
@@ -24802,15 +24859,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nER" = (
-/obj/structure/table,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/extinguisher/mini,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "nFs" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
@@ -24894,6 +24942,17 @@
 /obj/effect/landmark/secequipment,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"nHT" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/mop,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "nIj" = (
 /obj/structure/sign/warning/coldtemp,
 /turf/closed/wall,
@@ -25336,11 +25395,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "nWZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/coldroom)
 "nXg" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/vacuum/external{
@@ -25529,15 +25586,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/solars/port/fore)
 "obv" = (
-/obj/machinery/button/door/directional/east{
-	id = "mechbay";
-	name = "Mech Bay Shutters Control";
-	req_access_txt = "29"
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/science/robotics/mechbay)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "oby" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/disposal/bin,
@@ -25861,6 +25917,15 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
+"omE" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "omJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
@@ -26132,15 +26197,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
-"otc" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "otI" = (
 /obj/machinery/prisongate,
 /obj/machinery/door/firedoor,
@@ -26278,6 +26334,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"oyP" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "oyX" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -26470,11 +26529,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"oCk" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "oCr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
@@ -27388,6 +27442,21 @@
 "pbI" = (
 /turf/closed/wall,
 /area/security/prison/toilet)
+"pca" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mechbay";
+	name = "Mech Bay Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/robotics/mechbay)
 "pci" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/camera/directional/north{
@@ -27562,9 +27631,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 9
+	},
+/obj/structure/closet{
+	name = "Evidence Closet"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
@@ -27650,8 +27721,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/evidence,
 /obj/machinery/light/small/directional/north,
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
 "pjS" = (
@@ -27667,7 +27740,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/evidence,
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
 "pkG" = (
@@ -27686,9 +27761,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 5
+	},
+/obj/structure/closet{
+	name = "Evidence Closet"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
@@ -27938,8 +28015,7 @@
 /area/security/lockers)
 "ptM" = (
 /obj/machinery/light/directional/west,
-/obj/structure/table,
-/obj/item/pinpointer/wayfinding,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ptO" = (
@@ -28069,11 +28145,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pAH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "pBh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28248,15 +28319,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"pFX" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "pGa" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067";
@@ -28329,10 +28391,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"pJu" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "pJW" = (
 /obj/structure/table,
 /obj/item/toy/figure/warden{
@@ -28457,20 +28515,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"pMZ" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/mop,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "pNr" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
+"pNB" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/bridge)
 "pNC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/loading_area/red{
@@ -28531,10 +28581,6 @@
 	dir = 8
 	},
 /area/medical/treatment_center)
-"pPs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "pPt" = (
 /obj/effect/turf_decal/loading_area/red{
 	dir = 1
@@ -28726,9 +28772,13 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "pWg" = (
-/obj/machinery/atmospherics/components/trinary/filter,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "pWq" = (
 /obj/structure/closet/secure_closet/cytology,
 /obj/machinery/firealarm/directional/west,
@@ -28750,6 +28800,16 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
+"pWF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
+"pWG" = (
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "pWO" = (
 /turf/closed/indestructible/opshuttle,
 /area/science/test_area)
@@ -28843,14 +28903,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"pZt" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "pZL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29103,6 +29155,7 @@
 /area/engineering/engine_smes)
 "qhV" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "qid" = (
@@ -29306,13 +29359,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
-"qpD" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/head/hardhat/red,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "qpH" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics HFR Room";
@@ -29349,6 +29395,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"qql" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "qqz" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -29382,6 +29435,12 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
+"qsX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "qta" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
@@ -29636,12 +29695,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
-"qBn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "qBS" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -29953,6 +30006,7 @@
 	dir = 5;
 	name = "research purple"
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "qIu" = (
@@ -30064,11 +30118,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/security/processing)
-"qKE" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "qKS" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -30435,10 +30484,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"qXR" = (
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "qXY" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/barricade/wooden,
@@ -30495,6 +30540,10 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"qYT" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "qZl" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/window/reinforced,
@@ -30672,11 +30721,13 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "reV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "reW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -30806,9 +30857,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
-/obj/machinery/disposal/bin{
-	name = "Mail Unit"
-	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "rjS" = (
@@ -31527,6 +31576,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"rDB" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "rDO" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -31789,9 +31842,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
-"rJo" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/bridge)
 "rJG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
@@ -32428,10 +32478,6 @@
 "rXN" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"rXQ" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "rXV" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/roboticist,
@@ -32771,12 +32817,6 @@
 "shd" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
-"shj" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "shp" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/plasticflaps,
@@ -32790,9 +32830,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/patients_rooms)
-"shu" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/central)
 "shE" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
 /obj/structure/cable,
@@ -33050,17 +33087,12 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "sok" = (
-/obj/structure/table,
 /obj/item/clothing/glasses/welding,
 /obj/item/storage/belt/utility,
 /obj/item/clothing/head/welding,
 /obj/item/storage/belt/utility,
 /obj/item/clothing/head/welding,
-/obj/machinery/ecto_sniffer{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/toy/figure/roboticist,
+/obj/structure/rack,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "sol" = (
@@ -33510,11 +33542,6 @@
 	dir = 1
 	},
 /area/security/range)
-"szj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
 "szr" = (
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
@@ -33749,10 +33776,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
-"sIW" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "sJI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -33865,6 +33888,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"sMX" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "sNl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -33925,9 +33952,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "sPU" = (
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/coldroom)
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "sQm" = (
 /obj/structure/table,
 /obj/item/holosign_creator/robot_seat/restaurant,
@@ -34023,15 +34051,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/office)
-"sSn" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Radstorm Shelter"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "sSq" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
@@ -34157,11 +34176,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"sUO" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "sUZ" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -34884,15 +34898,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room)
-"too" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "toB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/security/prison/workout)
+"toT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "toX" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -34928,6 +34944,11 @@
 	dir = 10
 	},
 /area/command/gateway)
+"tqT" = (
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "tqY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34971,6 +34992,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"tsj" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "tsk" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -37161,11 +37187,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
-"upT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "upV" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 4
@@ -37415,6 +37436,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
+"uul" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue half"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "uuq" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -37607,10 +37636,6 @@
 /obj/item/clothing/glasses/sunglasses/big,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
-"uzf" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "uzC" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
@@ -39071,14 +39096,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "vgB" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/service/bar/atrium)
+/area/maintenance/department/electrical)
 "vgC" = (
 /obj/structure/bookcase,
 /obj/machinery/light/directional/west,
@@ -39384,12 +39404,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
-"vmn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "vmr" = (
 /obj/effect/wisp,
 /turf/open/floor/plating{
@@ -39872,6 +39886,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"vxk" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Radstorm Shelter"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "vxx" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/r_wall,
@@ -39899,13 +39922,10 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "vxF" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/service/bar/atrium)
+/area/maintenance/department/electrical)
 "vxR" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -40236,19 +40256,10 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "vHz" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "mechbay";
-	name = "Mech Bay Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/robotics/mechbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "vHL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -40321,17 +40332,9 @@
 	dir = 4;
 	name = "Medical blue corner"
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"vJw" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "vJE" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -40523,6 +40526,12 @@
 /obj/item/trash/energybar,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vNx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "vNO" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/blue{
@@ -40877,13 +40886,6 @@
 	},
 /turf/open/floor/grass,
 /area/science/genetics)
-"vWF" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "vWR" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/poster/contraband/random{
@@ -41363,6 +41365,11 @@
 	dir = 6
 	},
 /area/medical/treatment_center)
+"wgn" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "wgC" = (
 /turf/closed/wall/r_wall,
 /area/engineering/gravity_generator)
@@ -42107,9 +42114,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"wzs" = (
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "wzt" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Research Hallway - Server Access";
@@ -42744,6 +42748,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"wMt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "wMV" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -43214,6 +43224,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"wZC" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "wZJ" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "AI Core - North Outer";
@@ -44129,10 +44148,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "xDy" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/maintenance/department/electrical)
 "xDI" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -44295,15 +44316,6 @@
 "xHU" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
-"xIm" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "xIq" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -44939,9 +44951,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "xVQ" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "xVU" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -45107,10 +45119,6 @@
 "xYW" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"xYZ" = (
-/obj/structure/mopbucket,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "xZc" = (
 /turf/open/space/basic,
 /area/maintenance/department/medical/central)
@@ -45206,12 +45214,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"yaM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "yaQ" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -45607,9 +45609,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "yki" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "yko" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -58440,7 +58443,7 @@ wqG
 hPs
 wqG
 rSX
-hXq
+uGg
 iHA
 esD
 hXc
@@ -58697,7 +58700,7 @@ jSm
 ucv
 wqG
 quX
-hXq
+uGg
 pGw
 kNl
 kNl
@@ -58954,7 +58957,7 @@ uGg
 uGg
 qXY
 uGg
-hXq
+uGg
 oRi
 jwH
 cmt
@@ -62531,7 +62534,7 @@ oqP
 rhO
 rhO
 kNw
-dmk
+rhO
 dvv
 kiu
 aJV
@@ -63044,7 +63047,7 @@ rhO
 oqP
 rhO
 rhO
-bAZ
+woF
 bCL
 ebr
 ebr
@@ -63301,7 +63304,7 @@ rhO
 oqP
 rhO
 rhO
-bAZ
+woF
 dmk
 lpH
 lyK
@@ -63558,7 +63561,7 @@ rhO
 oqP
 rhO
 rhO
-bAZ
+woF
 dmk
 rhO
 rhO
@@ -63595,7 +63598,7 @@ wqG
 nrd
 ykr
 sZC
-emP
+mwy
 mgu
 mgu
 vlD
@@ -66420,7 +66423,7 @@ hXq
 hXq
 hXq
 hXq
-too
+cCS
 sZC
 orr
 gCS
@@ -67160,10 +67163,10 @@ bEh
 bEh
 bEh
 ovP
-oCk
-wzs
+yki
+dqW
 bYz
-shu
+mHn
 uXi
 tLO
 sHa
@@ -67420,7 +67423,7 @@ mNf
 bYz
 vBc
 bYz
-shu
+mHn
 vlK
 wcs
 xtk
@@ -67677,7 +67680,7 @@ sfa
 nkJ
 dDP
 bYz
-shu
+mHn
 hab
 qeC
 eDr
@@ -67932,9 +67935,9 @@ kuZ
 fEd
 sfa
 nkJ
-gQl
+tsj
 bYz
-shu
+mHn
 vuq
 vhv
 nnF
@@ -68168,7 +68171,7 @@ sgQ
 afY
 ble
 ble
-nWZ
+jUt
 ble
 ble
 lgE
@@ -68189,9 +68192,9 @@ kuZ
 fEd
 sfa
 nkJ
-gQl
+tsj
 bZf
-shu
+mHn
 vXJ
 nja
 vXJ
@@ -68424,9 +68427,9 @@ aQw
 sgQ
 blu
 ble
-nbd
-pWg
-reV
+edN
+kLg
+mgG
 ble
 ble
 cxy
@@ -68442,13 +68445,13 @@ mrW
 sEP
 fRX
 cCO
-yki
+vgB
 pHa
 mTT
 nkJ
 hSl
 bZf
-shu
+mHn
 fJK
 vhv
 vhv
@@ -68705,7 +68708,7 @@ sfa
 vIy
 hSl
 bZf
-shu
+mHn
 mTr
 xtk
 pXH
@@ -68957,12 +68960,12 @@ eCY
 abG
 kuK
 sEP
-szj
+vHz
 sfa
 vIy
 vdi
 bZf
-shu
+mHn
 mTE
 nar
 noe
@@ -69214,12 +69217,12 @@ lcI
 jqb
 nxR
 tVW
-iHu
+xDy
 sfa
-wzs
+dqW
 mvG
 bZf
-shu
+mHn
 tji
 naD
 noy
@@ -69470,13 +69473,13 @@ sfa
 sfa
 sfa
 sfa
-qKE
-eyQ
+vxF
+xVQ
 sfa
-wzs
-fPB
+dqW
+lxM
 bZf
-shu
+mHn
 vXL
 fWI
 gHG
@@ -69730,10 +69733,10 @@ sfa
 sfa
 sfa
 sfa
-wzs
+dqW
 mvG
 bZf
-shu
+mHn
 thy
 xtk
 fqj
@@ -69987,10 +69990,10 @@ sUb
 ukm
 ukm
 sfa
-wzs
+dqW
 hSl
 bZf
-shu
+mHn
 gdq
 xtk
 xac
@@ -70244,18 +70247,18 @@ bvL
 bvL
 bvL
 sfa
-wzs
+dqW
 hSl
 bZf
-shu
-shu
-shu
-shu
-shu
-shu
-shu
-shu
-shu
+mHn
+mHn
+mHn
+mHn
+mHn
+mHn
+mHn
+mHn
+mHn
 rXm
 agu
 rFs
@@ -70760,16 +70763,16 @@ sfa
 sfa
 eZy
 bPR
-wzs
+dqW
 lVr
-wzs
-shu
-shu
-shu
-shu
+dqW
+mHn
+mHn
+mHn
+mHn
 nRR
-shu
-shu
+mHn
+mHn
 pci
 xCL
 oFN
@@ -71020,7 +71023,7 @@ hSl
 hSl
 hSl
 hSl
-shu
+mHn
 gkd
 bWl
 qZl
@@ -71833,10 +71836,10 @@ ybf
 lMU
 nSZ
 ybf
-avn
-avn
-avn
-avn
+kGT
+kGT
+kGT
+kGT
 ybf
 lpN
 tCT
@@ -72086,7 +72089,7 @@ vdG
 lDe
 ybf
 mFk
-avn
+kGT
 lMU
 nWT
 ybf
@@ -72342,8 +72345,8 @@ kEY
 kEY
 lDo
 ybf
-avn
-avn
+kGT
+kGT
 lMU
 ybf
 ybf
@@ -72351,7 +72354,7 @@ ybf
 ybf
 ybf
 ybf
-hqV
+eMi
 vjJ
 xQY
 umW
@@ -72600,15 +72603,15 @@ uMm
 kLY
 ybf
 mMO
-avn
+kGT
 lMU
 ofS
 vYO
 wSK
 xda
 ybf
-avn
-avn
+kGT
+kGT
 vjJ
 xQY
 unJ
@@ -72857,7 +72860,7 @@ hpn
 hpn
 ybf
 ybf
-avn
+kGT
 lMU
 ybf
 oSh
@@ -73371,14 +73374,14 @@ pYM
 pYM
 lRW
 ybf
-avn
+kGT
 lMU
 ybf
 oUA
 wST
 qOc
 ybf
-avn
+kGT
 ybf
 vjJ
 xQY
@@ -73635,7 +73638,7 @@ ybf
 ybf
 qOv
 ybf
-avn
+kGT
 ybf
 vjJ
 xQY
@@ -73887,10 +73890,10 @@ vvi
 vKH
 vYt
 ikJ
-hqV
+eMi
 ybf
 pfu
-avn
+kGT
 ybf
 shp
 ybf
@@ -74147,9 +74150,9 @@ wka
 qFQ
 ybf
 bQx
-avn
-avn
-avn
+kGT
+kGT
+kGT
 ybf
 trU
 xQY
@@ -74632,9 +74635,9 @@ nbh
 nbh
 uXE
 uXE
-wpi
-wpi
-obv
+pca
+lbm
+uXE
 uXE
 jkT
 qzO
@@ -74656,7 +74659,7 @@ pYM
 pYM
 uaD
 ybf
-avn
+kGT
 eqU
 eqU
 eqU
@@ -74888,11 +74891,11 @@ xyU
 xyU
 xyU
 apd
-uXE
-kLg
-vHz
-uXE
-uXE
+xyU
+xyU
+xyU
+xyU
+xyU
 xyU
 pyZ
 cqE
@@ -75157,7 +75160,7 @@ vwp
 vwp
 vwp
 vwp
-dmG
+lAI
 vwp
 vUK
 tsC
@@ -75172,7 +75175,7 @@ sHl
 ybf
 bQx
 xJy
-avn
+kGT
 oUM
 xQY
 qQq
@@ -75397,16 +75400,16 @@ kNM
 nYv
 etF
 xkq
-aJQ
+uul
 ljd
-aJQ
-aJQ
-aJQ
-aJQ
-aJQ
+uul
+uul
+uul
+uul
+uul
 hgJ
-aJQ
-aJQ
+uul
+uul
 kYH
 xyU
 crc
@@ -75428,7 +75431,7 @@ csH
 csH
 ybf
 mYj
-avn
+kGT
 ols
 ndG
 xQY
@@ -75437,7 +75440,7 @@ cZb
 hny
 xQY
 uVS
-pJu
+mNT
 xQY
 uNR
 usm
@@ -75685,12 +75688,12 @@ bzc
 csH
 ybf
 mgP
-avn
-avn
-pJu
+kGT
+kGT
+mNT
 xQY
 qYh
-avn
+kGT
 slR
 rYp
 uVS
@@ -77214,7 +77217,7 @@ sAG
 goK
 lCt
 nAn
-buB
+qql
 vUK
 xyU
 xSR
@@ -77690,7 +77693,7 @@ vwQ
 uAm
 ipZ
 uAm
-cYK
+uAm
 wEK
 bvV
 jiF
@@ -78734,8 +78737,8 @@ nzy
 nzy
 nzy
 nzy
-nbo
-uzf
+cVG
+jnV
 hzS
 ays
 oCv
@@ -80790,7 +80793,7 @@ rZW
 uXP
 wux
 xNK
-rXQ
+rDB
 dFe
 hzS
 qpX
@@ -82345,7 +82348,7 @@ irs
 irs
 xsz
 irs
-cQc
+toT
 irs
 pMJ
 pMJ
@@ -82832,7 +82835,7 @@ rBl
 vdE
 vdE
 vdE
-xDy
+sPU
 mBf
 xPg
 qwq
@@ -83615,9 +83618,9 @@ oCe
 oCe
 oCe
 oCe
-vJw
+wZC
 weB
-hnA
+qsX
 nYv
 ojk
 oYo
@@ -83865,8 +83868,8 @@ mBf
 mIG
 oCe
 mlr
-xIm
-hnA
+cUR
+qsX
 nYv
 nYv
 wtY
@@ -84112,7 +84115,7 @@ vdE
 cmZ
 kVH
 cmZ
-vxF
+reV
 kVH
 cmZ
 cmZ
@@ -84383,7 +84386,7 @@ vBM
 qeX
 nYv
 nYv
-icS
+wMt
 nYv
 nYv
 bwY
@@ -84880,7 +84883,7 @@ lVP
 lVP
 lVP
 vdE
-vgB
+obv
 cmZ
 cmZ
 gsn
@@ -84935,8 +84938,8 @@ iur
 pUC
 qOf
 qKw
-upT
-upT
+gDQ
+gDQ
 qKw
 qKw
 sgR
@@ -85137,7 +85140,7 @@ vdE
 gjD
 vdE
 vdE
-cmZ
+pWg
 nNG
 nNG
 mEn
@@ -85192,7 +85195,7 @@ iur
 vXU
 mKo
 qKw
-upT
+gDQ
 nri
 usZ
 rTb
@@ -85706,7 +85709,7 @@ iur
 qEz
 qKw
 rbE
-upT
+gDQ
 rzT
 iur
 rTe
@@ -85963,7 +85966,7 @@ iur
 dNB
 qKw
 qKw
-upT
+gDQ
 czb
 iur
 qKw
@@ -86220,7 +86223,7 @@ iur
 iur
 iur
 qKw
-upT
+gDQ
 rAf
 iur
 icT
@@ -86403,10 +86406,10 @@ lVP
 lVP
 lVP
 lSf
+bAZ
+lVP
+lVP
 bQO
-lVP
-lVP
-jUt
 rbh
 lVP
 sQJ
@@ -86473,11 +86476,11 @@ ycI
 ycI
 xOw
 iur
-nER
-yaM
+nDW
+kga
 iur
 iur
-upT
+gDQ
 iur
 iur
 bZp
@@ -86681,8 +86684,8 @@ cxO
 aiT
 cxO
 cxO
-edN
-xVQ
+cxO
+cxO
 cJI
 aiT
 cxO
@@ -86730,11 +86733,11 @@ iJa
 yaG
 xOw
 jXz
-qpD
-upT
-otc
-upT
-upT
+cRl
+gDQ
+aqP
+gDQ
+gDQ
 qKw
 iur
 iur
@@ -86987,11 +86990,11 @@ qta
 yaG
 xOw
 iur
-nfQ
-qBn
+koa
+bcw
 iur
 qKw
-upT
+gDQ
 qKw
 iur
 meC
@@ -87247,8 +87250,8 @@ iur
 iur
 iur
 iur
-upT
-upT
+gDQ
+gDQ
 vXU
 iur
 meC
@@ -87501,10 +87504,10 @@ lUs
 yaG
 xOw
 iur
-pZt
-pMZ
+cbK
+nHT
 iur
-upT
+gDQ
 iur
 iur
 iur
@@ -87703,7 +87706,7 @@ pxw
 wBF
 wCG
 hEC
-cJI
+nbd
 rvZ
 ikf
 vjo
@@ -87758,10 +87761,10 @@ yaG
 yaG
 xOw
 jXz
-pPs
-pAH
-otc
-upT
+jtW
+fmd
+aqP
+gDQ
 iur
 meC
 meC
@@ -87963,7 +87966,7 @@ hEC
 rvZ
 rvZ
 qOA
-sPU
+nWZ
 aVI
 rvZ
 anB
@@ -88015,8 +88018,8 @@ xOw
 xOw
 xOw
 iur
-xYZ
-sIW
+ckb
+sMX
 iur
 qKw
 iur
@@ -88208,7 +88211,7 @@ vdE
 vdE
 xWS
 lkY
-mgG
+cYK
 lVP
 lVP
 lVP
@@ -88775,14 +88778,14 @@ hRI
 xXV
 iBd
 xXV
-iox
+omE
 xAv
 yaG
 yaG
 yaG
 yaG
-rJo
-rJo
+pNB
+pNB
 xOw
 meC
 meC
@@ -89011,7 +89014,7 @@ bPB
 bcA
 ljp
 tTz
-nhb
+kxL
 wKe
 yjs
 qyU
@@ -89034,12 +89037,12 @@ hCP
 hCP
 dLV
 jWU
-sSn
-vmn
-pFX
-sUO
-gYa
-rJo
+vxk
+mfi
+fkH
+wgn
+crt
+pNB
 xOw
 meC
 meC
@@ -89292,11 +89295,11 @@ xHl
 glK
 jYo
 yiq
-qXR
-luD
-jBA
-isZ
-rJo
+pWG
+vNx
+oyP
+ntz
+pNB
 xOw
 meC
 meC
@@ -89549,11 +89552,11 @@ bpn
 bpf
 bpn
 bpn
-gKq
-vWF
-shj
-giJ
-rJo
+tqT
+kaf
+bFe
+ekO
+pNB
 xOw
 meC
 meC
@@ -89806,11 +89809,11 @@ iMq
 eAD
 kel
 bpn
-rJo
-rJo
-rJo
-rJo
-rJo
+pNB
+pNB
+pNB
+pNB
+pNB
 xOw
 meC
 meC
@@ -93640,7 +93643,7 @@ tWO
 tWO
 tWO
 dPu
-tWO
+qYT
 gvh
 lil
 vgC
@@ -96732,7 +96735,7 @@ qMW
 qMW
 oAf
 vWT
-nmw
+lSO
 gvh
 wXw
 wXw
@@ -97248,8 +97251,8 @@ meC
 caa
 iRe
 prs
-cCe
-dQn
+pWF
+eJf
 pBD
 cql
 sHh
@@ -97508,7 +97511,7 @@ caa
 caa
 caa
 caa
-itr
+afB
 caa
 caa
 caa

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -365,6 +365,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"anr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "anB" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light/directional/north,
@@ -988,6 +993,10 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/medical/virology)
+"aFA" = (
+/obj/structure/mopbucket,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aFS" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -2836,7 +2845,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "bQy" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/recharge_station,
@@ -3743,6 +3752,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"ctE" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/bridge)
 "ctO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -4812,7 +4824,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "cZj" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	color = "#4169E1";
@@ -5153,6 +5165,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"djj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "djC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5376,6 +5394,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"dpM" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "dqa" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -5614,6 +5636,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/mixing)
+"dyc" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "dyg" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/white/smooth_large,
@@ -6072,7 +6098,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "dMe" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7296,7 +7322,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "erb" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -7590,6 +7616,10 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room)
+"exx" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "exJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -7827,6 +7857,11 @@
 /obj/structure/closet/crate/mail/full,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"eFS" = (
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "eGM" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -11364,6 +11399,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
+"gNd" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "gND" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -12039,7 +12083,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "hnE" = (
 /obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
@@ -12162,6 +12206,14 @@
 	dir = 4
 	},
 /area/security/execution/education)
+"hsF" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hsJ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12683,6 +12735,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"hFL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "hFP" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -12721,6 +12779,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hHd" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "hHg" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
@@ -13065,6 +13127,15 @@
 /obj/item/survivalcapsule,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"hPr" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/extinguisher/mini,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "hPs" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -13556,6 +13627,8 @@
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "icR" = (
@@ -13837,7 +13910,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "ikQ" = (
 /obj/structure/table,
 /obj/structure/sign/poster/official/random{
@@ -15083,6 +15156,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"iPC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "iPO" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/plants/portaseeder,
@@ -17063,8 +17140,14 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "jUt" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "jUN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall,
@@ -17149,12 +17232,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "jWU" = (
-/obj/machinery/vending/snack,
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
 	name = "Command blue half"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "jWV" = (
@@ -17192,10 +17276,12 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room)
 "jYo" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/blue/anticorner{
 	color = "#4169E1";
 	name = "Command blue corner"
+	},
+/obj/structure/sign/warning/radshelter{
+	pixel_y = -32
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -18926,6 +19012,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"kUc" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "kUe" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -19738,6 +19829,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"log" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "loj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19859,6 +19959,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
+"lqk" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "lqm" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -19869,7 +19976,7 @@
 "lqp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "lqr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -20411,6 +20518,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"lFz" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "lFH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -21735,6 +21848,12 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+"mks" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "mkB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -22626,7 +22745,7 @@
 "mFk" = (
 /obj/item/wheelchair,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "mFq" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
@@ -22972,7 +23091,7 @@
 "mMO" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "mMQ" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -23433,12 +23552,12 @@
 "mYh" = (
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "mYj" = (
 /obj/structure/rack,
 /obj/item/watertank,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "mYu" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -23596,9 +23715,14 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
 "nbd" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/door/airlock/hatch{
+	name = "Radstorm Shelter"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "nbe" = (
 /obj/structure/window/reinforced,
 /obj/item/kirbyplants{
@@ -23666,7 +23790,7 @@
 	name = "Given-As-Compensation"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "ndK" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000";
@@ -23985,7 +24109,6 @@
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
 "noF" = (
-/obj/structure/tank_holder/extinguisher,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24987,7 +25110,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/jani_wardrobe,
+/obj/structure/table,
+/obj/item/storage/box/mousetraps,
+/obj/item/storage/box/mousetraps,
 /turf/open/floor/iron,
 /area/service/janitor)
 "nRQ" = (
@@ -25034,7 +25159,7 @@
 "nSZ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "nTf" = (
 /obj/structure/chair/comfy/brown{
 	color = "#EFB341";
@@ -25139,7 +25264,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "nWZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -25481,7 +25606,7 @@
 "ofS" = (
 /obj/structure/sign/poster/official/love_ian,
 /turf/closed/wall,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "ofT" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -25489,7 +25614,7 @@
 "ofY" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "ogr" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
@@ -25527,7 +25652,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "ohz" = (
 /turf/closed/wall,
 /area/security/lockers)
@@ -25647,7 +25772,7 @@
 /obj/item/stack/sheet/cardboard,
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "omh" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26446,6 +26571,13 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oFK" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "oFN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half{
@@ -26840,7 +26972,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "oSh" = (
 /obj/structure/sign/poster/official/ian{
 	pixel_y = 30
@@ -26850,7 +26982,7 @@
 	name = "Dear Ian 2"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "oSr" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
@@ -26939,7 +27071,7 @@
 	},
 /obj/item/clothing/under/costume/skeleton,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "oUG" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Coldroom";
@@ -26950,7 +27082,7 @@
 "oUM" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "oUT" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood,
@@ -27001,6 +27133,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"oWj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "oWl" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
@@ -27248,7 +27385,7 @@
 /obj/structure/rack,
 /obj/item/wirecutters,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "pfy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -27258,7 +27395,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "pfG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -28347,6 +28484,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/iron,
 /area/service/janitor)
 "pRb" = (
@@ -28427,6 +28565,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"pUm" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/hardhat/red,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "pUC" = (
 /obj/item/kirbyplants/dead{
 	desc = "Dead plant. I thought all office plants were fake.";
@@ -29384,6 +29529,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"qCp" = (
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "qCx" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -29533,7 +29681,7 @@
 /obj/structure/rack,
 /obj/item/wrench,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "qFR" = (
 /obj/structure/table,
 /obj/item/paper/guides/jobs/hydroponics,
@@ -29865,7 +30013,7 @@
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "qMJ" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -29905,7 +30053,7 @@
 	name = "Dear Dan"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "qOf" = (
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
@@ -29922,7 +30070,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "qOA" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -29981,7 +30129,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "qQD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -30036,7 +30184,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "qTj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -30175,7 +30323,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "qYx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30373,7 +30521,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "reI" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /obj/structure/sign/painting/library_secure{
@@ -32161,7 +32309,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "rYy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -32449,14 +32597,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "sgz" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "sgA" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "sgK" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -32480,7 +32628,7 @@
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "sht" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "chemlock";
@@ -32611,7 +32759,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "slT" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -32635,7 +32783,7 @@
 "smF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "smT" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "roboticsshut";
@@ -34211,6 +34359,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"tfL" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "tgl" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -34634,7 +34786,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "tsi" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -34666,7 +34818,7 @@
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "tsH" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -35045,7 +35197,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "tBV" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -35174,11 +35326,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "tDM" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "tDP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38162,6 +38314,10 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
+"uSo" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "uSr" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/machinery/camera/directional/north{
@@ -38308,7 +38464,7 @@
 "uVS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "uVY" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security - Armory Hallway";
@@ -39868,6 +40024,9 @@
 "vFO" = (
 /turf/closed/wall/r_wall,
 /area/security/office)
+"vGc" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "vGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -40019,7 +40178,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "vKN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40591,7 +40750,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "vYD" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	color = "#4169E1";
@@ -40608,7 +40767,7 @@
 /obj/item/grenade/chem_grenade/colorful,
 /obj/item/grenade/chem_grenade/glitter,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "vYY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -41098,7 +41257,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "wkn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -42127,6 +42286,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
+"wGT" = (
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "wGV" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -42293,6 +42456,12 @@
 	},
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
+"wLq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "wLs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42585,21 +42754,21 @@
 /obj/effect/spawner/random/maintenance/four,
 /obj/structure/closet,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "wSP" = (
 /obj/item/toy/balloon/corgi,
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "wSR" = (
 /obj/item/paper/fluff/ruins/oldstation/survivor_note{
 	info = "This'll be the last package I ever send your ass, It's been six shifts, and still no word - I don't deserve it! I know you got my last two letters, I used the destination tagger perfect. So this is my final letter I'm sendin' you, I hope you read it. I'm in the clown car right now, I'm doin' 90 down the starboard hallway. Hey, Ian, I drank five bottles of Badminka Vodka, you dare me to drive? You know the song by Cuban Pete, 'Honking in the Air Tonight'. About that guy who coulda saved that Assistant from the Clowns clownin', But didn't. Then Pete saw it all, then at a bar theatre he found him? That's kinda how this is: you coulda rescued me from the clown an', now it's too late, I'm on a thousand downers from Chem and now I'm drowsy. And all I wanted was a lousy letter back or be able to pet ya'll. I hope you know I ripped all your pictures off the wall. I loved you, Ian! We coulda been together - think about it! You ruined it now, I hope you can't sleep and you dream about it! And when you dream I hope you can't sleep and you scream about it! I hope your conscience eats at you and you can't breathe without me! See Ian - Shut up Bitch! I'm trying to speech-to-text! Hey, Ian, that's my girlfriend screamin' in the trunk. But I didn't slit her throat, see I just tied her up see? I ain't like you, 'cause if she suffocates she'll suffer more and then she'll die too. Well, gotta go, I'm almost at the Bridge now. Oh shit, I forgot - How am I supposed to post this shit out?  *crash* ";
 	name = "Dear Ian 3"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "wST" = (
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "wSZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42895,7 +43064,7 @@
 	name = "Dear Ian"
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "xdk" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/window,
@@ -42942,7 +43111,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/elevatorshaft,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "xdX" = (
 /obj/machinery/light/directional/south,
 /obj/structure/training_machine,
@@ -43442,6 +43611,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"xss" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/mop,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xst" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -43671,9 +43851,11 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
-/obj/machinery/vending/coffee,
+/obj/structure/sign/warning/radshelter{
+	pixel_y = -32
+	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/command/bridge)
 "xAO" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -43978,7 +44160,7 @@
 "xJy" = (
 /obj/item/spear/bamboospear,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "xJF" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/brown{
@@ -44329,7 +44511,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/department/security)
 "xRM" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -70921,15 +71103,15 @@ lrG
 hbd
 hbd
 nop
-hbd
-hbd
-hbd
+ybf
+ybf
+ybf
 oRU
-hbd
-hbd
-hbd
-hbd
-hbd
+ybf
+ybf
+ybf
+ybf
+ybf
 pCI
 pCI
 pCI
@@ -71178,13 +71360,13 @@ kBB
 vdz
 hbd
 wwX
-hbd
-eJi
-eJi
-fdX
-eJi
-eJi
-eJi
+ybf
+lMU
+lMU
+vjJ
+lMU
+lMU
+lMU
 sgq
 xRE
 rGG
@@ -71435,15 +71617,15 @@ vdG
 lCf
 hbd
 hbd
-hbd
-eJi
+ybf
+lMU
 nSZ
-hbd
-nop
-nop
-nop
-nop
-hbd
+ybf
+qCp
+qCp
+qCp
+qCp
+ybf
 lpN
 tCT
 rkv
@@ -71690,19 +71872,19 @@ jEP
 vdG
 vdG
 lDe
-hbd
+ybf
 mFk
-nop
-eJi
+qCp
+lMU
 nWT
-hbd
-iHh
+ybf
+miS
 qMe
 bQx
-hbd
-hbd
+ybf
+ybf
 trU
-jUt
+xQY
 ccz
 ccz
 ccz
@@ -71947,19 +72129,19 @@ kFG
 kEY
 kEY
 lDo
-hbd
-nop
-nop
-eJi
-hbd
-hbd
-hbd
-hbd
-hbd
-hbd
-wwX
-fdX
-jUt
+ybf
+qCp
+qCp
+lMU
+ybf
+ybf
+ybf
+ybf
+ybf
+ybf
+tfL
+vjJ
+xQY
 umW
 bPs
 iAJ
@@ -72204,19 +72386,19 @@ umJ
 kYZ
 uMm
 kLY
-hbd
+ybf
 mMO
-nop
-eJi
+qCp
+lMU
 ofS
 vYO
 wSK
 xda
-hbd
-nop
-nop
-fdX
-jUt
+ybf
+qCp
+qCp
+vjJ
+xQY
 unJ
 ocN
 szf
@@ -72461,19 +72643,19 @@ jPd
 hpn
 hpn
 hpn
-hbd
-hbd
-nop
-eJi
-hbd
+ybf
+ybf
+qCp
+lMU
+ybf
 oSh
 wSP
 xdH
-hbd
+ybf
 sgA
-hbd
-fdX
-jUt
+ybf
+vjJ
+xQY
 unK
 hPm
 szf
@@ -72719,18 +72901,18 @@ umM
 uMB
 vuy
 vuy
-hbd
-hbd
-eJi
+ybf
+ybf
+lMU
 ofS
 wST
 wSR
 wST
-hbd
+ybf
 sgA
-hbd
-fdX
-jUt
+ybf
+vjJ
+xQY
 unJ
 uIq
 szf
@@ -72976,18 +73158,18 @@ knZ
 pYM
 pYM
 lRW
-hbd
-nop
-eJi
-hbd
+ybf
+qCp
+lMU
+ybf
 oUA
 wST
 qOc
-hbd
-nop
-hbd
-fdX
-jUt
+ybf
+qCp
+ybf
+vjJ
+xQY
 unJ
 bqu
 szf
@@ -73233,18 +73415,18 @@ koV
 uML
 kMb
 vva
-hbd
-iHh
-eJi
-hbd
-hbd
-hbd
+ybf
+miS
+lMU
+ybf
+ybf
+ybf
 qOv
-hbd
-nop
-hbd
-fdX
-jUt
+ybf
+qCp
+ybf
+vjJ
+xQY
 unL
 iqa
 xip
@@ -73493,15 +73675,15 @@ vvi
 vKH
 vYt
 ikJ
-wwX
-hbd
+tfL
+ybf
 pfu
-nop
-hbd
+qCp
+ybf
 shp
-hbd
-fdX
-jUt
+ybf
+vjJ
+xQY
 uob
 bqu
 vrc
@@ -73747,18 +73929,18 @@ tPf
 veF
 veF
 lTh
-hbd
+ybf
 mYh
 wka
 qFQ
-hbd
+ybf
 bQx
-nop
-nop
-nop
-hbd
+qCp
+qCp
+qCp
+ybf
 trU
-jUt
+xQY
 uof
 loj
 qXZ
@@ -74004,18 +74186,18 @@ uxf
 uML
 vvw
 vvw
-hbd
+ybf
 mYh
 wka
 ofY
-hbd
-hbd
-hbd
-hbd
-hbd
-hbd
-fdX
-jUt
+ybf
+ybf
+ybf
+ybf
+ybf
+ybf
+vjJ
+xQY
 uok
 mGO
 rre
@@ -74261,8 +74443,8 @@ pYM
 pYM
 pYM
 uaD
-hbd
-nop
+ybf
+qCp
 eqU
 eqU
 eqU
@@ -74272,8 +74454,8 @@ eqU
 eqU
 eqU
 eqU
-jUt
-jUt
+xQY
+xQY
 uIW
 qzb
 aJn
@@ -74518,19 +74700,19 @@ uxl
 uNv
 lIn
 lIn
-hbd
-hbd
-hbd
+ybf
+ybf
+ybf
 ohu
-hbd
-jUt
-jUt
-jUt
-jUt
-jUt
+ybf
+xQY
+xQY
+xQY
+xQY
+xQY
 eqU
 mFk
-jUt
+xQY
 uLk
 jZz
 aDh
@@ -74775,16 +74957,16 @@ lbq
 uNU
 veQ
 sHl
-hbd
+ybf
 bQx
 xJy
-nop
+qCp
 oUM
-jUt
+xQY
 qQq
 dMd
 dMd
-jUt
+xQY
 eqU
 tDK
 tBJ
@@ -75032,19 +75214,19 @@ lbB
 uOn
 csH
 csH
-hbd
+ybf
 mYj
-nop
+qCp
 ols
 ndG
-jUt
+xQY
 qTc
 cZb
 hny
-jUt
+xQY
 uVS
-gjA
-jUt
+hHd
+xQY
 uNR
 usm
 udn
@@ -75289,19 +75471,19 @@ csH
 ltF
 bzc
 csH
-hbd
-nbd
-nop
-nop
-gjA
-jUt
+ybf
+mgP
+qCp
+qCp
+hHd
+xQY
 qYh
-nop
+qCp
 slR
 rYp
 uVS
 tDM
-jUt
+xQY
 uOq
 wbX
 dir
@@ -75546,19 +75728,19 @@ hFP
 hFP
 hFP
 hFP
-jUt
-jUt
-jUt
-jUt
-jUt
-jUt
+xQY
+xQY
+xQY
+xQY
+xQY
+xQY
 rek
-jUt
+xQY
 smF
 lqp
 uVS
-jUt
-jUt
+xQY
+xQY
 uPT
 sZu
 sZu
@@ -75812,9 +75994,9 @@ pgT
 jPU
 hPV
 vzS
-jUt
+xQY
 tsD
-jUt
+xQY
 upX
 mfB
 xKM
@@ -84541,8 +84723,8 @@ iur
 pUC
 qOf
 qKw
-qKw
-qKw
+anr
+anr
 qKw
 qKw
 sgR
@@ -84798,11 +84980,11 @@ iur
 vXU
 mKo
 qKw
-qKw
+anr
 nri
 usZ
 rTb
-qKw
+tWA
 iur
 nri
 oVY
@@ -85312,7 +85494,7 @@ iur
 qEz
 qKw
 rbE
-qKw
+anr
 rzT
 iur
 rTe
@@ -85569,7 +85751,7 @@ iur
 dNB
 qKw
 qKw
-qKw
+anr
 czb
 iur
 qKw
@@ -85821,12 +86003,12 @@ wAQ
 lRe
 ycI
 xOw
-meC
+iur
 iur
 iur
 iur
 qKw
-qKw
+anr
 rAf
 iur
 icT
@@ -86078,12 +86260,12 @@ ycI
 ycI
 ycI
 xOw
-meC
-meC
-meC
+iur
+hPr
+wLq
 iur
 iur
-iur
+anr
 iur
 iur
 bZp
@@ -86335,14 +86517,14 @@ ndq
 iJa
 yaG
 xOw
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+jXz
+pUm
+anr
+log
+anr
+anr
+qKw
+iur
 iur
 jXz
 jXz
@@ -86592,14 +86774,14 @@ lsg
 qta
 yaG
 xOw
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+iur
+exx
+mks
+iur
+qKw
+anr
+qKw
+iur
 meC
 iny
 agm
@@ -86849,14 +87031,14 @@ lvr
 lSi
 yaG
 miN
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+iur
+iur
+iur
+iur
+anr
+anr
+vXU
+iur
 meC
 sPN
 agm
@@ -87106,14 +87288,14 @@ lAd
 lUs
 yaG
 xOw
-meC
-meC
-meC
-meC
-meC
-meC
-meC
-meC
+iur
+hsF
+xss
+iur
+anr
+iur
+iur
+iur
 meC
 meC
 meC
@@ -87363,12 +87545,12 @@ yaG
 yaG
 yaG
 xOw
-meC
-meC
-meC
-meC
-meC
-meC
+jXz
+iPC
+oWj
+log
+anr
+iur
 meC
 meC
 meC
@@ -87620,12 +87802,12 @@ xOw
 xOw
 xOw
 xOw
-meC
-meC
-meC
-meC
-meC
-meC
+iur
+aFA
+dyc
+iur
+qKw
+iur
 meC
 meC
 meC
@@ -87877,12 +88059,12 @@ xOw
 meC
 meC
 meC
-meC
-meC
-meC
-meC
-meC
-meC
+iur
+iur
+iur
+iur
+iur
+iur
 meC
 meC
 meC
@@ -88131,8 +88313,8 @@ nRi
 xTU
 yaG
 xOw
-meC
-meC
+xOw
+xOw
 meC
 meC
 meC
@@ -88381,15 +88563,15 @@ hRI
 xXV
 iBd
 xXV
-xXV
+jUt
 xAv
 yaG
 yaG
 yaG
 yaG
+ctE
+ctE
 xOw
-meC
-meC
 meC
 meC
 meC
@@ -88640,13 +88822,13 @@ hCP
 hCP
 dLV
 jWU
-yiq
+nbd
+hFL
+gNd
+kUc
+uSo
+ctE
 xOw
-xOw
-xOw
-xOw
-meC
-meC
 meC
 meC
 meC
@@ -88898,12 +89080,12 @@ xHl
 glK
 jYo
 yiq
+wGT
+djj
+vGc
+oFK
+ctE
 xOw
-meC
-meC
-meC
-meC
-meC
 meC
 meC
 meC
@@ -89155,12 +89337,12 @@ bpn
 bpf
 bpn
 bpn
+eFS
+lqk
+lFz
+dpM
+ctE
 xOw
-meC
-meC
-meC
-meC
-meC
 meC
 meC
 meC
@@ -89412,12 +89594,12 @@ iMq
 eAD
 kel
 bpn
+ctE
+ctE
+ctE
+ctE
+ctE
 xOw
-meC
-meC
-meC
-meC
-meC
 meC
 meC
 meC
@@ -89673,8 +89855,8 @@ xOw
 xOw
 xOw
 xOw
-meC
-meC
+xOw
+xOw
 meC
 meC
 meC

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -43,9 +43,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "abz" = (
-/obj/structure/closet/mini_fridge,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "abG" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82,14 +83,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
-"acR" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/science/research)
 "acX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -146,13 +139,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
-"afB" = (
-/obj/machinery/door/morgue{
-	name = "Mass Driver";
-	req_access_txt = "27"
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "afW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -282,11 +268,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "akg" = (
-/obj/effect/turf_decal/tile/purple/anticorner{
-	color = "#4D0067";
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /turf/open/floor/iron/white,
@@ -325,16 +310,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"alQ" = (
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/cargo/sorting)
 "alZ" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -348,6 +323,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/green,
 /area/service/library)
+"amn" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue half"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "amt" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -404,17 +387,24 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"aoP" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
+"aot" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/main)
+"aoP" = (
+/obj/machinery/status_display/ai/directional/north,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "aoR" = (
@@ -451,6 +441,8 @@
 /area/service/kitchen)
 "aqa" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "aqc" = (
@@ -485,15 +477,6 @@
 /obj/structure/easel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aqP" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "arf" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -515,14 +498,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
 "arV" = (
-/obj/item/storage/secure/safe/directional/east,
-/obj/machinery/modular_computer/console/preset/id{
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/command/heads_quarters/ce)
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "ase" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -625,16 +608,19 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 8
-	},
 /obj/machinery/airalarm/mixingchamber{
 	dir = 8;
 	pixel_x = -25
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"awc" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "awl" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -667,14 +653,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "axD" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/pods{
-	name = "MINING POD";
-	pixel_y = 30
+/obj/structure/chair/office{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/cargo/miningdock)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "axW" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -826,8 +809,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -1062,19 +1044,19 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aIk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 8
-	},
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/closet/bombcloset,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "aIm" = (
@@ -1183,6 +1165,9 @@
 	},
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -1293,9 +1278,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aQb" = (
-/obj/machinery/modular_computer/console/preset/cargochat/engineering,
+/obj/structure/filingcabinet/chestdrawer,
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/command/heads_quarters/ce)
 "aQe" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -1345,10 +1331,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
-"aRi" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "aRC" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -1382,9 +1364,9 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "aSy" = (
-/obj/machinery/computer/department_orders/engineering,
+/obj/structure/table,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/command/heads_quarters/ce)
 "aSz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
@@ -1562,9 +1544,11 @@
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
 "bbt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bbY" = (
@@ -1573,12 +1557,6 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"bcw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bcA" = (
 /obj/machinery/door/airlock{
 	name = "Service Lathe Access";
@@ -1650,37 +1628,17 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bdW" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/effect/turf_decal/siding/thinplating/dark/end{
-	dir = 8
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/window{
+	dir = 4
 	},
-/obj/machinery/button/door/directional/west{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_y = 10;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door/directional/west{
-	id = "engstorage";
-	name = "Engineering Secure Storage Control";
-	pixel_x = -36;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door/directional/west{
-	desc = "A remote control switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_y = -6;
-	req_access_txt = "10"
-	},
-/obj/machinery/requests_console/directional/south{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 5;
-	name = "Chief Engineer's Request Console"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
+"bek" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/office)
 "beA" = (
 /turf/closed/wall,
 /area/science/xenobiology)
@@ -1798,8 +1756,15 @@
 	},
 /area/construction/mining/aux_base)
 "bgY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/conveyor/inverted{
+	dir = 4;
+	id = "QMLoad2"
+	},
+/obj/machinery/door/poddoor{
+	id = "cargoload";
+	name = "Cargo Loading Door"
+	},
+/turf/open/floor/iron,
 /area/cargo/storage)
 "bhP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -2004,11 +1969,10 @@
 /turf/closed/wall,
 /area/service/library)
 "bnB" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "bnE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2023,6 +1987,22 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"bnX" = (
+/obj/structure/table,
+/obj/machinery/button/door/directional/east{
+	id = "celock";
+	name = "CE Office Lockdown Button";
+	pixel_x = 40;
+	req_access_txt = "56"
+	},
+/obj/item/stamp/denied,
+/obj/item/stamp/ce{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "boe" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -2061,10 +2041,11 @@
 /area/engineering/storage/tech)
 "boW" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bpf" = (
@@ -2118,6 +2099,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"bpP" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "bql" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -2188,11 +2176,13 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "bsi" = (
+/obj/structure/plasticflaps,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "cargodisposals"
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -2294,9 +2284,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"btm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "btO" = (
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "btU" = (
@@ -2329,10 +2325,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "bwK" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "bwU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -2387,15 +2383,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "byV" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "31"
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "bzc" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/landmark/start/hangover,
@@ -2422,9 +2416,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "bAu" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "bAv" = (
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2440,14 +2434,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bAZ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "bBc" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -2533,6 +2524,7 @@
 	dir = 9;
 	name = "engineering yellow"
 	},
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/carpet/orange,
 /area/engineering/lobby)
 "bEf" = (
@@ -2553,14 +2545,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "bEq" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/command/heads_quarters/ce)
 "bEw" = (
 /obj/effect/turf_decal/siding/green{
@@ -2573,6 +2563,13 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"bEP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "bEX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2580,12 +2577,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/science/genetics)
-"bFe" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "bFl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2629,7 +2620,6 @@
 /area/engineering/atmos)
 "bGv" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/wizard,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/commons/vacant_room)
@@ -2697,11 +2687,15 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "bKA" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side,
+/turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
 "bKE" = (
 /obj/machinery/door/airlock/external/glass{
@@ -2710,9 +2704,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bKL" = (
@@ -2880,10 +2872,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/project)
 "bQO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/window{
+	pixel_y = -3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "bQX" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -3035,15 +3031,17 @@
 /turf/open/space/basic,
 /area/maintenance/department/medical)
 "bVS" = (
-/obj/structure/disposaloutlet,
-/turf/open/floor/plating,
-/area/cargo/sorting)
-"bVW" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/window{
+	pixel_y = -3
 	},
-/obj/machinery/light/directional/east,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
+"bVW" = (
+/obj/effect/turf_decal/tile/brown/anticorner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "bWl" = (
@@ -3060,12 +3058,18 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "bWx" = (
-/obj/machinery/computer/mech_bay_power_console{
+/obj/effect/turf_decal/tile/brown/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/light/no_nightlight/directional/north,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
+/obj/item/folder/yellow,
 /turf/open/floor/iron,
-/area/cargo/warehouse)
+/area/cargo/storage)
 "bWH" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/iron/dark,
@@ -3094,12 +3098,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bYw" = (
-/obj/machinery/computer/cargo{
-	dir = 1
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/structure/window{
+	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/brown/half,
-/turf/open/floor/iron,
-/area/cargo/qm)
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "bYz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3264,20 +3271,25 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
-"cbK" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
+"cbU" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "ccf" = (
 /obj/machinery/air_sensor/atmos/plasma_tank,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos/upper)
 "ccy" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron,
 /area/engineering/main)
 "ccz" = (
@@ -3410,21 +3422,6 @@
 	dir = 8
 	},
 /area/service/chapel)
-"cgI" = (
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot{
-	beacon_freq = 1400;
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "cgN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3511,10 +3508,6 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"ckb" = (
-/obj/structure/mopbucket,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "cko" = (
 /obj/structure/reflector/single,
 /obj/effect/turf_decal/siding/yellow{
@@ -3552,6 +3545,18 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"clH" = (
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "clS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3584,6 +3589,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"cmr" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "cmt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3668,10 +3680,14 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "cox" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/conveyor_switch/oneway{
+	dir = 1;
+	id = "QMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/tile/brown/half{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -3684,6 +3700,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "cqd" = (
@@ -3737,10 +3757,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"crt" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "crV" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -3805,14 +3821,8 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
+/obj/effect/turf_decal/siding/red/end{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
@@ -3829,6 +3839,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/east,
+/obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "cuN" = (
@@ -3856,7 +3867,7 @@
 "cwa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "cwb" = (
 /obj/machinery/door/window/eastright{
 	dir = 2;
@@ -3896,6 +3907,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/starboard/aft)
+"cxj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cxm" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -3914,11 +3929,10 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /obj/item/radio/off,
 /obj/item/screwdriver,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 10;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
 "cxM" = (
@@ -4014,11 +4028,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "czH" = (
@@ -4139,11 +4152,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
-"cCS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "cDi" = (
 /obj/machinery/power/emitter,
 /obj/structure/cable,
@@ -4341,16 +4349,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cIt" = (
-/obj/machinery/conveyor/inverted{
-	dir = 4;
-	id = "QMLoad2"
-	},
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "Cargo Loading Door"
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "cID" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -4426,6 +4427,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"cNF" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "cOo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -4490,7 +4496,9 @@
 /turf/open/floor/plating,
 /area/cargo/miningdock)
 "cPR" = (
-/obj/machinery/suit_storage_unit/industrial/loader,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cPV" = (
@@ -4513,8 +4521,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"cQD" = (
+"cQu" = (
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
+"cQD" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -4544,13 +4557,6 @@
 	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
 	},
 /area/maintenance/port/fore)
-"cRl" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/head/hardhat/red,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "cRr" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
@@ -4573,14 +4579,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cRL" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "cargodisposals";
-	name = "disposals conveyor switch";
-	pixel_x = -8
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "cSb" = (
@@ -4638,14 +4643,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"cTo" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/machinery/light/no_nightlight/directional/north,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "cTt" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/tile/purple/anticorner{
@@ -4708,15 +4705,6 @@
 	dir = 1
 	},
 /area/science/research)
-"cUR" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "cUW" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -4746,16 +4734,16 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "cVk" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Delivery Office";
-	req_one_access_txt = "48;50"
+/obj/structure/filingcabinet,
+/obj/structure/window{
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "cVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -4779,11 +4767,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
-"cVG" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "cVW" = (
 /obj/structure/reflector/double/anchored{
 	dir = 6
@@ -4881,12 +4864,9 @@
 	},
 /area/science/research)
 "cYK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "cZb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden{
 	dir = 4
@@ -5092,6 +5072,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"dfu" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "dfw" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light/small/directional/east,
@@ -5150,6 +5137,7 @@
 	id = "bridge blast entrance";
 	name = "Bridge Blast door"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/command/bridge)
 "dho" = (
@@ -5235,17 +5223,14 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "djC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/office)
 "dkk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/textured_large,
@@ -5364,11 +5349,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"dnk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 1
+"dna" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"dnk" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -5476,17 +5463,26 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
-"dqW" = (
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "drb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos/upper)
 "drD" = (
-/obj/structure/closet/wardrobe/miner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/item/storage/box{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
-/area/cargo/miningdock)
+/area/cargo/sorting)
 "drU" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm/directional/west,
@@ -5901,6 +5897,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "dDI" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet,
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
@@ -5958,17 +5959,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"dFp" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
 "dFK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6000,9 +5990,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tcomms)
 "dIB" = (
-/obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "dIZ" = (
@@ -6400,8 +6391,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "dWm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "dWG" = (
@@ -6592,16 +6583,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/engineering/lobby)
 "eaC" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Warehouse";
-	req_access_txt = "31"
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/cargo/warehouse)
+/area/cargo/storage)
 "eaK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -6718,20 +6703,23 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "edN" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/structure/window{
+	pixel_y = -3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "edR" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48"
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light/small/directional/east,
+/obj/structure/window{
+	pixel_y = -3
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/cargo/miningdock)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "edX" = (
 /obj/item/stack/sheet/plastic/fifty{
 	pixel_x = 3;
@@ -6979,6 +6967,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"eiL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/cargo/office)
 "eiU" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -7060,15 +7052,10 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "ejQ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Vacant Offices A"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/poddoor/massdriver_trash,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/disposal)
 "ejZ" = (
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
@@ -7102,10 +7089,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"ekO" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "ekX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -7121,18 +7104,11 @@
 /turf/closed/wall/r_wall,
 /area/service/hydroponics)
 "ely" = (
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	icon_state = "left";
-	name = "Danger: Conveyor Access";
-	req_access_txt = "12"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/conveyor/inverted{
-	dir = 6;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "elD" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson/engine,
@@ -7316,23 +7292,19 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "epo" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Dock";
-	req_access_txt = "48"
+/obj/machinery/mass_driver/trash{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/cargo/storage)
-"epp" = (
-/obj/structure/sign/warning/pods{
-	name = "MINING POD";
-	pixel_y = 30
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/cargo/miningdock)
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"epD" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "epF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/nuclearbomb/beer,
@@ -7445,6 +7417,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"ets" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "etu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -7525,8 +7501,13 @@
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "euI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/side,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/command/heads_quarters/ce)
 "evb" = (
 /obj/machinery/newscaster/directional/east,
@@ -7662,10 +7643,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
 "ewR" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ewV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -7675,16 +7654,12 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "exo" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "exJ" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "exL" = (
@@ -7759,6 +7734,15 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"ezo" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "ezJ" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -7767,7 +7751,7 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "ezO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7807,29 +7791,39 @@
 	},
 /area/ai_monitored/turret_protected/ai_upload)
 "eAO" = (
-/obj/structure/table,
-/obj/item/toy/figure/ce,
-/obj/item/storage/box/matches{
-	pixel_y = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "eAW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
+"eBi" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "eBC" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eCd" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/button/flasher{
+	id = "scicell";
+	pixel_x = 24;
+	req_access_txt = "2"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
@@ -7917,6 +7911,15 @@
 /obj/structure/closet/crate/mail/full,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"eGg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "eGM" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -7972,6 +7975,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"eIs" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/iron,
+/area/cargo/office)
 "eIA" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -7989,19 +8002,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eIO" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/structure/window{
-	dir = 4
+/obj/machinery/light/small/directional/west,
+/obj/machinery/computer/pod/old/mass_driver_controller/trash{
+	pixel_x = -24
 	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
-"eJf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "garbage";
+	name = "disposal conveyor"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eJi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8009,9 +8020,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "eJw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/computer/cargo{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown/half,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "eJJ" = (
@@ -8025,14 +8037,15 @@
 /area/ai_monitored/command/storage/eva)
 "eJL" = (
 /obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/box/shipping,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
 /turf/open/floor/iron,
 /area/cargo/office)
 "eJY" = (
@@ -8047,12 +8060,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
 "eKE" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eKF" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room)
@@ -8065,13 +8077,10 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
 "eKT" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eLa" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -8084,9 +8093,10 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "eLc" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "eLt" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "HoP Office";
@@ -8120,6 +8130,7 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/command/bridge)
 "eLR" = (
@@ -8133,6 +8144,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"eLS" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "eLW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8149,13 +8164,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
-"eMi" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "eMl" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/machinery/light/small/directional/west,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room)
@@ -8265,8 +8280,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -8282,6 +8296,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"eRA" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "eSf" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -8389,7 +8412,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "eWF" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -8423,7 +8446,12 @@
 /area/commons/fitness/recreation)
 "eXM" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom/directional/east,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
 /turf/open/floor/wood,
 /area/commons/vacant_room)
 "eYr" = (
@@ -8436,6 +8464,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"eYC" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "eYE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -8654,6 +8686,10 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "fep" = (
@@ -8758,7 +8794,7 @@
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "fhn" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
@@ -8867,15 +8903,6 @@
 "fkv" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
-"fkH" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "fkO" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -8909,18 +8936,10 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "flJ" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office";
-	req_access_txt = "56"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
 "flO" = (
@@ -8928,11 +8947,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
-"fmd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "fmi" = (
 /obj/machinery/suit_storage_unit/medical,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -8968,7 +8982,7 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "fnV" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -8977,6 +8991,17 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"fpe" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/mop,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "fpl" = (
 /obj/machinery/door/airlock{
 	name = "Service Lathe Access";
@@ -8997,6 +9022,20 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"fpr" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "mechbay";
+	name = "Mech Bay Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/robotics/mechbay)
 "fpx" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/effect/turf_decal/stripes/line,
@@ -9011,21 +9050,6 @@
 "fqA" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"fqH" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/bounty_board/directional/east,
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/multitool,
-/obj/item/pen/blue{
-	pixel_y = -4
-	},
-/obj/item/pen/red,
-/turf/open/floor/iron,
-/area/cargo/office)
 "fqX" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -9042,15 +9066,16 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "frC" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Disposal Conveyor Access";
-	req_access_txt = "12"
+/obj/structure/filingcabinet,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "frG" = (
 /turf/open/floor/wood,
 /area/service/bar)
@@ -9190,11 +9215,17 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "fxq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/qm)
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -4
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "fxr" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -9298,11 +9329,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	color = "#4D0067";
-	dir = 8
-	},
 /obj/structure/closet/bombcloset,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "fBB" = (
@@ -9327,7 +9357,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/engineering/lobby)
 "fCb" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -9383,6 +9413,13 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"fCW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "fCZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9417,10 +9454,14 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "fDv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "fDS" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -9434,17 +9475,11 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
 "fDZ" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/c_tube,
-/obj/item/cane,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/disposal)
 "fEd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -9565,10 +9600,10 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "fIV" = (
@@ -9655,6 +9690,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/security/warden)
+"fLk" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "fLn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9720,14 +9760,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "fPh" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/window{
-	pixel_y = -3
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "fPu" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/north,
@@ -9930,14 +9969,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"fTy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "fTz" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -9949,10 +9980,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "fTV" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/corner,
-/obj/item/dest_tagger,
-/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "fUP" = (
@@ -10059,6 +10092,9 @@
 	},
 /turf/open/floor/glass,
 /area/command/heads_quarters/rd)
+"fWW" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "fWY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -10078,6 +10114,12 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
+"fXL" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "fXP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/grille,
@@ -10102,11 +10144,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "fZM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/warehouse)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "fZT" = (
 /obj/effect/turf_decal/tile/blue/half,
 /obj/machinery/light/directional/south,
@@ -10155,7 +10195,11 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "gbI" = (
-/obj/machinery/modular_computer/console/preset/cargochat/cargo{
+/obj/machinery/door/window/northright{
+	name = "Incoming Mail";
+	req_one_access_txt = "50"
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -10287,12 +10331,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ggD" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/cargo/warehouse)
+/area/cargo/storage)
 "ggE" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -10430,6 +10476,10 @@
 /obj/item/gps/mining,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"gkF" = (
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "gkI" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -10564,15 +10614,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"gnA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/command/heads_quarters/ce)
 "gnR" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
@@ -10698,11 +10739,6 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"gqi" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/tile/brown/anticorner,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "gqo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10734,6 +10770,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"gqH" = (
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "gqI" = (
 /obj/structure/rack,
 /obj/item/storage/box/smart_metal_foam,
@@ -10772,11 +10816,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "grU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/cargo/miningdock)
@@ -10869,11 +10914,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "guY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/vehicle/sealed/mecha/working/ripley/cargo,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron/recharge_floor,
-/area/cargo/warehouse)
+/obj/structure/table/wood,
+/obj/item/toy/figure/wizard,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood,
+/area/commons/vacant_room)
 "gvg" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -11045,6 +11090,15 @@
 "gyC" = (
 /turf/open/floor/iron,
 /area/security/processing)
+"gyJ" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/extinguisher/mini,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "gzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
@@ -11178,12 +11232,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"gCE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "gCH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11205,11 +11253,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"gDQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "gDY" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/corner{
@@ -11360,11 +11403,10 @@
 	name = "Science Cell";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 5;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "gJw" = (
@@ -11384,15 +11426,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "gKg" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
+/obj/structure/closet/secure_closet/brig{
+	id = "engcell";
+	name = "Engineering Cell Locker"
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/obj/machinery/keycard_auth/directional/south,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "gKn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table,
@@ -11450,6 +11489,17 @@
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /turf/open/floor/wood,
 /area/service/bar)
+"gLw" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Engineering";
+	req_access_txt = "63"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "gLy" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/neutral/line,
@@ -11495,9 +11545,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "gNJ" = (
-/obj/structure/bookcase/random,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/space)
 "gOi" = (
 /obj/structure/sink{
 	dir = 4;
@@ -11511,10 +11560,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "gOt" = (
-/obj/machinery/conveyor/inverted{
-	dir = 6;
+/obj/machinery/conveyor{
+	dir = 1;
 	id = "QMLoad2"
 	},
+/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gOK" = (
@@ -11529,12 +11579,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "gPa" = (
-/obj/structure/table/wood,
-/obj/structure/window{
-	pixel_y = -3
+/obj/structure/chair/comfy{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gPj" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -11619,27 +11668,20 @@
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
-	},
 /obj/machinery/camera/autoname/directional/west{
 	c_tag = "Sec Checkpoint - Research"
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
-"gSu" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "gSv" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "gSG" = (
@@ -11719,15 +11761,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
-"gVZ" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/cargo/office)
 "gWf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11739,6 +11772,16 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gWx" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/science/research)
 "gWy" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -11755,13 +11798,15 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
 "gWP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/table,
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/candle{
+	pixel_x = 9;
+	pixel_y = 7
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard/fore)
 "gXj" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -11794,6 +11839,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/lockers)
+"gYj" = (
+/obj/machinery/door/airlock/mining{
+	name = "Cargo Bay";
+	req_one_access_txt = "31;48"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/cargo/office)
 "gYY" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
@@ -11806,6 +11862,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-entrance"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/command/bridge)
 "gZy" = (
@@ -11844,6 +11901,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"haR" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "hbd" = (
 /turf/closed/wall,
 /area/maintenance/department/crew_quarters/dorms)
@@ -11999,6 +12060,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "hgw" = (
@@ -12032,10 +12094,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"hgM" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "hhc" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "researchlock";
@@ -12113,19 +12171,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "hix" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/table,
-/obj/item/paper_bin/carbon,
-/obj/item/pen,
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/security/checkpoint/supply)
 "hiS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12147,6 +12197,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"hjU" = (
+/obj/machinery/computer/apc_control{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/command/heads_quarters/ce)
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12292,8 +12351,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -12423,9 +12481,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "hvS" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
+/obj/structure/sign/warning/pods{
+	name = "MINING POD";
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
 /area/cargo/miningdock)
 "hwf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12436,28 +12496,35 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "hwp" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "hwr" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/obj/structure/window{
-	pixel_y = -3
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/book/random,
+/obj/item/c_tube,
+/obj/item/cane,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hwE" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "hwY" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Warehouse";
+	req_access_txt = "31"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "hxv" = (
@@ -12557,21 +12624,19 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"hBD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "hBG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "hBM" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad2"
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad2"
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -12687,16 +12752,10 @@
 /area/ai_monitored/command/nuke_storage)
 "hEn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/red/corner{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/red/corner{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
-	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "hEC" = (
@@ -12894,6 +12953,11 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"hIX" = (
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "hJg" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,
@@ -12920,12 +12984,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "hJO" = (
-/obj/machinery/mineral/ore_redemption,
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Ore Redemption Access";
-	req_access_txt = "64"
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/cargo/office)
 "hJT" = (
@@ -13070,24 +13130,23 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"hMG" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+"hMN" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
+"hNc" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Vacant Offices A"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
-"hNc" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/light/no_nightlight/directional/west,
-/turf/open/floor/iron,
-/area/cargo/qm)
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"hNf" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/bridge)
 "hNi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -13130,13 +13189,6 @@
 	dir = 4
 	},
 /area/science/research)
-"hNZ" = (
-/obj/effect/turf_decal/loading_area,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "hOv" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -13245,6 +13297,11 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
+"hRi" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "hRu" = (
 /turf/closed/wall,
 /area/service/lawoffice/upper)
@@ -13326,11 +13383,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "hUA" = (
@@ -13375,6 +13431,16 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"hWC" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "hWD" = (
 /turf/closed/wall,
 /area/cargo/storage)
@@ -13623,6 +13689,11 @@
 /obj/structure/closet/secure_closet/detective,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"ibo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "ibr" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -13768,22 +13839,20 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ifO" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/qm)
+/obj/structure/rack,
+/obj/item/plunger,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ifY" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
+/obj/machinery/door/airlock/mining/glass{
+	name = "Disposal Conveyor Access";
+	req_access_txt = "12"
 	},
-/obj/machinery/light/no_nightlight/directional/west,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "igj" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple/anticorner{
@@ -13918,10 +13987,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
-"iiZ" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/open/floor/iron,
-/area/cargo/sorting)
 "ijz" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -13992,16 +14057,12 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "ilo" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/photocopier,
-/turf/open/floor/iron,
-/area/cargo/office)
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "ilr" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -14165,9 +14226,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "ipK" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ipP" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -14336,12 +14399,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "itF" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "itG" = (
@@ -14405,16 +14472,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "iuT" = (
-/obj/structure/filingcabinet,
-/obj/structure/window{
-	pixel_y = -3
-	},
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/structure/bookcase/random,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iuU" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -14477,7 +14537,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ixh" = (
-/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/closet/crate/decorations,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "ixr" = (
@@ -14629,17 +14691,32 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"iBw" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Cargo";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "iBB" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "iBF" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/office)
 "iBJ" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/freezer,
@@ -14660,11 +14737,21 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"iCW" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/computer/atmos_alert,
+"iCH" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/hallway/primary/central/fore)
+"iCW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "iDo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -14689,8 +14776,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/cargo/office)
 "iEG" = (
@@ -14704,6 +14792,13 @@
 "iEU" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
+"iEY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "iEZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/red/full{
@@ -14715,16 +14810,12 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "iFo" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 5;
-	height = 6;
-	id = "supply_home";
-	name = "Cargo Bay";
-	width = 12
+/obj/machinery/door/airlock/maintenance{
+	name = "Warehouse Maintenance";
+	req_one_access_txt = "31"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iFp" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/machinery/photocopier,
@@ -14793,29 +14884,29 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "iHa" = (
-/obj/machinery/photocopier,
-/turf/open/floor/iron,
+/obj/machinery/vending/coffee,
+/obj/structure/sign/poster/contraband/hacking_guide{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
 /area/command/heads_quarters/ce)
 "iHh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "iHz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/cargo/miningdock)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "iHA" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -14935,20 +15026,18 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/siding/red/corner{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "iKl" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Maintenance";
-	req_one_access_txt = "31;48"
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/security/checkpoint/supply)
 "iKq" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet/green,
@@ -15098,9 +15187,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "iMF" = (
-/obj/machinery/modular_computer/console/preset/engineering,
+/obj/machinery/photocopier,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/command/heads_quarters/ce)
 "iMV" = (
 /obj/structure/table,
 /obj/item/ai_module/reset,
@@ -15274,6 +15363,14 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"iQH" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "iRe" = (
 /obj/structure/noticeboard/directional/north{
 	dir = 2;
@@ -15299,14 +15396,7 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "iRD" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/cargo/sorting)
 "iSb" = (
 /obj/machinery/door/airlock/security{
@@ -15317,12 +15407,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "iSd" = (
-/obj/structure/table,
-/obj/item/storage/box/shipping,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/piratepad/civilian,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/status_display/supply{
+	pixel_x = -32
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
@@ -15367,6 +15462,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "iTi" = (
@@ -15551,15 +15647,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
-"iYR" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/qm)
 "iYV" = (
 /obj/machinery/announcement_system,
 /turf/open/floor/iron/dark,
@@ -15605,11 +15692,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
-"iZW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "jaf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -15647,10 +15729,9 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "jaV" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "jbq" = (
@@ -15718,15 +15799,8 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "jda" = (
-/obj/machinery/door/window/northright{
-	name = "Incoming Mail";
-	req_one_access_txt = "50"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/sorting)
+/turf/closed/wall,
+/area/security/checkpoint/supply)
 "jdB" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -15763,6 +15837,19 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
+"jeU" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
+"jfp" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/flasher/directional/east{
+	id = "supcell"
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "jft" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -15965,8 +16052,7 @@
 /area/security/prison/workout)
 "jlb" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/oil,
-/obj/structure/closet/crate/decorations,
+/obj/structure/closet/crate/freezer,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "jlc" = (
@@ -16066,10 +16152,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
-"jnV" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "joj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16170,19 +16252,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "jrT" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/glass,
-/obj/item/stack/ore/glass,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
+/obj/structure/disposaloutlet,
+/turf/open/floor/plating,
+/area/cargo/sorting)
 "jrY" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -16207,10 +16279,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"jtW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "jtX" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -16285,9 +16353,16 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "jvV" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	icon_state = "left";
+	name = "Danger: Conveyor Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "garbage"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "jvY" = (
@@ -16341,9 +16416,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jzp" = (
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/structure/rack,
+/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "jzz" = (
@@ -16361,9 +16434,15 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "jzC" = (
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/loading_area,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "jzK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16530,17 +16609,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "jEY" = (
-/obj/structure/filingcabinet/chestdrawer/wheeled,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "jFe" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -16550,13 +16622,9 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "jFp" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/structure/window{
-	pixel_y = -3
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "jFq" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/blood/random,
@@ -16605,10 +16673,15 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "jGH" = (
-/obj/effect/turf_decal/tile/brown/anticorner{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
-/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jGO" = (
@@ -16663,20 +16736,18 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "jHv" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/area/cargo/warehouse)
 "jHw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance";
-	req_one_access_txt = "31"
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 8
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/cargo/storage)
 "jHE" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -16762,13 +16833,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "jIW" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/closed/wall,
+/area/space)
 "jIX" = (
 /obj/structure/window{
 	dir = 4
@@ -16809,10 +16875,9 @@
 	},
 /area/engineering/gravity_generator)
 "jKS" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+/obj/machinery/modular_computer/console/preset/cargochat/engineering{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jLA" = (
@@ -17061,6 +17126,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "jQZ" = (
@@ -17078,12 +17144,8 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "jRr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/cardboard,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jRA" = (
@@ -17127,6 +17189,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"jSQ" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "jTa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17183,6 +17250,7 @@
 "jTY" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "jUc" = (
@@ -17191,6 +17259,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"jUd" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "jUo" = (
 /obj/structure/chair/wood,
 /obj/machinery/light/small/directional/west,
@@ -17206,11 +17278,11 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "jUt" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
 "jUN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall,
@@ -17329,15 +17401,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "jXR" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light/small/directional/east,
-/obj/structure/window{
-	pixel_y = -3
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "jYo" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	color = "#4169E1";
@@ -17348,6 +17415,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"jYM" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "jZb" = (
 /obj/machinery/door/airlock/engineering{
 	id_tag = "EngiAccessInner";
@@ -17397,29 +17468,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kaf" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "kah" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
 "kaE" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/status_display/ai/directional/north,
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/security/checkpoint/supply)
 "kbc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17501,22 +17557,17 @@
 /turf/open/floor/wood,
 /area/service/library)
 "kcP" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/brown/anticorner,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
-/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/internals,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/warehouse)
 "kcZ" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "kdw" = (
@@ -17602,19 +17653,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kfo" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/brown/half{
+/obj/machinery/computer/shuttle/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown/anticorner{
 	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "qmlock";
-	name = "Lockdown Shutters";
-	pixel_x = -5
-	},
-/obj/machinery/button/door{
-	id = "qmprivacy";
-	name = "Privacy Shutters";
-	pixel_x = 5
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -17637,20 +17680,13 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "kfX" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"kga" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "kgf" = (
 /obj/structure/chair{
 	dir = 8
@@ -17844,24 +17880,16 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kmO" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/conveyor/inverted{
-	dir = 4;
-	id = "QMLoad2"
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/warehouse)
 "knH" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/red/corner{
-	color = "#FF0000";
-	name = "security red"
-	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "knI" = (
@@ -17889,10 +17917,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"koa" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "kox" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -18067,6 +18091,9 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
+"kth" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "kts" = (
 /obj/machinery/camera/xray/directional/east{
 	c_tag = "AI Chamber W";
@@ -18144,10 +18171,12 @@
 /turf/closed/wall/r_wall,
 /area/medical/morgue)
 "kwv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/machinery/light/small/directional/east,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
-/area/cargo/sorting)
+/area/cargo/warehouse)
 "kwB" = (
 /obj/machinery/light/directional/east,
 /obj/structure/closet/radiation,
@@ -18181,11 +18210,10 @@
 	departmentType = 5;
 	name = "Sec Outpost - Research"
 	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 6;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
 "kwT" = (
@@ -18241,11 +18269,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"kxL" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "kxS" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -18258,16 +18281,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"kyg" = (
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "kyv" = (
-/obj/machinery/door/airlock/external/glass{
-	req_access_txt = "31"
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/obj/effect/turf_decal/tile/brown/anticorner{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/qm)
 "kyz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -18332,9 +18356,13 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "kAs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "kAW" = (
@@ -18527,9 +18555,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"kGT" = (
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "kGU" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -18551,7 +18576,7 @@
 /obj/machinery/light/directional/west,
 /obj/structure/table,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "kHH" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -18559,26 +18584,22 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
 "kHX" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mech_bay_recharge_port,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/brown/anticorner{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
-/area/cargo/warehouse)
+/area/cargo/storage)
 "kIj" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "kIK" = (
-/obj/machinery/computer/atmos_control,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/turf/closed/wall,
+/area/security/checkpoint/engineering)
 "kIL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -18619,13 +18640,17 @@
 "kJN" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 10;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+"kJP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "kKg" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
@@ -18681,9 +18706,14 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "kLg" = (
-/obj/machinery/atmospherics/components/trinary/filter,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/structure/bed,
+/obj/item/bedsheet/qm,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/cargo/qm)
 "kLs" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Base Airlock"
@@ -18750,8 +18780,10 @@
 /area/service/hydroponics/garden)
 "kMc" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -18969,9 +19001,14 @@
 /turf/open/floor/iron/dark/side,
 /area/construction/mining/aux_base)
 "kRy" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/computer/piratepad_control/civilian{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
@@ -19113,16 +19150,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "security red"
-	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "kUA" = (
@@ -19355,13 +19386,12 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
 "lao" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
+	dir = 8
 	},
-/obj/machinery/light_switch/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
@@ -19405,7 +19435,10 @@
 /turf/open/floor/carpet/green,
 /area/service/library/private)
 "laX" = (
-/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lbf" = (
@@ -19423,20 +19456,6 @@
 	dir = 4
 	},
 /area/construction/mining/aux_base)
-"lbm" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "mechbay";
-	name = "Mech Bay Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/robotics/mechbay)
 "lbp" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -19692,6 +19711,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"lgN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "lgW" = (
 /turf/open/floor/iron/dark,
 /area/science/storage)
@@ -19783,11 +19808,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "lkd" = (
-/obj/effect/turf_decal/siding/red/corner{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "lkx" = (
@@ -20033,23 +20058,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lpQ" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_one_access_txt = "31;48"
+/obj/machinery/mineral/ore_redemption,
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Ore Redemption Access";
+	req_access_txt = "64"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/cargo/office)
 "lqm" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "lqp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/closed/wall/r_wall,
@@ -20111,33 +20133,10 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "ltl" = (
-/obj/machinery/computer/cargo{
-	dir = 4
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "QMLoad2"
 	},
-/obj/machinery/button/door/directional/east{
-	id = "cargoload";
-	layer = 3.3;
-	name = "Loading Doors";
-	pixel_x = -24;
-	pixel_y = -8;
-	req_access_txt = "31"
-	},
-/obj/machinery/button/door/directional/east{
-	id = "cargounload";
-	layer = 3.3;
-	name = "Unloading Doors";
-	pixel_x = -24;
-	pixel_y = 8;
-	req_access_txt = "31"
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Cargo - Cargobay W";
-	name = "cargo camera"
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ltu" = (
@@ -20285,7 +20284,10 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/loading_area,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "lxJ" = (
@@ -20297,10 +20299,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"lxM" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "lxT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20377,10 +20375,13 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "lAa" = (
-/obj/machinery/rnd/bepis,
-/obj/effect/turf_decal/tile/brown/half,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/qm)
 "lAd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -20396,13 +20397,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
-"lAI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "lAP" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/clothing/mask/gas,
@@ -20460,6 +20454,7 @@
 	pixel_x = 25
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "lBI" = (
@@ -20559,6 +20554,13 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "lEa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/west{
+	id = "cargoware";
+	name = "Warehouse Shutters";
+	req_access_txt = "31"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -20588,6 +20590,12 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"lEG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "lEH" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
@@ -20653,12 +20661,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/storage/tcomms)
-"lGr" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 4
-	},
-/area/engineering/gravity_generator)
 "lGz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -20667,8 +20669,14 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "lGL" = (
-/obj/machinery/door/poddoor/massdriver_trash,
-/obj/structure/fans/tiny,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Disposal Exit";
+	name = "disposal exit vent"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "lGU" = (
@@ -20757,9 +20765,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lJO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/brown/anticorner{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
-/area/cargo/sorting)
+/area/cargo/qm)
 "lJW" = (
 /obj/effect/turf_decal/trimline/neutral/end{
 	dir = 1
@@ -20797,9 +20808,7 @@
 "lKo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "lKy" = (
@@ -20916,6 +20925,17 @@
 	icon_state = "chapel"
 	},
 /area/ai_monitored/turret_protected/ai_upload)
+"lLK" = (
+/obj/machinery/button/flasher{
+	id = "supcell";
+	pixel_x = 24;
+	req_access_txt = "2"
+	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "lMv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -20977,8 +20997,22 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "lOf" = (
-/turf/closed/wall,
-/area/space)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "qmlock";
+	name = "Lockdown Shutters";
+	pixel_x = -5
+	},
+/obj/machinery/button/door{
+	id = "qmprivacy";
+	name = "Privacy Shutters";
+	pixel_x = 5
+	},
+/turf/open/floor/iron,
+/area/cargo/qm)
 "lOi" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 1;
@@ -21054,13 +21088,8 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "lPl" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "celock";
-	name = "CE Office Lockdown Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "lPs" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -21095,9 +21124,13 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "lQH" = (
-/obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cargoware";
+	name = "Warehouse Shutters";
+	req_access_txt = "31"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21199,12 +21232,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
-"lSO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
 "lSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21216,10 +21243,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
 "lTg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/qm)
 "lTh" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/green/anticorner{
@@ -21335,8 +21363,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -21352,8 +21379,9 @@
 /area/medical/patients_rooms)
 "lVX" = (
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/internals,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "lWn" = (
@@ -21484,11 +21512,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	color = "#4D0067";
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "lZC" = (
@@ -21581,14 +21608,11 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "mbY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -21772,12 +21796,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/service/abandoned_gambling_den)
-"mfi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "mfn" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -21829,11 +21847,10 @@
 /turf/closed/wall,
 /area/hallway/primary/port)
 "mgG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/qm)
 "mgL" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -21858,14 +21875,15 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "miv" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	req_one_access_txt = "31"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard/fore)
 "miw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21936,13 +21954,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mkh" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/chair/office,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "mkB" = (
@@ -22128,11 +22145,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "mpa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mpd" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
@@ -22158,6 +22173,7 @@
 /area/engineering/atmos/office)
 "mpD" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "mpM" = (
@@ -22244,6 +22260,18 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"mtn" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "mto" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22255,12 +22283,16 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "mty" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
+/obj/docking_port/stationary{
+	dwidth = 3;
+	height = 5;
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/delta;
+	width = 7
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/space/basic,
+/area/space)
 "mtF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22308,10 +22340,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"muM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mail Maintenance";
+	req_one_access_txt = "48;50"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "muW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "mve" = (
@@ -22329,15 +22369,6 @@
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -22345,6 +22376,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "mvS" = (
@@ -22393,11 +22430,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"mwy" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "mwG" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -22680,37 +22712,20 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "mCM" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"mCO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "mCS" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/brown/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mCT" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "mCV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -22914,9 +22929,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing)
-"mHn" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/central)
 "mHA" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
@@ -23122,10 +23134,11 @@
 /area/hallway/secondary/exit/departure_lounge)
 "mKZ" = (
 /obj/structure/table,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "mLn" = (
@@ -23157,15 +23170,13 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "mLG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "qmlock";
+	name = "Quartermaster Lockdown Shutters"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
+/turf/open/floor/plating,
+/area/cargo/qm)
 "mLQ" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#4169E1";
@@ -23187,6 +23198,16 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
+"mMJ" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "mMO" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
@@ -23242,14 +23263,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mMY" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "mNf" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -23296,25 +23313,37 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"mNB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "mNS" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/storage)
-"mNT" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "mOc" = (
 /obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central/aft)
 "mOe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office";
+	req_access_txt = "56"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "mOg" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -23385,12 +23414,14 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "mQl" = (
-/obj/structure/chair/office,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/brown/anticorner{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/cargo/qm)
+/area/cargo/storage)
 "mQm" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/structure/filingcabinet,
@@ -23507,6 +23538,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/neon/simple/purple,
 /area/command/heads_quarters/rd)
+"mTB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "mTD" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/grimy,
@@ -23537,11 +23572,9 @@
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/port)
 "mUE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -23735,6 +23768,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"mZI" = (
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/coldroom)
 "mZJ" = (
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
@@ -23772,11 +23809,20 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "nav" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/bot/mulebot{
+	beacon_freq = 1400;
+	home_destination = "QM #1";
+	suffix = "#1"
+	},
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/cargo/storage)
 "naD" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -5;
@@ -23818,12 +23864,17 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
 "nbd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/bot/mulebot{
+	beacon_freq = 1400;
+	home_destination = "QM #1";
+	suffix = "#1"
+	},
+/obj/effect/turf_decal/tile/brown/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "nbe" = (
 /obj/structure/window/reinforced,
 /obj/item/kirbyplants{
@@ -23856,16 +23907,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"ncK" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/office)
 "ncQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -23900,8 +23941,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "ndR" = (
+/obj/machinery/light/small/directional/west,
 /obj/machinery/conveyor{
-	dir = 1;
+	dir = 9;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -23965,6 +24007,15 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"nfi" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Radstorm Shelter"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "nfA" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -24229,6 +24280,7 @@
 	color = "#4169E1";
 	name = "Command blue half"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "noV" = (
@@ -24340,6 +24392,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "nsw" = (
@@ -24347,13 +24402,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "nsG" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48"
 	},
-/obj/machinery/recycler,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/cargo/miningdock)
 "ntb" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating{
@@ -24380,13 +24435,6 @@
 	dir = 4
 	},
 /area/medical/treatment_center)
-"ntz" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "ntE" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -24413,30 +24461,16 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"nuu" = (
-/obj/machinery/conveyor/inverted{
-	dir = 8;
-	id = "QMLoad"
-	},
-/obj/machinery/door/poddoor{
-	id = "cargounload";
-	name = "Cargo Unloading Door"
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "nuz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "nuI" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/command/heads_quarters/ce)
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
 "nve" = (
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
@@ -24589,7 +24623,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "nyv" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/toxin{
@@ -24643,12 +24677,20 @@
 /turf/open/floor/carpet/green,
 /area/service/library/private)
 "nyI" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "cargodisposals"
+/obj/machinery/door/airlock/mining{
+	name = "Quartermaster Office";
+	req_one_access_txt = "41"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "qmlock";
+	name = "Quartermaster Lockdown Shutters"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/cargo/sorting)
+/area/cargo/qm)
 "nyK" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
@@ -24662,9 +24704,6 @@
 /area/service/kitchen)
 "nzp" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/camera/directional/south{
@@ -24672,16 +24711,15 @@
 	name = "Ordnance Lab Camera";
 	network = list("ss13","rd")
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "nzx" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "nzy" = (
@@ -24701,11 +24739,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	color = "#4D0067"
-	},
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -24772,19 +24810,11 @@
 	},
 /area/medical/treatment_center)
 "nCj" = (
-/obj/structure/table,
-/obj/item/cartridge/engineering{
-	pixel_x = -3;
-	pixel_y = 2
+/obj/machinery/suit_storage_unit/ce,
+/obj/machinery/keycard_auth/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
-/obj/item/cartridge/engineering{
-	pixel_x = 3
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/orange,
 /area/command/heads_quarters/ce)
 "nCw" = (
 /obj/item/radio/intercom/directional/west,
@@ -24830,15 +24860,6 @@
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plating,
 /area/service/chapel/office)
-"nDW" = (
-/obj/structure/table,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/extinguisher/mini,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "nEc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal/bin,
@@ -24929,6 +24950,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
+"nHs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "nHz" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Detective";
@@ -24942,17 +24970,6 @@
 /obj/effect/landmark/secequipment,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
-"nHT" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/mop,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "nIj" = (
 /obj/structure/sign/warning/coldtemp,
 /turf/closed/wall,
@@ -24971,9 +24988,9 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "nIJ" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "nJa" = (
@@ -25035,16 +25052,21 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"nKs" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "nKW" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos/upper)
 "nLi" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/cargo/warehouse)
+/area/cargo/storage)
 "nLH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -25351,6 +25373,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"nVb" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "nVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/glass,
@@ -25375,17 +25401,16 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "nWx" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/conveyor/inverted{
-	dir = 8;
-	id = "QMLoad"
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/cargo/storage)
 "nWF" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/ore_box,
-/turf/open/floor/plating,
+/obj/machinery/computer/shuttle/mining,
+/obj/structure/sign/warning/pods{
+	name = "MINING POD";
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
 /area/cargo/miningdock)
 "nWT" = (
 /obj/structure/rack,
@@ -25395,9 +25420,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "nWZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/coldroom)
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/poddoor/shutters{
+	id = "cargoware";
+	name = "Warehouse Shutters"
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "nXg" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/vacuum/external{
@@ -25423,8 +25453,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -25443,9 +25472,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "nXR" = (
-/obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/poly,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side,
 /area/command/heads_quarters/ce)
 "nXY" = (
 /obj/effect/turf_decal/siding/wood{
@@ -25502,6 +25529,32 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"nZt" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_y = 10;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_x = -36;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door/directional/west{
+	desc = "A remote control switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_y = -6;
+	req_access_txt = "10"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "nZu" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067"
@@ -25533,11 +25586,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"oao" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "oas" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/east,
@@ -25586,14 +25634,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/solars/port/fore)
 "obv" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/emcloset,
+/obj/structure/sign/warning/pods{
+	name = "MINING POD";
+	pixel_y = 30
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
+/turf/open/floor/plating,
+/area/cargo/miningdock)
 "oby" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/disposal/bin,
@@ -25722,11 +25770,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/iron,
 /area/cargo/office)
 "ofS" = (
@@ -25742,14 +25785,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "ogr" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/structure/table,
+/obj/item/paper_bin/carbon,
+/obj/item/pen,
 /turf/open/floor/iron,
 /area/cargo/office)
 "ogJ" = (
@@ -25783,7 +25825,6 @@
 /turf/closed/wall,
 /area/security/lockers)
 "ohS" = (
-/obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -25797,10 +25838,33 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "oiq" = (
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "QMLoad"
+/obj/machinery/computer/cargo{
+	dir = 4
 	},
+/obj/machinery/button/door/directional/east{
+	id = "cargoload";
+	layer = 3.3;
+	name = "Loading Doors";
+	pixel_x = -24;
+	pixel_y = -8;
+	req_access_txt = "31"
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cargounload";
+	layer = 3.3;
+	name = "Unloading Doors";
+	pixel_x = -24;
+	pixel_y = 8;
+	req_access_txt = "31"
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Cargo - Cargobay W";
+	name = "cargo camera"
+	},
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 8
+	},
+/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ois" = (
@@ -25827,19 +25891,34 @@
 "oja" = (
 /obj/machinery/navbeacon/wayfinding,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "oji" = (
-/obj/structure/table,
-/obj/item/paper_bin/carbon,
-/obj/item/paper/monitorkey,
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/floor/carpet/orange,
+/obj/item/storage/secure/safe/directional/east,
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 5;
+	name = "Chief Engineer's Request Console"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/command/heads_quarters/ce)
 "ojk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25917,23 +25996,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
-"omE" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
-"omJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "omP" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/beakers{
@@ -26273,12 +26335,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "owP" = (
-/obj/effect/turf_decal/tile/brown/anticorner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/qm)
+/obj/effect/turf_decal/delivery,
+/obj/structure/tank_dispenser/oxygen,
+/obj/structure/sign/warning/pods{
+	name = "MINING POD";
+	pixel_y = 30
+	},
+/turf/open/floor/plating,
+/area/cargo/miningdock)
 "oxd" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/grass/jungle/b,
@@ -26334,13 +26398,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"oyP" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "oyX" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ozh" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -26359,10 +26425,6 @@
 /obj/machinery/computer/scan_consolenew,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"ozS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/cargo/warehouse)
 "ozZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half{
@@ -26385,15 +26447,6 @@
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -26402,6 +26455,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "oAl" = (
@@ -26422,12 +26479,19 @@
 /area/security/prison)
 "oAr" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "oAA" = (
@@ -26445,12 +26509,19 @@
 	name = "Research Lockdown Door"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/full{
-	color = "#4D0067"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/lab)
 "oAL" = (
@@ -26500,8 +26571,7 @@
 /area/medical/pharmacy)
 "oBS" = (
 /obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
+/obj/machinery/computer/atmos_alert,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "oCc" = (
@@ -26609,16 +26679,13 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "oDa" = (
-/obj/structure/plasticflaps,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "cargodisposals"
-	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
-/area/cargo/sorting)
+/area/cargo/warehouse)
 "oDC" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26673,6 +26740,10 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oEZ" = (
+/obj/structure/closet/mini_fridge,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "oFh" = (
 /obj/structure/chair{
 	dir = 8
@@ -26680,13 +26751,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oFt" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "security red"
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/security/science,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "oFy" = (
@@ -26695,11 +26765,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "oFG" = (
@@ -26845,6 +26914,14 @@
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"oJM" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "oJR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/slot_machine,
@@ -26911,9 +26988,13 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "oKX" = (
-/obj/machinery/computer/station_alert,
+/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/security/checkpoint/engineering)
 "oKZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26959,8 +27040,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "oLU" = (
+/obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "oNz" = (
@@ -27000,16 +27083,15 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
-"oNZ" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
+"oNU" = (
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "oOC" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -27018,6 +27100,13 @@
 /obj/structure/chair/pew,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"oOD" = (
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "oOO" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 4
@@ -27139,10 +27228,16 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "oSK" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/machinery/light/small/directional/east,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 1;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "oSR" = (
@@ -27312,7 +27407,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "oXG" = (
@@ -27321,6 +27418,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"oXH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/office)
 "oXM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -27343,6 +27446,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"oXV" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/hardhat/red,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "oYo" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/blue/half{
@@ -27384,6 +27494,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "oZZ" = (
@@ -27411,6 +27522,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/library)
+"paO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "paU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27442,21 +27558,6 @@
 "pbI" = (
 /turf/closed/wall,
 /area/security/prison/toilet)
-"pca" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "mechbay";
-	name = "Mech Bay Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/robotics/mechbay)
 "pci" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/camera/directional/north{
@@ -27554,25 +27655,12 @@
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
 "pfO" = (
-/obj/machinery/disposal/delivery_chute{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	base_state = "right";
+/obj/machinery/conveyor{
 	dir = 4;
-	icon_state = "right";
-	layer = 3
+	id = "garbage"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "pfX" = (
@@ -27679,12 +27767,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "phW" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "piN" = (
@@ -27692,6 +27779,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"piY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "pju" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -27891,7 +27984,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "poG" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
@@ -28032,8 +28125,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "puo" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "puH" = (
@@ -28064,11 +28157,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pxh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
 	},
-/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "pxm" = (
@@ -28274,26 +28366,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "pEK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "celock";
-	name = "CE Office Lockdown Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
 "pES" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "garbage"
 	},
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 1;
-	icon_state = "left";
-	name = "Danger: Conveyor Access";
-	req_access_txt = "12"
-	},
+/obj/machinery/recycler,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "pFH" = (
@@ -28335,6 +28415,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"pGu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	req_access_txt = "31"
+	},
+/turf/open/floor/plating,
+/area/cargo/office)
 "pGw" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/directional/north{
@@ -28518,9 +28606,6 @@
 "pNr" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
-"pNB" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/bridge)
 "pNC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/loading_area/red{
@@ -28545,6 +28630,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"pOi" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "pOu" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -28743,11 +28834,9 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "pUP" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/tile/brown/half,
+/obj/structure/closet/secure_closet/security/cargo,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/security/checkpoint/supply)
 "pUQ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -28771,14 +28860,17 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"pWg" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
+"pVR" = (
+/obj/machinery/computer/security,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/service/bar/atrium)
+/area/security/checkpoint/engineering)
+"pWg" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/cargo/miningdock)
 "pWq" = (
 /obj/structure/closet/secure_closet/cytology,
 /obj/machinery/firealarm/directional/west,
@@ -28800,24 +28892,14 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/drone_bay)
-"pWF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel/office)
-"pWG" = (
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "pWO" = (
 /turf/closed/indestructible/opshuttle,
 /area/science/test_area)
 "pWS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/effect/turf_decal/delivery,
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/cargo/miningdock)
 "pXe" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -28839,22 +28921,14 @@
 /area/engineering/supermatter/room)
 "pYf" = (
 /obj/structure/table,
-/obj/machinery/button/door/directional/east{
-	id = "celock";
-	name = "CE Office Lockdown Button";
-	pixel_x = 40;
-	req_access_txt = "56"
-	},
-/obj/item/stamp/denied,
-/obj/item/stamp/ce{
-	pixel_x = -2;
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
+/obj/item/flashlight/lamp,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "pYh" = (
-/turf/closed/wall,
-/area/cargo/qm)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "pYl" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -28892,17 +28966,11 @@
 	},
 /area/science/research)
 "pZn" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/cargo/storage)
 "pZL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29046,12 +29114,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
 "qfG" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Science";
+	req_access_txt = "63"
 	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/security/checkpoint/supply)
 "qfM" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -29107,11 +29177,20 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "qgI" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	id = "supcell";
+	name = "Cargo Cell";
+	req_access_txt = "63"
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/security/checkpoint/supply)
 "qhj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29154,8 +29233,7 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "qhV" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/disposal/bin,
+/obj/machinery/computer/station_alert,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "qid" = (
@@ -29215,11 +29293,6 @@
 /obj/item/toy/figure/geneticist,
 /turf/open/floor/grass,
 /area/science/genetics)
-"qkW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "qln" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700";
@@ -29351,12 +29424,11 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "qpz" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "security red"
-	},
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "qpH" = (
@@ -29380,6 +29452,7 @@
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
 	},
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/command/heads_quarters/captain/private)
 "qpP" = (
@@ -29395,13 +29468,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"qql" = (
-/obj/effect/turf_decal/tile/blue/half{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "qqz" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -29420,6 +29486,10 @@
 /obj/item/grenade/barrier,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"qro" = (
+/obj/structure/mopbucket,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "qrQ" = (
 /obj/machinery/button/door/directional/north{
 	id = "Prosecution1";
@@ -29435,12 +29505,6 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
-"qsX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "qta" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
@@ -29534,8 +29598,9 @@
 /turf/closed/wall,
 /area/maintenance/department/medical/central)
 "qwv" = (
-/turf/open/floor/iron/dark/side,
-/area/command/heads_quarters/ce)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "qwH" = (
 /obj/structure/grille/broken,
 /turf/open/space/basic,
@@ -29589,8 +29654,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/sloth/paperwork,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qyB" = (
@@ -29690,6 +29753,11 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"qAD" = (
+/obj/machinery/computer/station_alert,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "qAZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/directional/north,
@@ -29799,7 +29867,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "qEl" = (
-/obj/effect/turf_decal/tile/brown/half{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -29808,15 +29876,12 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qEo" = (
-/obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/mulebot{
-	beacon_freq = 1400;
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
-/obj/effect/turf_decal/tile/brown/anticorner{
+/obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qEz" = (
@@ -29880,7 +29945,7 @@
 /area/science/genetics)
 "qGo" = (
 /turf/closed/wall,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "qGv" = (
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/siding/green{
@@ -30010,13 +30075,10 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "qIu" = (
-/obj/machinery/mass_driver/trash{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "qIC" = (
@@ -30234,9 +30296,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "qOk" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/cargo/miningdock)
 "qOv" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -30314,7 +30374,8 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "qQM" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -30329,20 +30390,17 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"qSc" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "qSj" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage)
 "qSA" = (
-/obj/machinery/door/window/eastright{
-	name = "Danger: Conveyor Access";
-	req_access_txt = "12"
-	},
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "qSK" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 4
@@ -30395,12 +30453,13 @@
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
 "qVa" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Warehouse Maintenance";
-	req_one_access_txt = "31"
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/cargo/qm)
 "qVc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -30414,6 +30473,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"qVS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "qWk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
@@ -30475,11 +30546,10 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos/upper)
 "qXL" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "qXQ" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -30509,11 +30579,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "qYF" = (
@@ -30535,15 +30604,16 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "qYQ" = (
-/obj/machinery/disposal/delivery_chute{
-	dir = 1
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "QMLoad"
 	},
-/turf/open/floor/plating,
-/area/cargo/sorting)
-"qYT" = (
-/obj/structure/closet/emcloset,
+/obj/machinery/door/poddoor{
+	id = "cargounload";
+	name = "Cargo Unloading Door"
+	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/area/cargo/storage)
 "qZl" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/window/reinforced,
@@ -30611,14 +30681,13 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "rbW" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor/inverted{
+	dir = 8;
+	id = "QMLoad"
 	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/turf/open/floor/iron,
+/area/cargo/storage)
 "rbX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -30646,9 +30715,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
+/obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/cargo/office)
 "rcX" = (
@@ -30673,7 +30740,7 @@
 	name = "security red"
 	},
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rdI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/meter,
@@ -30721,13 +30788,16 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "reV" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/door/airlock/mining{
+	name = "Mining Dock";
+	req_access_txt = "48"
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/service/bar/atrium)
+/area/cargo/storage)
 "reW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -30820,19 +30890,17 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "rim" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/door/airlock/external/glass{
+	req_access_txt = "31"
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/requests_console/directional/north{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo Bay Requests Console"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/cargo/storage)
 "rio" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -30845,12 +30913,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "rjC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/brown/anticorner,
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rjI" = (
@@ -30949,6 +31014,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"rmg" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/door_timer{
+	id = "cargocell";
+	name = "Cargo Cell";
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "rms" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -31182,10 +31256,12 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "rsF" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
-/area/cargo/sorting)
+/area/cargo/storage)
 "rte" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31226,14 +31302,17 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "ruv" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/tank_dispenser/oxygen,
-/obj/structure/sign/warning/pods{
-	name = "MINING POD";
-	pixel_y = 30
+/obj/machinery/door/airlock/external/glass{
+	req_access_txt = "31"
 	},
-/turf/open/floor/plating,
-/area/cargo/miningdock)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "ruy" = (
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/trimline/red/line{
@@ -31264,11 +31343,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "rvt" = (
@@ -31443,35 +31521,26 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "rBl" = (
-/obj/machinery/piratepad/civilian,
-/obj/machinery/status_display/supply{
-	pixel_y = -32
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/brown/anticorner{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/cargo/storage)
 "rBm" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8;
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "rBx" = (
@@ -31528,16 +31597,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "rCr" = (
-/obj/structure/chair/comfy/brown{
-	color = "#EFB341";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/floor/carpet/royalblack,
-/area/command/heads_quarters/ce)
+/obj/structure/closet/wardrobe/miner,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "rCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31576,10 +31638,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
-"rDB" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white/textured_large,
-/area/medical/medbay/lobby)
 "rDO" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -31656,6 +31714,11 @@
 	dir = 5;
 	name = "engineering yellow"
 	},
+/obj/machinery/microwave{
+	desc = "NT didn't give them one, so they made one..";
+	name = "jury-rigged microwave";
+	pixel_y = 5
+	},
 /turf/open/floor/carpet/orange,
 /area/engineering/lobby)
 "rFs" = (
@@ -31719,11 +31782,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	color = "#4D0067";
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "rGo" = (
@@ -31774,15 +31836,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rIi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/grass,
 /area/medical/virology)
 "rIz" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "rIK" = (
@@ -31855,7 +31915,7 @@
 	name = "Security Post Camera"
 	},
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rJM" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -31866,7 +31926,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rKg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -31882,7 +31942,7 @@
 	},
 /obj/structure/table,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rKj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31909,9 +31969,6 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "rKx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -31945,7 +32002,9 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "rLq" = (
-/obj/structure/closet/secure_closet/miner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "rLr" = (
@@ -32078,10 +32137,19 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "rOJ" = (
-/obj/machinery/disposal/bin,
-/obj/structure/cable,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/glass,
+/obj/item/stack/ore/glass,
 /turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/area/cargo/miningdock)
 "rOR" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/closed/wall/r_wall,
@@ -32210,6 +32278,9 @@
 	receive_ore_updates = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "rSW" = (
@@ -32307,7 +32378,7 @@
 /area/science/storage)
 "rUI" = (
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rUK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -32321,7 +32392,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rVk" = (
 /turf/open/floor/carpet,
 /area/service/bar)
@@ -32339,7 +32410,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "rVW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -32369,18 +32440,12 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "rWI" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/stack/wrapping_paper{
-	pixel_y = 5
-	},
-/obj/item/stack/package_wrap,
-/turf/open/floor/iron,
-/area/cargo/office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rWO" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -32402,16 +32467,14 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "rXa" = (
-/obj/docking_port/stationary{
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/delta;
-	width = 7
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/cargo/miningdock)
 "rXd" = (
 /obj/structure/sink{
 	dir = 4;
@@ -32450,12 +32513,15 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "rXF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	req_access_txt = "31"
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_one_access_txt = "31;48"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
 /area/cargo/office)
 "rXJ" = (
 /obj/effect/turf_decal/siding/purple/corner{
@@ -32476,6 +32542,12 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "rXN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door/directional/west{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "rXV" = (
@@ -32496,6 +32568,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"rYk" = (
+/obj/structure/cable,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/cargo/office)
 "rYp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -32504,11 +32581,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "rYy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 5;
+	height = 6;
+	id = "supply_home";
+	name = "Cargo Bay";
+	width = 12
 	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/turf/open/space/basic,
+/area/space)
 "rYE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -32530,8 +32612,8 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "rYX" = (
-/obj/machinery/conveyor{
-	dir = 1;
+/obj/machinery/conveyor/inverted{
+	dir = 10;
 	id = "QMLoad"
 	},
 /turf/open/floor/iron,
@@ -32588,6 +32670,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"sah" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "say" = (
 /obj/effect/mob_spawn/corpse/human/assistant,
 /turf/open/floor/plating{
@@ -32881,8 +32969,9 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "sjy" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/freezer,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "skL" = (
@@ -32909,12 +32998,12 @@
 	},
 /obj/structure/chair,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "slz" = (
 /obj/effect/turf_decal/siding/red/corner,
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "slA" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -32925,7 +33014,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "slG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -32958,12 +33047,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "slU" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -33177,8 +33265,10 @@
 /area/medical/chemistry)
 "sqx" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -33295,6 +33385,13 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"ssU" = (
+/obj/structure/table,
+/obj/item/paper_bin/carbon,
+/obj/item/paper/monitorkey,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "stc" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/half{
@@ -33361,7 +33458,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "svI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33553,7 +33650,8 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "sAa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "sAG" = (
@@ -33652,7 +33750,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "sEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33800,10 +33898,9 @@
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
 "sKv" = (
-/obj/structure/rack,
-/obj/item/plunger,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "sKP" = (
 /obj/structure/rack,
 /obj/structure/window{
@@ -33852,10 +33949,20 @@
 /turf/open/floor/engine/o2,
 /area/engineering/atmos/upper)
 "sMy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/pen/red,
+/obj/item/pen/blue{
+	pixel_y = -4
+	},
+/obj/item/multitool,
+/obj/item/toy/figure/cargotech,
 /turf/open/floor/iron,
-/area/cargo/warehouse)
+/area/cargo/storage)
 "sMB" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -33878,20 +33985,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"sMV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
-"sMX" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "sNl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -33899,23 +33992,12 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "sNp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	freq = 1400;
-	location = "Disposals"
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/door/window/northright{
-	dir = 2;
-	name = "delivery door";
-	req_access_txt = "31"
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stamp,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "sNV" = (
 /obj/machinery/door/airlock/external/glass{
 	req_access_txt = "31"
@@ -33923,9 +34005,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "sOA" = (
@@ -33952,10 +34032,12 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "sPU" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/corner,
+/obj/item/dest_tagger,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/cargo/sorting)
 "sQm" = (
 /obj/structure/table,
 /obj/item/holosign_creator/robot_seat/restaurant,
@@ -33981,12 +34063,11 @@
 /area/engineering/supermatter/room)
 "sQG" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
 /obj/machinery/status_display/ai/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "sQJ" = (
@@ -34049,8 +34130,15 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
 /area/cargo/office)
+"sSl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "sSq" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
@@ -34132,6 +34220,21 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"sTL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters{
+	id = "mechbay";
+	name = "Mech Bay Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/robotics/mechbay)
 "sTO" = (
 /obj/structure/cable,
 /obj/machinery/disposal/bin,
@@ -34148,9 +34251,10 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos/upper)
 "sUm" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/vehicle/sealed/mecha/working/ripley/cargo,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron/recharge_floor,
 /area/cargo/warehouse)
 "sUq" = (
 /obj/machinery/light/small/directional/west,
@@ -34197,9 +34301,18 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "sVy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/stack/wrapping_paper{
+	pixel_y = 5
+	},
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/cargo/office)
 "sVK" = (
@@ -34232,7 +34345,7 @@
 	name = "Sec Outpost - Arrivals"
 	},
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "sWD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
@@ -34279,11 +34392,13 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "sYm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor/inverted{
+	dir = 4;
+	id = "QMLoad2"
 	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/turf/open/floor/iron,
+/area/cargo/storage)
 "sYs" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
@@ -34325,13 +34440,9 @@
 /area/security/prison/safe)
 "sZc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door/directional/west{
-	id = "cargoware";
-	name = "Warehouse Shutters";
-	req_access_txt = "31"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "sZh" = (
@@ -34393,10 +34504,8 @@
 /area/security/processing)
 "tal" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "taB" = (
@@ -34414,14 +34523,13 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "tbh" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 2
+/obj/machinery/door/window/eastright{
+	name = "Danger: Conveyor Access";
+	req_access_txt = "12"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -34442,9 +34550,7 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "tdj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -34664,10 +34770,10 @@
 /area/command/heads_quarters/rd)
 "tjj" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -34808,12 +34914,19 @@
 	dir = 1;
 	id = "QMLoad2"
 	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"tmt" = (
+/obj/machinery/door_timer{
+	id = "engcell";
+	name = "Engineering Cell";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "tmH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34902,13 +35015,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/security/prison/workout)
-"toT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "toX" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -34944,11 +35050,6 @@
 	dir = 10
 	},
 /area/command/gateway)
-"tqT" = (
-/obj/effect/spawner/random/structure/table,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "tqY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34992,11 +35093,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"tsj" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "tsk" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
@@ -35035,9 +35131,9 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "tsQ" = (
-/obj/structure/table,
-/turf/open/floor/carpet/orange,
-/area/command/heads_quarters/ce)
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "tsS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
@@ -35101,12 +35197,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "tua" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	dir = 9;
-	name = "security red"
-	},
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "tuc" = (
@@ -35141,11 +35236,8 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
 "tuK" = (
-/obj/machinery/computer/shuttle/mining,
-/obj/structure/sign/warning/pods{
-	name = "MINING POD";
-	pixel_y = 30
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "tvj" = (
@@ -35186,14 +35278,14 @@
 /obj/machinery/shower{
 	pixel_y = 16
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
-	dir = 4
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "tvA" = (
@@ -35347,7 +35439,7 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
-/area/security/checkpoint)
+/area/security/checkpoint/customs)
 "tBi" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "cell6lock";
@@ -35418,17 +35510,13 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "tBW" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
+/obj/machinery/door/airlock/mining{
+	name = "Cargo Bay";
+	req_one_access_txt = "31;48"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/office)
 "tCi" = (
 /obj/machinery/door/window/eastright{
 	dir = 8;
@@ -35555,6 +35643,7 @@
 /area/security/brig/upper)
 "tEe" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "tEk" = (
@@ -35659,6 +35748,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"tGH" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "tHH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -35721,11 +35819,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "tJl" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/tile/brown/anticorner{
-	dir = 1
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 8
 	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "tJp" = (
@@ -35745,12 +35844,7 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
 "tKA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "qmlock";
-	name = "Quartermaster Lockdown Shutters"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/cargo/qm)
 "tKL" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -35953,11 +36047,13 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
 "tRd" = (
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/sloth/paperwork,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "tRh" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -36151,6 +36247,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"tUL" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "tUT" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -36165,12 +36268,11 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "tVf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mail Maintenance";
-	req_one_access_txt = "48;50"
+/obj/machinery/modular_computer/console/preset/cargochat/cargo{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "tVB" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 4
@@ -36207,10 +36309,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "tWU" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 1;
-	id = "QMLoad"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -36227,20 +36325,9 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
 "tXd" = (
-/obj/machinery/door/airlock/mining{
-	name = "Quartermaster Office";
-	req_one_access_txt = "41"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "qmlock";
-	name = "Quartermaster Lockdown Shutters"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/cargo/qm)
+/area/cargo/sorting)
 "tXp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36339,23 +36426,22 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
 "tZG" = (
-/obj/machinery/vending/coffee,
-/obj/structure/sign/poster/contraband/hacking_guide{
-	pixel_y = 32
+/obj/machinery/conveyor_switch/oneway{
+	id = "cargodisposals";
+	name = "disposals conveyor switch";
+	pixel_x = -8
 	},
-/turf/open/floor/iron/dark/corner{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/area/command/heads_quarters/ce)
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "tZL" = (
 /obj/structure/table,
 /obj/item/toy/plush/fly,
 /turf/open/floor/iron,
 /area/security/prison)
 "uaj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
 	dir = 4
@@ -36787,11 +36873,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "uia" = (
@@ -36846,15 +36931,15 @@
 /obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ujb" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ujh" = (
@@ -36943,7 +37028,7 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "ulV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "umc" = (
@@ -36952,21 +37037,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"umf" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/light_switch/directional/east,
-/obj/item/storage/box/shipping,
-/obj/item/stamp,
-/obj/item/stamp/denied{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "umh" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 9
@@ -37211,14 +37281,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "uqs" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/structure/closet/secure_closet/brig{
+	id = "cargocell";
+	name = "Cargo Cell Locker"
 	},
-/obj/structure/cable,
-/obj/machinery/autolathe,
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/security/checkpoint/supply)
 "uqu" = (
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
@@ -37261,12 +37329,10 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "ure" = (
-/obj/structure/bed,
-/obj/item/bedsheet/qm,
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "urf" = (
@@ -37293,9 +37359,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
 "urm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "urN" = (
@@ -37400,11 +37464,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "utk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/button/door/directional/west{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	req_access_txt = "12"
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -37422,6 +37484,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/courtroom)
+"utC" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "uua" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -37436,14 +37506,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
-"uul" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue half"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
 "uuq" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -37503,6 +37565,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"uvW" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "uwg" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -37510,18 +37579,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
-"uwo" = (
-/obj/machinery/computer/piratepad_control/civilian{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "uwp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -37587,6 +37644,7 @@
 /area/ai_monitored/command/storage/eva)
 "uxD" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/command/heads_quarters/captain/private)
 "uxM" = (
@@ -37652,10 +37710,11 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "uAP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/conveyor/inverted{
+	dir = 5
+	},
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/cargo/sorting)
 "uBb" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating,
@@ -37936,12 +37995,12 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "uGJ" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "uGQ" = (
@@ -38448,12 +38507,23 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "uRb" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	freq = 1400;
+	location = "Disposals"
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/door/window/northright{
+	dir = 2;
+	name = "delivery door";
+	req_access_txt = "31"
+	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 1;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/starboard/fore)
 "uRi" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -38466,12 +38536,12 @@
 /turf/open/floor/carpet/red,
 /area/maintenance/department/security)
 "uRn" = (
-/obj/machinery/computer/security/mining{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 10;
+	id = "cargodisposals"
 	},
-/obj/effect/turf_decal/tile/brown/half,
 /turf/open/floor/iron,
-/area/cargo/qm)
+/area/cargo/sorting)
 "uRu" = (
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
@@ -38479,9 +38549,17 @@
 	},
 /area/service/chapel)
 "uRv" = (
-/obj/effect/turf_decal/tile/brown/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/office)
 "uRx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Public Defender Maintenance";
@@ -38500,25 +38578,26 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "uRI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/photocopier,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/cargo/office)
 "uRX" = (
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "uSa" = (
 /obj/structure/table,
-/obj/item/book/random,
-/obj/item/book/random,
-/obj/item/candle{
-	pixel_x = 9;
-	pixel_y = 7
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/cell_charger,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "uSg" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/siding/brown{
@@ -38584,6 +38663,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "uTJ" = (
@@ -38659,6 +38739,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"uVz" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "uVI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
@@ -38731,13 +38815,20 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+"uXd" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "uXf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/cargo/storage)
 "uXi" = (
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
@@ -38754,6 +38845,12 @@
 "uXr" = (
 /turf/closed/wall,
 /area/science/breakroom)
+"uXs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "uXE" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -38793,15 +38890,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"uYf" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "uYn" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -38836,6 +38924,11 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"uZy" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "uZY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -38884,19 +38977,8 @@
 /turf/open/floor/wood,
 /area/service/library)
 "vbn" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/rnd/production/techfab/department/cargo,
-/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/security/checkpoint/supply)
 "vbE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -38976,10 +39058,10 @@
 "vdx" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/siding/red{
-	color = "#FF0000";
-	name = "security red"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "vdz" = (
@@ -39015,9 +39097,14 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "vdZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/side,
-/area/command/heads_quarters/ce)
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "veq" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light/directional/east,
@@ -39060,6 +39147,12 @@
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"veR" = (
+/obj/machinery/computer/department_orders/engineering{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "vfx" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/structure/chair/pew/left,
@@ -39077,11 +39170,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "vgt" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/cargo/miningdock)
 "vgw" = (
@@ -39096,9 +39190,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "vgB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Delivery Office";
+	req_one_access_txt = "48;50"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/maintenance/department/electrical)
+/area/cargo/storage)
 "vgC" = (
 /obj/structure/bookcase,
 /obj/machinery/light/directional/west,
@@ -39328,7 +39429,10 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "vky" = (
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/cargo/sorting)
 "vkz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
@@ -39472,6 +39576,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"vpc" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/captain)
 "vpg" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -39638,11 +39747,9 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "vtF" = (
@@ -39882,19 +39989,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "vwX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown/half,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"vxk" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Radstorm Shelter"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "vxx" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/r_wall,
@@ -39922,10 +40022,10 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "vxF" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "vxR" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -39961,6 +40061,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"vyA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
 "vyD" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -40159,6 +40265,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+"vDA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "vDD" = (
 /obj/structure/bed/dogbed/lia,
 /mob/living/simple_animal/hostile/carp/lia,
@@ -40201,6 +40312,17 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
+"vEp" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
+"vEE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "vEK" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -40255,11 +40377,18 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
-"vHz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+"vHe" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/maintenance/department/electrical)
+/area/hallway/primary/central/fore)
+"vHz" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/iron/dark/side,
+/area/command/heads_quarters/ce)
 "vHL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -40273,17 +40402,9 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tcomms)
 "vHV" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/east{
-	id = "cargoware";
-	name = "Warehouse Shutters";
-	req_access_txt = "31"
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vIl" = (
@@ -40520,18 +40641,27 @@
 /area/maintenance/starboard/fore)
 "vNi" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "vNk" = (
 /obj/item/trash/energybar,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vNx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+"vNo" = (
+/obj/structure/table,
+/obj/item/toy/figure/ce,
+/obj/item/storage/box/matches{
+	pixel_y = 4
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "vNO" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/blue{
@@ -40642,9 +40772,8 @@
 	dir = 1;
 	id = "garbage"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Disposal Exit";
-	name = "disposal exit vent"
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -40822,14 +40951,24 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "vUN" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/computer/pod/old/mass_driver_controller/trash{
-	pixel_x = -24
+/obj/machinery/disposal/delivery_chute{
+	dir = 4
 	},
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "garbage";
-	name = "disposal conveyor"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -41022,6 +41161,21 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vZF" = (
+/obj/structure/table,
+/obj/item/cartridge/engineering{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 3
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
 "vZI" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -41046,14 +41200,9 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "vZM" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/floor/iron/dark/side,
+/area/command/heads_quarters/ce)
 "vZS" = (
 /obj/item/trash/energybar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41216,13 +41365,14 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "wcJ" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"wcK" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/science/central)
 "wcP" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -41347,6 +41497,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"wft" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "wfu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
@@ -41365,16 +41519,21 @@
 	dir = 6
 	},
 /area/medical/treatment_center)
-"wgn" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "wgC" = (
 /turf/closed/wall/r_wall,
 /area/engineering/gravity_generator)
 "wgE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 1;
+	icon_state = "left";
+	name = "Danger: Conveyor Access";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wgX" = (
@@ -41408,15 +41567,12 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "whW" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
 "wib" = (
@@ -41485,9 +41641,17 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "wkC" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "wlx" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom/directional/west{
@@ -41901,6 +42065,10 @@
 	dir = 8
 	},
 /area/service/chapel)
+"wvO" = (
+/obj/effect/spawner/random/clothing/bowler_or_that,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wvS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -41980,6 +42148,12 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"wxh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "wxl" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -42032,8 +42206,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "wxS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wxV" = (
@@ -42226,14 +42407,11 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "wBs" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/poddoor/shutters{
-	id = "cargoware";
-	name = "Warehouse Shutters"
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/cargo/warehouse)
+/area/cargo/storage)
 "wBF" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/bananalamp{
@@ -42256,9 +42434,7 @@
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
 "wBQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wCd" = (
@@ -42308,6 +42484,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"wCj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron,
+/area/engineering/main)
 "wCu" = (
 /obj/item/trash/boritos,
 /obj/effect/mob_spawn/corpse/human/assistant,
@@ -42367,14 +42550,8 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "wDu" = (
-/obj/machinery/computer/apc_control{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/command/heads_quarters/ce)
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "wDA" = (
 /obj/machinery/door/airlock/security{
 	name = "Equipment Room";
@@ -42500,11 +42677,9 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "wGQ" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "wGV" = (
@@ -42619,10 +42794,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "wKp" = (
-/obj/effect/turf_decal/tile/brown/anticorner{
+/obj/effect/turf_decal/tile/brown/half{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "wKB" = (
@@ -42748,12 +42925,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
-"wMt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "wMV" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -42873,9 +43044,8 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tcomms)
 "wQW" = (
-/obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -42914,6 +43084,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"wRv" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/ce)
 "wRU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -42927,26 +43106,15 @@
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
 "wSd" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/item/storage/box{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron,
-/area/cargo/sorting)
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "wSe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+/obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/engineering/main)
 "wSk" = (
@@ -43054,6 +43222,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"wVp" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/main)
 "wVx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -43181,12 +43353,10 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "wZb" = (
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	dir = 8;
-	name = "Science purple corner"
-	},
 /obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -43213,8 +43383,15 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "wZl" = (
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8;
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wZt" = (
@@ -43224,15 +43401,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"wZC" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
 "wZJ" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "AI Core - North Outer";
@@ -43282,6 +43450,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"xcQ" = (
+/obj/structure/table,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
+"xcZ" = (
+/obj/machinery/disposal/delivery_chute{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/cargo/sorting)
 "xda" = (
 /obj/structure/table/wood,
 /obj/item/food/burger/corgi,
@@ -43513,6 +43691,11 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
+"xid" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "xij" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science/research)
@@ -43720,10 +43903,6 @@
 /area/service/abandoned_gambling_den)
 "xor" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xot" = (
@@ -43907,6 +44086,7 @@
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "xvl" = (
+/obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/command/heads_quarters/captain/private)
 "xvt" = (
@@ -43932,11 +44112,13 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "xvO" = (
-/obj/effect/turf_decal/tile/brown/half{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xvQ" = (
@@ -44058,6 +44240,7 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "xzS" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xAv" = (
@@ -44148,12 +44331,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "xDy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
+/obj/machinery/atmospherics/components/trinary/filter,
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "xDI" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -44327,14 +44507,19 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "xIF" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "xIH" = (
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stamp,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "xIP" = (
@@ -44480,9 +44665,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "xLJ" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xLW" = (
@@ -44496,12 +44678,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "xMq" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	desc = "NT didn't give them one, so they made one..";
-	name = "jury-rigged microwave";
-	pixel_y = 5
-	},
+/obj/machinery/computer/atmos_control,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "xMv" = (
@@ -44519,8 +44697,11 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/office)
 "xNb" = (
-/turf/closed/wall,
-/area/cargo/miningdock)
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "xNB" = (
 /obj/machinery/door/window/brigdoor/eastright{
 	dir = 2;
@@ -44585,15 +44766,15 @@
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/project)
 "xOu" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/machinery/light/small/directional/west,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "xOw" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -44864,8 +45045,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067";
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -44886,11 +45069,17 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "xUc" = (
-/obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/iron/dark/side{
-	dir = 8
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	id = "engcell";
+	name = "Engineering Cell";
+	req_access_txt = "63"
 	},
-/area/command/heads_quarters/ce)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "xUk" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
@@ -44914,9 +45103,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "xUG" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xUT" = (
@@ -44951,9 +45141,14 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "xVQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/electrical)
+/turf/open/floor/carpet/royalblack,
+/area/command/heads_quarters/ce)
 "xVU" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -44994,16 +45189,8 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "xWB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -2
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 1;
-	pixel_y = 4
-	},
+/obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xWN" = (
@@ -45116,6 +45303,13 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xYV" = (
+/obj/machinery/door/morgue{
+	name = "Mass Driver";
+	req_access_txt = "27"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "xYW" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -45226,11 +45420,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "ybf" = (
 /turf/closed/wall,
 /area/maintenance/department/security)
@@ -45252,20 +45449,21 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/toy/figure/cargotech,
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "ycF" = (
-/obj/effect/spawner/random/clothing/bowler_or_that,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/half,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "ycH" = (
-/obj/effect/turf_decal/tile/purple/half{
-	color = "#4D0067"
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "ycI" = (
@@ -45336,21 +45534,16 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "yfA" = (
-/obj/machinery/conveyor/inverted{
-	dir = 5
-	},
+/obj/machinery/rnd/bepis,
+/obj/effect/turf_decal/tile/brown/half,
 /turf/open/floor/iron,
-/area/cargo/sorting)
+/area/cargo/storage)
 "yfC" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/tile/brown/half,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "yfD" = (
 /obj/structure/toilet/greyscale,
 /obj/machinery/camera{
@@ -45381,6 +45574,7 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/command/bridge)
 "yfQ" = (
@@ -45540,16 +45734,15 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
 "yiO" = (
-/obj/structure/filingcabinet,
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/structure/window{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/commons/vacant_room)
+/turf/open/floor/iron,
+/area/cargo/storage)
 "yje" = (
 /turf/open/floor/iron,
 /area/security/courtroom)
@@ -45609,10 +45802,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "yki" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "yko" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -45625,6 +45819,12 @@
 "ykr" = (
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"ykD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "ylh" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -59195,12 +59395,12 @@ xYW
 bie
 evD
 cmv
-mLG
+sVf
 fVX
 jPx
 eXq
 lVQ
-mCO
+ycH
 xYW
 xYW
 gyn
@@ -59457,7 +59657,7 @@ lxV
 cmv
 evD
 lVQ
-mCT
+wZb
 aIk
 fAV
 gyn
@@ -60744,7 +60944,7 @@ xYW
 oFy
 erd
 erd
-omJ
+tal
 xYW
 wtl
 fCe
@@ -61263,7 +61463,7 @@ erd
 eLw
 erd
 dho
-mCO
+ycH
 hXq
 wqG
 hHl
@@ -62797,7 +62997,7 @@ kiu
 hNG
 aJV
 xYW
-lVQ
+eGg
 cqb
 rSQ
 sQG
@@ -63598,7 +63798,7 @@ wqG
 nrd
 ykr
 sZC
-mwy
+uZy
 mgu
 mgu
 vlD
@@ -66423,7 +66623,7 @@ hXq
 hXq
 hXq
 hXq
-cCS
+paO
 sZC
 orr
 gCS
@@ -67163,10 +67363,10 @@ bEh
 bEh
 bEh
 ovP
-yki
-dqW
+xid
+fWW
 bYz
-mHn
+wcK
 uXi
 tLO
 sHa
@@ -67423,7 +67623,7 @@ mNf
 bYz
 vBc
 bYz
-mHn
+wcK
 vlK
 wcs
 xtk
@@ -67680,7 +67880,7 @@ sfa
 nkJ
 dDP
 bYz
-mHn
+wcK
 hab
 qeC
 eDr
@@ -67935,9 +68135,9 @@ kuZ
 fEd
 sfa
 nkJ
-tsj
+hRi
 bYz
-mHn
+wcK
 vuq
 vhv
 nnF
@@ -68171,7 +68371,7 @@ sgQ
 afY
 ble
 ble
-jUt
+wSd
 ble
 ble
 lgE
@@ -68192,9 +68392,9 @@ kuZ
 fEd
 sfa
 nkJ
-tsj
+hRi
 bZf
-mHn
+wcK
 vXJ
 nja
 vXJ
@@ -68427,9 +68627,9 @@ aQw
 sgQ
 blu
 ble
-edN
-kLg
-mgG
+vxF
+xDy
+yki
 ble
 ble
 cxy
@@ -68445,13 +68645,13 @@ mrW
 sEP
 fRX
 cCO
-vgB
+mTB
 pHa
 mTT
 nkJ
 hSl
 bZf
-mHn
+wcK
 fJK
 vhv
 vhv
@@ -68708,7 +68908,7 @@ sfa
 vIy
 hSl
 bZf
-mHn
+wcK
 mTr
 xtk
 pXH
@@ -68960,12 +69160,12 @@ eCY
 abG
 kuK
 sEP
-vHz
+btm
 sfa
 vIy
 vdi
 bZf
-mHn
+wcK
 mTE
 nar
 noe
@@ -69217,12 +69417,12 @@ lcI
 jqb
 nxR
 tVW
-xDy
+bEP
 sfa
-dqW
+fWW
 mvG
 bZf
-mHn
+wcK
 tji
 naD
 noy
@@ -69473,13 +69673,13 @@ sfa
 sfa
 sfa
 sfa
-vxF
-xVQ
+vEp
+jeU
 sfa
-dqW
-lxM
+fWW
+uVz
 bZf
-mHn
+wcK
 vXL
 fWI
 gHG
@@ -69733,10 +69933,10 @@ sfa
 sfa
 sfa
 sfa
-dqW
+fWW
 mvG
 bZf
-mHn
+wcK
 thy
 xtk
 fqj
@@ -69990,10 +70190,10 @@ sUb
 ukm
 ukm
 sfa
-dqW
+fWW
 hSl
 bZf
-mHn
+wcK
 gdq
 xtk
 xac
@@ -70247,18 +70447,18 @@ bvL
 bvL
 bvL
 sfa
-dqW
+fWW
 hSl
 bZf
-mHn
-mHn
-mHn
-mHn
-mHn
-mHn
-mHn
-mHn
-mHn
+wcK
+wcK
+wcK
+wcK
+wcK
+wcK
+wcK
+wcK
+wcK
 rXm
 agu
 rFs
@@ -70763,16 +70963,16 @@ sfa
 sfa
 eZy
 bPR
-dqW
+fWW
 lVr
-dqW
-mHn
-mHn
-mHn
-mHn
+fWW
+wcK
+wcK
+wcK
+wcK
 nRR
-mHn
-mHn
+wcK
+wcK
 pci
 xCL
 oFN
@@ -71023,7 +71223,7 @@ hSl
 hSl
 hSl
 hSl
-mHn
+wcK
 gkd
 bWl
 qZl
@@ -71836,10 +72036,10 @@ ybf
 lMU
 nSZ
 ybf
-kGT
-kGT
-kGT
-kGT
+kyg
+kyg
+kyg
+kyg
 ybf
 lpN
 tCT
@@ -72065,7 +72265,7 @@ xij
 cuF
 xij
 qpz
-mKZ
+gWx
 xij
 xij
 xij
@@ -72089,7 +72289,7 @@ vdG
 lDe
 ybf
 mFk
-kGT
+kyg
 lMU
 nWT
 ybf
@@ -72321,7 +72521,7 @@ uPb
 rut
 fVH
 tEe
-gSv
+lkd
 lkd
 mkh
 cxH
@@ -72345,8 +72545,8 @@ kEY
 kEY
 lDo
 ybf
-kGT
-kGT
+kyg
+kyg
 lMU
 ybf
 ybf
@@ -72354,7 +72554,7 @@ ybf
 ybf
 ybf
 ybf
-eMi
+jYM
 vjJ
 xQY
 umW
@@ -72542,7 +72742,7 @@ meC
 spf
 igx
 cGm
-vME
+wCj
 yaU
 gmF
 vov
@@ -72579,8 +72779,8 @@ weD
 hft
 tEe
 gJp
-acR
-acR
+lkd
+gSv
 kwN
 xij
 wbr
@@ -72603,15 +72803,15 @@ uMm
 kLY
 ybf
 mMO
-kGT
+kyg
 lMU
 ofS
 vYO
 wSK
 xda
 ybf
-kGT
-kGT
+kyg
+kyg
 vjJ
 xQY
 unJ
@@ -72799,7 +72999,7 @@ gzV
 xRT
 vME
 cGm
-vME
+bpP
 yaU
 veB
 fdu
@@ -72860,7 +73060,7 @@ hpn
 hpn
 ybf
 ybf
-kGT
+kyg
 lMU
 ybf
 oSh
@@ -73056,7 +73256,7 @@ meC
 spf
 vME
 cGm
-vME
+bpP
 yaU
 qNl
 gzx
@@ -73374,14 +73574,14 @@ pYM
 pYM
 lRW
 ybf
-kGT
+kyg
 lMU
 ybf
 oUA
 wST
 qOc
 ybf
-kGT
+kyg
 ybf
 vjJ
 xQY
@@ -73638,7 +73838,7 @@ ybf
 ybf
 qOv
 ybf
-kGT
+kyg
 ybf
 vjJ
 xQY
@@ -73890,10 +74090,10 @@ vvi
 vKH
 vYt
 ikJ
-eMi
+jYM
 ybf
 pfu
-kGT
+kyg
 ybf
 shp
 ybf
@@ -74088,7 +74288,7 @@ gKQ
 hDO
 hDO
 hDO
-jKS
+veR
 oHA
 oCI
 gXo
@@ -74150,9 +74350,9 @@ wka
 qFQ
 ybf
 bQx
-kGT
-kGT
-kGT
+kyg
+kyg
+kyg
 ybf
 trU
 xQY
@@ -74340,9 +74540,9 @@ qqz
 uhz
 spf
 dji
-uAP
+wes
 vME
-pWS
+vME
 vME
 hDO
 wSe
@@ -74599,7 +74799,7 @@ uNX
 wes
 dby
 vME
-pWS
+vME
 vME
 ptq
 dnk
@@ -74635,8 +74835,8 @@ nbh
 nbh
 uXE
 uXE
-pca
-lbm
+sTL
+fpr
 uXE
 uXE
 jkT
@@ -74659,7 +74859,7 @@ pYM
 pYM
 uaD
 ybf
-kGT
+kyg
 eqU
 eqU
 eqU
@@ -74855,8 +75055,8 @@ frT
 spf
 sKg
 ptq
-ptq
-pWS
+vME
+vME
 vME
 ptq
 vME
@@ -75107,13 +75307,13 @@ wgC
 ruE
 vys
 vys
-spf
-spf
-spf
-bAu
+hSp
+hSp
+hSp
+hSp
 mOe
-ptq
-rYy
+hSp
+hSp
 vME
 ptq
 ptq
@@ -75160,7 +75360,7 @@ vwp
 vwp
 vwp
 vwp
-lAI
+nHs
 vwp
 vUK
 tsC
@@ -75175,7 +75375,7 @@ sHl
 ybf
 bQx
 xJy
-kGT
+kyg
 oUM
 xQY
 qQq
@@ -75364,16 +75564,16 @@ wgC
 vBi
 nxL
 tJp
-spf
+pEK
 aQb
-vME
-vME
-vME
-ptq
-vME
-vME
-ptq
-vME
+vHz
+xIF
+qVS
+ssU
+hSp
+hSp
+wVp
+aot
 oHA
 hZl
 jQP
@@ -75400,16 +75600,16 @@ kNM
 nYv
 etF
 xkq
-uul
+amn
 ljd
-uul
-uul
-uul
-uul
-uul
+amn
+amn
+amn
+amn
+amn
 hgJ
-uul
-uul
+amn
+amn
 kYH
 xyU
 crc
@@ -75431,7 +75631,7 @@ csH
 csH
 ybf
 mYj
-kGT
+kyg
 ols
 ndG
 xQY
@@ -75440,7 +75640,7 @@ cZb
 hny
 xQY
 uVS
-mNT
+nVb
 xQY
 uNR
 usm
@@ -75621,16 +75821,16 @@ wgC
 jxX
 cdU
 bMm
-spf
+pEK
 iMF
-vME
-vME
+vZM
+xOu
+vZF
+vNo
+nZt
+wRv
 vME
 ptq
-vME
-vME
-ptq
-vME
 oHA
 oHA
 oHA
@@ -75688,12 +75888,12 @@ bzc
 csH
 ybf
 mgP
-kGT
-kGT
-mNT
+kyg
+kyg
+nVb
 xQY
 qYh
-kGT
+kyg
 slR
 rYp
 uVS
@@ -75878,17 +76078,17 @@ wgC
 oNH
 cdU
 hOv
-spf
+pEK
 aSy
-vME
-vME
+nXR
+xVQ
+bnX
+clH
+mMJ
+wRv
 vME
 ptq
-vME
-vME
-ptq
-ptq
-vME
+bGx
 lzd
 oqM
 dls
@@ -76135,15 +76335,15 @@ kGU
 xSw
 mbP
 xrv
-spf
-hSp
-lPl
-lPl
-hSp
+pEK
+uSa
+nXR
+xVQ
+xcQ
 flJ
-hSp
-hSp
-vME
+hjU
+wRv
+kJP
 ptq
 ptq
 lvO
@@ -76392,7 +76592,7 @@ wgC
 jAo
 uxX
 gas
-lGr
+pEK
 lPl
 nXR
 bKA
@@ -76400,7 +76600,7 @@ lao
 whW
 oji
 hSp
-hSp
+vME
 vME
 ptq
 aNj
@@ -76649,18 +76849,18 @@ oHn
 vSX
 beY
 uIp
-rff
-lPl
+pEK
+hSp
 iHa
 euI
 bEq
 nCj
-eAO
-bdW
 hSp
-spf
+hSp
+wEK
+wEK
 fBY
-spf
+wEK
 oqM
 aKW
 ukl
@@ -76908,13 +77108,13 @@ mFX
 mVt
 rff
 pEK
-oyX
-qwv
-hMG
-pYf
-rCr
-gKg
 hSp
+hSp
+hSp
+hSp
+hSp
+gKg
+kIK
 dSR
 ipZ
 uAm
@@ -77164,14 +77364,14 @@ ueU
 aui
 ira
 rff
-pEK
-jHv
-qwv
-hMG
+wgC
+meC
+meC
+kIK
 tsQ
 lqm
 wDu
-hSp
+kIK
 xMq
 ipZ
 ipZ
@@ -77217,7 +77417,7 @@ sAG
 goK
 lCt
 nAn
-qql
+oOD
 vUK
 xyU
 xSR
@@ -77421,14 +77621,14 @@ kMj
 vtK
 eJY
 jKE
-pEK
-rOJ
-vdZ
-dFp
-oNZ
+wgC
+meC
+meC
+kIK
+tsQ
 mMY
 arV
-hSp
+kIK
 oBS
 aqa
 uAm
@@ -77678,14 +77878,14 @@ mlb
 mlb
 awq
 wgC
-hSp
-hSp
-tZG
-gnA
+wgC
+meC
+meC
+kIK
 nuI
 xUc
-hSp
-hSp
+nuI
+kIK
 qhV
 aqa
 efY
@@ -77693,7 +77893,7 @@ vwQ
 uAm
 ipZ
 uAm
-uAm
+cYK
 wEK
 bvV
 jiF
@@ -77936,14 +78136,14 @@ wgC
 wgC
 wgC
 meC
-hSp
-hSp
-hSp
-hSp
-hSp
-hSp
+meC
+meC
 kIK
-uAm
+qAD
+iCW
+tmt
+kIK
+kIK
 aqa
 bVk
 nTf
@@ -78195,12 +78395,12 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-wEK
+kIK
+pVR
+oNU
 iCW
-uAm
+iCW
+gLw
 aqa
 tYo
 bDy
@@ -78452,12 +78652,12 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-wEK
+kIK
+haR
+cmr
+vEE
 oKX
-uAm
+kIK
 yaQ
 tYo
 rFr
@@ -78709,8 +78909,8 @@ meC
 meC
 meC
 meC
-meC
-meC
+kIK
+kIK
 sPF
 sPF
 sPF
@@ -78737,8 +78937,8 @@ nzy
 nzy
 nzy
 nzy
-cVG
-jnV
+cQu
+eYC
 hzS
 ays
 oCv
@@ -78940,8 +79140,6 @@ meC
 meC
 meC
 meC
-meC
-meC
 xOw
 xOw
 xOw
@@ -78954,7 +79152,9 @@ xOw
 xOw
 xOw
 xOw
-meC
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -79197,8 +79397,6 @@ meC
 meC
 meC
 meC
-meC
-meC
 lFM
 lFM
 lFM
@@ -79211,7 +79409,9 @@ xOw
 xOw
 xOw
 xOw
-meC
+xOw
+xOw
+xOw
 meC
 meC
 meC
@@ -79454,15 +79654,13 @@ meC
 meC
 meC
 meC
-meC
-meC
+ejQ
+epo
 lGL
 qIu
 vPe
 ndR
 slU
-jIW
-miv
 vdE
 vdE
 vdE
@@ -79470,7 +79668,9 @@ tyb
 tyb
 tyb
 tyb
-pYh
+tKA
+meC
+meC
 meC
 meC
 meC
@@ -79711,23 +79911,23 @@ meC
 meC
 meC
 meC
-meC
-meC
 lFM
 rjB
 lFM
 lFM
 lFM
+utk
+ilo
 uRb
-mty
-sNp
 sQJ
 vdE
+kyv
+lOf
 tJl
 kfo
-hNc
-ifO
 tyb
+meC
+meC
 meC
 meC
 meC
@@ -79968,22 +80168,20 @@ meC
 meC
 meC
 meC
-meC
-meC
 lFM
+ewR
+eIO
 rXN
 vUN
 utk
 pfO
-uRb
-vZM
 vdE
 sQJ
 vdE
+kLg
+lTg
 ure
 eJw
-mQl
-bYw
 tyb
 meC
 meC
@@ -79991,7 +80189,9 @@ meC
 meC
 meC
 meC
-iFo
+rYy
+meC
+meC
 meC
 meC
 meC
@@ -80225,32 +80425,32 @@ meC
 meC
 meC
 meC
-meC
-meC
 lFM
+exo
+eKE
 sAa
 wgE
-oao
+utk
 pES
-uRb
-nsG
 vdE
 sQJ
 vdE
+lAa
+mgG
 wcJ
 vwX
-fxq
-uRn
 tyb
 meC
 meC
 hWD
-nuu
+qYQ
+rim
+nWx
 bKE
 bgY
-kyv
-cIt
-lOf
+hWD
+meC
+meC
 meC
 meC
 sPF
@@ -80482,32 +80682,32 @@ meC
 meC
 meC
 meC
-meC
-meC
 lFM
 lFM
+eKT
+fDZ
 wxS
 jvV
 tbh
-ely
-qSA
 vdE
 sQJ
+iFo
+lJO
 qVa
 wKp
 bVW
-iYR
-owP
-pYh
+tKA
 meC
 meC
 hWD
+rbW
+rsF
 nWx
 tdj
-bgY
-fDv
-kmO
-lOf
+sYm
+hWD
+meC
+meC
 meC
 meC
 sPF
@@ -80740,33 +80940,33 @@ meC
 meC
 meC
 meC
-meC
-meC
 lFM
+eLc
+fPh
 wZl
 ujb
 rBm
-ybb
-gWP
 vdE
 sQJ
 vdE
 vdE
 vdE
+mLG
+nyI
 tKA
-tXd
-pYh
 hWD
 hWD
 hWD
-nuu
+qYQ
+ruv
+nWx
 sNV
 bgY
-byV
-cIt
 hWD
 hWD
 hWD
+hUA
+hUA
 hUA
 iEv
 dzz
@@ -80793,7 +80993,7 @@ rZW
 uXP
 wux
 xNK
-rDB
+wft
 dFe
 hzS
 qpX
@@ -80993,8 +81193,6 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
 dXa
 dXa
@@ -81003,30 +81201,32 @@ lFM
 lFM
 lFM
 vdE
-frC
+ifY
 vdE
 vdE
 sQJ
 sQJ
 lVP
+miv
+mQl
 jHw
 kfX
-uYf
+xor
 pxh
-hgM
+pxh
 rYX
-rYX
+rBl
 oiq
 mUE
 ltl
 hBM
 gOt
 tmr
-ifY
-iBF
 hUA
+iBF
+eIs
 ofK
-rRb
+eiL
 pJe
 rRb
 ybZ
@@ -81250,44 +81450,44 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-ewR
-fPh
+abz
+bQO
 eyo
 eyo
-xOu
-ewR
+eMl
+abz
 vdE
 lVP
-qXL
+ipK
 sQJ
 sQJ
 sQJ
 lVP
 vdE
-cgI
-hNZ
+nav
+nLi
+tjj
+tWU
 cox
 aLD
 tWU
 mbY
-aLD
-tjj
 bAG
-cox
-aLD
-aLD
+tjj
+tWU
+tWU
+wkC
+ybb
 tBW
 djC
-hUA
-rim
+lgN
+rRb
 rRb
 pJe
 rRb
 rcR
-gkl
+pGu
 uXW
 nYv
 nYv
@@ -81507,14 +81707,12 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-exo
-gPa
+axD
+bVS
 eyo
 eyo
-yfC
+eXM
 eyo
 vdE
 lVP
@@ -81523,6 +81721,8 @@ lVP
 lVP
 lVP
 lVP
+mpa
+nbd
 jzC
 qEo
 lQH
@@ -81531,23 +81731,23 @@ vHV
 phW
 urm
 xor
-xIF
-hgM
 bAG
-xIF
+urm
+uXf
+bAG
 mCS
-bAG
+gYj
 uRv
 wGQ
-ncK
-gCE
+wGQ
+wGQ
 pJe
-rRb
+oXH
 oXr
 rXF
 nsb
-nYv
-nYv
+jiF
+jiF
 tlb
 wuJ
 nYv
@@ -81764,8 +81964,6 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
 eyo
 eyo
@@ -81776,34 +81974,36 @@ eyo
 vdE
 lVP
 vdE
-qVa
+iFo
 vdE
 vdE
 vdE
 vdE
 ydG
-wBs
-wBs
+nWZ
+nWZ
 ydG
-bnB
+wBs
+pZn
+wVN
 bbt
 wVN
-fTy
-wVN
-wBQ
 qyz
+tRd
 wVN
-wBQ
+qyz
+ycF
+hUA
 uRI
 ogr
 eJL
+rYk
 rRb
-uXf
 rRb
-rWI
+rRb
 gkl
 rKx
-mBf
+nYv
 mBf
 lgG
 qcU
@@ -82021,18 +82221,18 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-eIO
-hwr
+bdW
+bYw
 eyo
 eyo
-yiO
-eIO
+frC
+bdW
 vdE
 lVP
 vdE
+iHz
+jXR
 cQD
 ohS
 qQM
@@ -82043,15 +82243,15 @@ hwY
 ggD
 eaC
 uGJ
-qkW
+urm
 jRr
-xIF
-puo
 bAG
-bwK
+puo
 wVN
 bAG
-lAa
+yfA
+hUA
+hUA
 hUA
 aoP
 sVy
@@ -82059,9 +82259,9 @@ muW
 muW
 itF
 lpQ
-rKx
-nYv
-nYv
+tUL
+ets
+ets
 qkn
 itE
 bvV
@@ -82278,47 +82478,47 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-eKE
+bnB
 eyo
 eyo
-sYm
+eAO
 eyo
 eyo
 vdE
 lVP
 vdE
+jEY
+kcP
 btO
 lVX
 dIB
 exJ
 jaV
 hwp
-nLi
-sMy
 ydG
+sMy
+qwv
 xvO
-aRi
-sMV
-hgM
-xIF
+xor
+urm
 bAG
 bAG
-wBQ
+qyz
 bAG
+yfC
+jda
 pUP
 hUA
-ilo
-nav
-rRb
-rRb
-gVZ
+hUA
+hUA
+hUA
+bek
+hJO
 hJO
 lxE
-nYv
-nYv
+hWC
+mtn
 xpO
 wuJ
 nYv
@@ -82348,7 +82548,7 @@ irs
 irs
 xsz
 irs
-toT
+mNB
 irs
 pMJ
 pMJ
@@ -82535,49 +82735,49 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
+bwK
+cIt
 eKF
-ipK
-lTg
 tok
 tok
 tok
-ejQ
+hNc
 lVP
 vdE
+jFp
+kmO
 ixh
 oLU
 jlb
 wQW
 sjy
 xUG
-fZM
-bWx
 ydG
-cTo
+bWx
+bAG
+qyz
 bAG
 wBQ
-bAG
-laX
-dDI
 uiY
-rjC
-dDI
-gqi
-hUA
+laX
+vdZ
+uiY
+yiO
+iBw
+vbn
+hMN
 kaE
-rRb
-rRb
-rRb
+vbn
+rmg
+iKl
 uqs
-gkl
+iKl
 qgI
-nYv
-qgI
-pZn
-wuJ
+vdE
+vdE
+vdE
+vdE
 oGq
 mBf
 xPg
@@ -82792,50 +82992,50 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
 eyo
 eyo
-mpa
+ely
 eyo
 eyo
 eyo
 vdE
 lVP
 vdE
-ozS
+xzS
+xLJ
+xLJ
 xzS
 xzS
-ozS
-ozS
-xzS
-xzS
-kHX
+xLJ
+xLJ
+oDa
 ydG
+kHX
+uiY
 jGH
 dDI
 rjC
-dDI
-kcP
 hWD
 hWD
-cVk
+vgB
 hWD
 hWD
-hUA
+jda
+vyA
+vbn
 hix
-umf
-fqH
+vbn
+vbn
 qfG
 vbn
-gkl
-uwo
-rBl
+vbn
+vbn
 vdE
+oee
+sQJ
 vdE
-vdE
-sPU
+fLk
 mBf
 xPg
 qwq
@@ -83049,48 +83249,48 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-eKT
-iuT
+byV
+cVk
 eyo
 eyo
-jEY
-eKT
+fxq
+byV
 vdE
 lVP
 vdE
+jHv
+kwv
 jzp
 oSK
 cPR
 xWB
 xLJ
 sUm
-xzS
-guY
 ydG
 hWD
 hWD
-epo
+reV
 hWD
 hWD
+iRD
+tVf
 vky
 gbI
 kAs
 jda
-alQ
-vky
-vdE
-vdE
-vdE
+jda
+gqH
+dfu
+fXL
+lLK
 iKl
+sah
+jfp
+sah
 vdE
-vdE
-vdE
-vdE
-vdE
-oee
+sQJ
+sQJ
 vdE
 nYv
 mBf
@@ -83306,15 +83506,13 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-eLc
+bAu
 eyo
 eyo
 eyo
 eyo
-wkC
+fZM
 vdE
 lVP
 vdE
@@ -83327,25 +83525,27 @@ ydG
 ydG
 ydG
 ydG
-rLq
+ulV
 nTV
-hBD
 rLq
+ulV
+qOk
+sKv
 xNb
-iiZ
+vky
 rIz
-kAs
+rIz
 mpD
-mpD
-rsF
 vdE
-abz
-ycF
-sQJ
-sQJ
-sQJ
-sQJ
-sQJ
+vdE
+vdE
+vdE
+vdE
+vdE
+vdE
+vdE
+vdE
+vdE
 sQJ
 sQJ
 iiC
@@ -83563,15 +83763,13 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-eMl
-jFp
+bAZ
+edN
 eyo
 eyo
-rbW
-eMl
+fDv
+bAZ
 vdE
 lVP
 lVP
@@ -83584,18 +83782,20 @@ meC
 meC
 meC
 cPN
-rLq
+ulV
 nTV
-hBD
 rLq
-xNb
+ulV
+qOk
+sNp
+tXd
 xIH
-lJO
-kwv
 lzH
 lzH
 lzH
-tVf
+muM
+sQJ
+sQJ
 sQJ
 sQJ
 sQJ
@@ -83618,9 +83818,9 @@ oCe
 oCe
 oCe
 oCe
-wZC
+iCH
 weB
-qsX
+vHe
 nYv
 ojk
 oYo
@@ -83820,15 +84020,13 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
-eXM
-jXR
-eyo
-eyo
-yfC
 bGv
+edR
+eyo
+eyo
+eXM
+guY
 vdE
 sQJ
 lVP
@@ -83841,19 +84039,21 @@ cPN
 cPN
 cPN
 cPN
-gSu
-ulV
-hBD
+pYf
+qSA
 rLq
-xNb
+ulV
+qOk
+sPU
+tZG
 fTV
 cRL
 bsi
 iRD
-oDa
-vky
 vdE
 sQJ
+sQJ
+oEZ
 vdE
 vdE
 vdE
@@ -83868,8 +84068,8 @@ mBf
 mIG
 oCe
 mlr
-cUR
-qsX
+cbU
+vHe
 nYv
 nYv
 wtY
@@ -84077,8 +84277,6 @@ meC
 meC
 meC
 meC
-meC
-meC
 dXa
 dXa
 dXa
@@ -84095,27 +84293,29 @@ meC
 meC
 meC
 cPN
-axD
-hvS
+obv
+pWg
 cPN
-epp
+hvS
 nTV
-iZW
+tuK
+rCr
+qOk
 drD
-xNb
-wSd
-yfA
+uAP
 iqb
 iqb
 iqb
-qYQ
+xcZ
 vdE
 sQJ
+sQJ
+wvO
 vdE
 cmZ
 kVH
 cmZ
-reV
+iQH
 kVH
 cmZ
 cmZ
@@ -84339,34 +84539,34 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
 pud
-sKv
+ifO
 vdE
 lVP
 vdE
 meC
 meC
 meC
+mty
+nsG
 rXa
 vgt
 grU
-iHz
-edR
 nTV
 nTV
-iZW
+tuK
+rOJ
+qOk
 jrT
-xNb
-bVS
-nyI
+uRn
 vdE
 vdE
 vdE
 vdE
 vdE
+sQJ
+sQJ
 sQJ
 vdE
 ecU
@@ -84386,7 +84586,7 @@ vBM
 qeX
 nYv
 nYv
-wMt
+sSl
 nYv
 nYv
 bwY
@@ -84596,10 +84796,8 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
-tRd
+gPa
 sQJ
 sQJ
 lVP
@@ -84609,17 +84807,19 @@ meC
 meC
 meC
 cPN
-ruv
-nWF
+owP
+pWS
 cPN
+nWF
+qXL
 tuK
 dWm
-iZW
+qOk
 qOk
 vdE
 vdE
-vdE
-vdE
+sQJ
+sQJ
 sQJ
 sQJ
 sQJ
@@ -84853,14 +85053,14 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
-uSa
+gWP
 sQJ
 sQJ
 lVP
 vdE
+meC
+meC
 meC
 meC
 meC
@@ -84883,7 +85083,7 @@ lVP
 lVP
 lVP
 vdE
-obv
+eRA
 cmZ
 cmZ
 gsn
@@ -84938,8 +85138,8 @@ iur
 pUC
 qOf
 qKw
-gDQ
-gDQ
+vDA
+vDA
 qKw
 qKw
 sgR
@@ -85110,14 +85310,14 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
-fDZ
+hwr
 sQJ
 vdE
 lVP
 vdE
+meC
+meC
 meC
 meC
 meC
@@ -85140,7 +85340,7 @@ vdE
 gjD
 vdE
 vdE
-pWg
+oJM
 nNG
 nNG
 mEn
@@ -85195,7 +85395,7 @@ iur
 vXU
 mKo
 qKw
-gDQ
+vDA
 nri
 usZ
 rTb
@@ -85367,14 +85567,14 @@ meC
 meC
 meC
 meC
-meC
-meC
 tXp
 tXp
 tXp
 vdE
 lVP
 vdE
+meC
+meC
 meC
 meC
 meC
@@ -85627,11 +85827,11 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
 lVP
 vdE
+meC
+meC
 meC
 meC
 meC
@@ -85709,7 +85909,7 @@ iur
 qEz
 qKw
 rbE
-gDQ
+vDA
 rzT
 iur
 rTe
@@ -85884,10 +86084,10 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
 lVP
+jIW
+jIW
 vdE
 vdE
 vdE
@@ -85966,7 +86166,7 @@ iur
 dNB
 qKw
 qKw
-gDQ
+vDA
 czb
 iur
 qKw
@@ -86141,10 +86341,10 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
 lVP
+gNJ
+gNJ
 sQJ
 vdE
 lEH
@@ -86223,7 +86423,7 @@ iur
 iur
 iur
 qKw
-gDQ
+vDA
 rAf
 iur
 icT
@@ -86398,18 +86598,18 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
 lVP
+jUt
+jUt
 lVP
 lVP
 lVP
 lSf
-bAZ
+oyX
 lVP
 lVP
-bQO
+pYh
 rbh
 lVP
 sQJ
@@ -86476,11 +86676,11 @@ ycI
 ycI
 xOw
 iur
-nDW
-kga
+gyJ
+wxh
 iur
 iur
-gDQ
+vDA
 iur
 iur
 bZp
@@ -86655,9 +86855,9 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
+iuT
+gNJ
 gNJ
 sQJ
 sQJ
@@ -86733,11 +86933,11 @@ iJa
 yaG
 xOw
 jXz
-cRl
-gDQ
-aqP
-gDQ
-gDQ
+oXV
+vDA
+tGH
+vDA
+vDA
 qKw
 iur
 iur
@@ -86912,9 +87112,9 @@ meC
 meC
 meC
 meC
-meC
-meC
 vdE
+iuT
+gNJ
 gNJ
 sQJ
 vdE
@@ -86990,11 +87190,11 @@ qta
 yaG
 xOw
 iur
-koa
-bcw
+qSc
+dna
 iur
 qKw
-gDQ
+vDA
 qKw
 iur
 meC
@@ -87250,8 +87450,8 @@ iur
 iur
 iur
 iur
-gDQ
-gDQ
+vDA
+vDA
 vXU
 iur
 meC
@@ -87504,10 +87704,10 @@ lUs
 yaG
 xOw
 iur
-cbK
-nHT
+utC
+fpe
 iur
-gDQ
+vDA
 iur
 iur
 iur
@@ -87706,7 +87906,7 @@ pxw
 wBF
 wCG
 hEC
-nbd
+fCW
 rvZ
 ikf
 vjo
@@ -87730,7 +87930,7 @@ jCs
 qmO
 ljp
 yjs
-wKe
+bFl
 yjs
 uwA
 rrH
@@ -87761,10 +87961,10 @@ yaG
 yaG
 xOw
 jXz
-jtW
-fmd
-aqP
-gDQ
+cxj
+ibo
+tGH
+vDA
 iur
 meC
 meC
@@ -87966,7 +88166,7 @@ hEC
 rvZ
 rvZ
 qOA
-nWZ
+mZI
 aVI
 rvZ
 anB
@@ -87987,7 +88187,7 @@ jCs
 qmO
 ljp
 yjs
-wKe
+bFl
 yjs
 tUF
 yhY
@@ -88008,7 +88208,7 @@ bfy
 uTD
 yhF
 rsm
-ncQ
+vpc
 yaG
 uie
 wnr
@@ -88018,8 +88218,8 @@ xOw
 xOw
 xOw
 iur
-ckb
-sMX
+qro
+jUd
 iur
 qKw
 iur
@@ -88211,7 +88411,7 @@ vdE
 vdE
 xWS
 lkY
-cYK
+rWI
 lVP
 lVP
 lVP
@@ -88244,7 +88444,7 @@ rEf
 qmO
 ljp
 yjs
-wKe
+bFl
 yjs
 uwA
 dla
@@ -88501,7 +88701,7 @@ sqV
 nNw
 tTz
 yjs
-wKe
+bFl
 yjs
 cYd
 dma
@@ -88758,7 +88958,7 @@ hXv
 hNF
 tTz
 sVK
-aRd
+cHe
 sVK
 yiq
 yiq
@@ -88778,14 +88978,14 @@ hRI
 xXV
 iBd
 xXV
-omE
+ezo
 xAv
 yaG
 yaG
 yaG
 yaG
-pNB
-pNB
+hNf
+hNf
 xOw
 meC
 meC
@@ -89014,8 +89214,8 @@ bPB
 bcA
 ljp
 tTz
-kxL
-wKe
+cNF
+bFl
 yjs
 qyU
 dnS
@@ -89037,12 +89237,12 @@ hCP
 hCP
 dLV
 jWU
-vxk
-mfi
-fkH
-wgn
-crt
-pNB
+nfi
+ykD
+eBi
+jSQ
+nKs
+hNf
 xOw
 meC
 meC
@@ -89272,8 +89472,8 @@ yjs
 yjs
 sVK
 yjs
-wKe
-wKe
+bFl
+bFl
 gYY
 dhe
 gYY
@@ -89295,11 +89495,11 @@ xHl
 glK
 jYo
 yiq
-pWG
-vNx
-oyP
-ntz
-pNB
+gkF
+lEG
+kth
+uXd
+hNf
 xOw
 meC
 meC
@@ -89552,11 +89752,11 @@ bpn
 bpf
 bpn
 bpn
-tqT
-kaf
-bFe
-ekO
-pNB
+hIX
+uvW
+pOi
+epD
+hNf
 xOw
 meC
 meC
@@ -89809,11 +90009,11 @@ iMq
 eAD
 kel
 bpn
-pNB
-pNB
-pNB
-pNB
-pNB
+hNf
+hNf
+hNf
+hNf
+hNf
 xOw
 meC
 meC
@@ -90302,7 +90502,7 @@ jGO
 yjs
 wKe
 yjs
-wnT
+uwA
 xOw
 xSQ
 hMu
@@ -90558,8 +90758,8 @@ bgK
 jGO
 yjs
 wKe
-yjs
-wnT
+eLS
+uwA
 xOw
 xSQ
 aOc
@@ -90816,7 +91016,7 @@ jGO
 yjs
 wKe
 yjs
-wnT
+uwA
 xOw
 xSQ
 bxR
@@ -91330,7 +91530,7 @@ lIC
 wKe
 wKe
 yjs
-wnT
+uwA
 xOw
 xOw
 xSQ
@@ -91586,11 +91786,11 @@ aCu
 jGO
 yjs
 wKe
-yjs
-wnT
+eLS
+uwA
 meC
 xOw
-xSQ
+wYd
 tvA
 far
 wAm
@@ -91844,7 +92044,7 @@ lkB
 yjs
 wKe
 yjs
-wnT
+uwA
 meC
 xOw
 uFB
@@ -93643,7 +93843,7 @@ tWO
 tWO
 tWO
 dPu
-qYT
+awc
 gvh
 lil
 vgC
@@ -96735,7 +96935,7 @@ qMW
 qMW
 oAf
 vWT
-lSO
+piY
 gvh
 wXw
 wXw
@@ -97251,8 +97451,8 @@ meC
 caa
 iRe
 prs
-pWF
-eJf
+uXs
+iEY
 pBD
 cql
 sHh
@@ -97511,7 +97711,7 @@ caa
 caa
 caa
 caa
-afB
+xYV
 caa
 caa
 caa

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -67,6 +67,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "acE" = (
@@ -246,10 +247,15 @@
 "aiZ" = (
 /turf/open/floor/wood,
 /area/security/prison/workout)
+"ajc" = (
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "ajd" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "ajy" = (
@@ -365,11 +371,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"anr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "anB" = (
 /obj/machinery/deepfryer,
 /obj/machinery/light/directional/north,
@@ -423,7 +424,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "apx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -442,6 +443,7 @@
 /area/engineering/atmos/upper)
 "apO" = (
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aqa" = (
@@ -514,7 +516,7 @@
 	dir = 8;
 	name = "Ports to Mix"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "asq" = (
@@ -993,10 +995,6 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/medical/virology)
-"aFA" = (
-/obj/structure/mopbucket,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "aFS" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -1185,6 +1183,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai)
+"aMI" = (
+/obj/structure/mopbucket,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
@@ -1445,8 +1447,13 @@
 	dir = 4
 	},
 /obj/machinery/icecream_vat,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
+"aVQ" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/bridge)
 "aVR" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
@@ -1460,6 +1467,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"aWz" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "aXe" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -1492,6 +1503,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"aYd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "aYi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -1783,6 +1801,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"bhf" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "bhP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/dark/textured_large,
@@ -2041,6 +2063,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"boU" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/head/hardhat/red,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "boW" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -2387,6 +2416,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"bzE" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "bzI" = (
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -2597,6 +2630,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"bGl" = (
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "bGs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -2840,7 +2876,7 @@
 "bPR" = (
 /obj/structure/closet/mini_fridge,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "bQx" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -2856,12 +2892,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmos/project)
 "bQO" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bQX" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -2967,7 +3005,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "bUg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red/anticorner{
@@ -3083,7 +3121,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "bYE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3118,7 +3156,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "bZp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3473,6 +3511,12 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
+"cjR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "cjS" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -3523,7 +3567,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/area/hallway/primary/central/fore)
 "clY" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Creature Pen";
@@ -3752,9 +3796,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"ctE" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/bridge)
 "ctO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -4498,7 +4539,9 @@
 	pixel_y = 12
 	},
 /obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
 /area/maintenance/port/fore)
 "cRr" = (
 /obj/machinery/light/directional/east,
@@ -5060,6 +5103,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dgF" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "dgT" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -5165,12 +5213,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
-"djj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "djC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5301,6 +5343,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"dna" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "dnk" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 1
@@ -5394,10 +5442,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"dpM" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "dqa" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -5636,10 +5680,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/mixing)
-"dyc" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "dyg" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/white/smooth_large,
@@ -5655,6 +5695,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"dys" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "dzo" = (
 /obj/structure/closet/bombcloset,
 /obj/item/clothing/mask/gas,
@@ -5851,7 +5895,7 @@
 "dDP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "dDQ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -6135,6 +6179,13 @@
 "dMz" = (
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"dMB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "dMZ" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
@@ -6647,6 +6698,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
 "edy" = (
@@ -7042,6 +7094,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"eky" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "ekX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -7616,10 +7673,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room)
-"exx" = (
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "exJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -7833,6 +7886,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/service/theater)
+"eEt" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "eEw" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/siding/yellow{
@@ -7857,11 +7919,6 @@
 /obj/structure/closet/crate/mail/full,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eFS" = (
-/obj/effect/spawner/random/structure/table,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "eGM" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -8215,7 +8272,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "eSf" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -8323,7 +8380,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/security/checkpoint)
 "eWF" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -8388,7 +8445,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "eZF" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/iron/dark/telecomms,
@@ -8660,7 +8717,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "fgi" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -8723,7 +8780,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "fis" = (
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -8757,7 +8814,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "fiL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -9124,7 +9181,7 @@
 	},
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "fxJ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Genetics Lab Maintenance";
@@ -9585,6 +9642,12 @@
 /obj/machinery/computer/security/telescreen/entertainment,
 /turf/open/floor/carpet,
 /area/service/bar)
+"fLD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "fLH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9836,6 +9899,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"fSS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "fTj" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -10075,6 +10144,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"gbp" = (
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "gbI" = (
 /obj/machinery/modular_computer/console/preset/cargochat/cargo{
 	dir = 4
@@ -10789,6 +10863,15 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"gtT" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "guY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/vehicle/sealed/mecha/working/ripley/cargo,
@@ -10918,6 +11001,10 @@
 	dir = 8
 	},
 /area/service/chapel)
+"gxL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "gxQ" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -10966,6 +11053,11 @@
 "gyC" = (
 /turf/open/floor/iron,
 /area/security/processing)
+"gyK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "gzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
@@ -11380,6 +11472,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"gMb" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Radstorm Shelter"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "gMo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -11399,15 +11500,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
-"gNd" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "gND" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -11952,7 +12044,7 @@
 	name = "Medical blue half"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "hgM" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -12068,6 +12160,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"hlp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "hnn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12206,14 +12303,6 @@
 	dir = 4
 	},
 /area/security/execution/education)
-"hsF" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "hsJ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12235,7 +12324,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "htD" = (
@@ -12517,7 +12606,9 @@
 /area/engineering/supermatter/room)
 "hCz" = (
 /obj/item/trash/boritos,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
 /area/maintenance/port/fore)
 "hCA" = (
 /obj/structure/closet/secure_closet/hop,
@@ -12721,7 +12812,7 @@
 "hFB" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "hFK" = (
 /obj/structure/chair{
 	dir = 8
@@ -12735,12 +12826,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
-"hFL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "hFP" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -12779,10 +12864,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hHd" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "hHg" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
@@ -13108,6 +13189,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
+"hPl" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "hPm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
@@ -13127,15 +13214,6 @@
 /obj/item/survivalcapsule,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"hPr" = (
-/obj/structure/table,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/extinguisher/mini,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "hPs" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -13191,6 +13269,13 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
+"hQV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/service/chapel/office)
 "hRu" = (
 /turf/closed/wall,
 /area/service/lawoffice/upper)
@@ -13229,7 +13314,7 @@
 /area/engineering/atmos/project)
 "hSl" = (
 /turf/closed/wall,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "hSn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/parquet,
@@ -14519,6 +14604,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"izT" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
+"izV" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "iAj" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700";
@@ -15156,10 +15253,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
-"iPC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "iPO" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/plants/portaseeder,
@@ -15182,6 +15275,9 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"iQa" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/science/central)
 "iQm" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer{
 	dir = 8
@@ -15208,6 +15304,7 @@
 	dir = 4;
 	pixel_x = -11
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "iQB" = (
@@ -15230,6 +15327,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "iRo" = (
@@ -15265,7 +15363,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/security/checkpoint)
 "iSd" = (
 /obj/structure/table,
 /obj/item/storage/box/shipping,
@@ -15553,6 +15651,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
+"iZC" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "iZW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -15735,7 +15837,9 @@
 /area/engineering/atmos)
 "jfO" = (
 /obj/effect/spawner/random/entertainment/drugs,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
 /area/maintenance/port/fore)
 "jgn" = (
 /obj/structure/table,
@@ -15960,7 +16064,9 @@
 /area/security/prison/mess)
 "jmX" = (
 /obj/item/trash/syndi_cakes,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
 /area/maintenance/port/fore)
 "jmZ" = (
 /obj/machinery/button/door/directional/north{
@@ -16083,6 +16189,7 @@
 /area/security/processing)
 "jqb" = (
 /obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "jqW" = (
@@ -17140,14 +17247,10 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "jUt" = (
-/obj/effect/turf_decal/tile/blue/half{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue half"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "jUN" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall,
@@ -17935,6 +18038,7 @@
 /area/engineering/atmos/upper)
 "kro" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
 "krE" = (
@@ -18092,6 +18196,13 @@
 "kwG" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"kwI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "kwN" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm/directional/south,
@@ -18377,6 +18488,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
 "kFx" = (
@@ -18754,7 +18866,7 @@
 	name = "Medical blue half"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "kOB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19012,11 +19124,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"kUc" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "kUe" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/trimline/neutral/line{
@@ -19207,7 +19314,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "kYY" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -19667,7 +19774,7 @@
 	name = "Medical blue half"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "ljm" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/mess)
@@ -19759,6 +19866,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"lmB" = (
+/obj/machinery/door/morgue{
+	name = "Mass Driver";
+	req_access_txt = "27"
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "lmC" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19829,15 +19943,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
-"log" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "loj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19959,13 +20064,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
-"lqk" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "lqm" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -20349,7 +20447,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "lBE" = (
@@ -20518,12 +20616,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"lFz" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "lFH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -21102,6 +21194,9 @@
 /area/service/hydroponics/garden)
 "lSf" = (
 /obj/effect/spawner/random/entertainment/drugs,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lSi" = (
@@ -21233,7 +21328,7 @@
 "lVr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "lVP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21724,6 +21819,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/office)
+"mgf" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "mgo" = (
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron,
@@ -21732,11 +21831,12 @@
 /turf/closed/wall,
 /area/hallway/primary/port)
 "mgG" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mgL" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -21848,12 +21948,6 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
-"mks" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "mkB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -22232,7 +22326,7 @@
 "mvG" = (
 /obj/structure/window/reinforced/fulltile/unanchored,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "mvK" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -23159,7 +23253,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mNp" = (
@@ -23424,6 +23517,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "mTY" = (
@@ -23715,14 +23809,10 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
 "nbd" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Radstorm Shelter"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "nbe" = (
 /obj/structure/window/reinforced,
 /obj/item/kirbyplants{
@@ -23744,7 +23834,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engineering/supermatter/room)
 "nbV" = (
 /obj/item/target,
@@ -23864,6 +23954,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"nfy" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "nfA" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -24005,8 +24099,9 @@
 "nkJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "nkQ" = (
 /obj/machinery/flasher/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -24697,6 +24792,14 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
+"nDg" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue half"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "nDm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -25128,7 +25231,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "nSc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -25266,11 +25369,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "nWZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "nXg" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/vacuum/external{
@@ -25723,7 +25826,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/area/hallway/primary/central/fore)
 "ojF" = (
 /obj/machinery/photocopier,
 /obj/structure/sign/painting/library_secure{
@@ -26121,6 +26224,11 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
+"ovH" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured_large,
+/area/medical/medbay/lobby)
 "ovP" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine/atmos)
@@ -26571,13 +26679,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"oFK" = (
-/obj/machinery/vending/snack,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "oFN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half{
@@ -26928,6 +27029,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"oQE" = (
+/obj/machinery/vending/snack,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "oQQ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -27056,6 +27164,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"oTR" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/extinguisher/mini,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "oUa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -27077,6 +27194,7 @@
 	name = "Coldroom";
 	req_one_access_txt = "28;35"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
 "oUM" = (
@@ -27133,11 +27251,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"oWj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "oWl" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
@@ -27369,6 +27482,12 @@
 /obj/structure/bookcase,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
+"peO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "pfm" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -27795,6 +27914,7 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "prR" = (
@@ -28211,6 +28331,12 @@
 "pHa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
+"pIm" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "pIx" = (
@@ -28364,6 +28490,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"pNo" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
 "pNr" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/engineering/storage/tcomms)
@@ -28565,13 +28695,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"pUm" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/head/hardhat/red,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "pUC" = (
 /obj/item/kirbyplants/dead{
 	desc = "Dead plant. I thought all office plants were fake.";
@@ -28580,7 +28703,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "pUF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -28625,9 +28748,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "pWg" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/trinary/filter,
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "pWq" = (
 /obj/structure/closet/secure_closet/cytology,
 /obj/machinery/firealarm/directional/west,
@@ -28783,6 +28906,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
 "qby" = (
@@ -28865,7 +28990,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/area/hallway/primary/central/fore)
 "qfe" = (
 /obj/machinery/door/poddoor{
 	id = "engstorage";
@@ -29529,9 +29654,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"qCp" = (
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "qCx" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -30076,6 +30198,10 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
+/obj/machinery/airalarm/kitchen_cold_room{
+	dir = 1;
+	pixel_y = 24
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
 "qPv" = (
@@ -30272,7 +30398,9 @@
 /obj/item/food/grown/cannabis{
 	pixel_y = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
 /area/maintenance/port/fore)
 "qXj" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -30447,6 +30575,11 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"rcu" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "rcC" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -30536,9 +30669,11 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "reV" = (
-/obj/item/trash/candy,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
 "reW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -30894,6 +31029,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"rpQ" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
 "rpV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -31625,7 +31769,9 @@
 /area/medical/treatment_center)
 "rIS" = (
 /obj/item/trash/chips,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
 /area/maintenance/port/fore)
 "rJe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31751,6 +31897,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"rKR" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "rLq" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
@@ -31866,6 +32015,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"rNU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rNY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/north,
@@ -32456,6 +32611,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+"scW" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "scZ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -32491,6 +32653,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"sdD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "sdF" = (
 /obj/machinery/modular_computer/console/preset/cargochat/science,
 /obj/effect/turf_decal/tile/brown/full,
@@ -32911,6 +33078,7 @@
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "sow" = (
@@ -33463,7 +33631,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/port)
+/area/security/checkpoint)
 "sEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33487,7 +33655,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/area/hallway/primary/central/fore)
 "sFa" = (
 /obj/structure/table,
 /obj/effect/turf_decal/siding/yellow{
@@ -33758,12 +33926,9 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "sPU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/coldroom)
 "sQm" = (
 /obj/structure/table,
 /obj/item/holosign_creator/robot_seat/restaurant,
@@ -34108,6 +34273,7 @@
 	name = "Coldroom";
 	req_one_access_txt = "28;35"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "sYU" = (
@@ -34198,6 +34364,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
+"tak" = (
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/mop,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "tal" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -34311,7 +34488,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "tep" = (
 /obj/effect/turf_decal/tile/purple/anticorner{
 	color = "#4D0067";
@@ -34359,10 +34536,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"tfL" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
 "tgl" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -35304,6 +35477,7 @@
 	name = "engineering yellow"
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "tDj" = (
@@ -36659,7 +36833,7 @@
 	dir = 4;
 	name = "Mix 1 Output"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "ujn" = (
@@ -37145,6 +37319,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
+"usy" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "usW" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067"
@@ -38314,10 +38492,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
-"uSo" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "uSr" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/machinery/camera/directional/north{
@@ -38389,7 +38563,7 @@
 	name = "South West Central Hallway Camera"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/area/hallway/primary/port)
 "uTW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -38745,7 +38919,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "vdo" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -39404,6 +39578,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"vtd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "vtf" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -39702,12 +39882,14 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "vxF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 8
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/service/bar/atrium)
 "vxR" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -39778,11 +39960,18 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
 "vzS" = (
 /turf/closed/wall/r_wall,
 /area/security/brig/upper)
+"vzY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "vAd" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/purple{
@@ -39866,7 +40055,7 @@
 /obj/structure/rack,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "vBd" = (
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
@@ -40024,9 +40213,6 @@
 "vFO" = (
 /turf/closed/wall/r_wall,
 /area/security/office)
-"vGc" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "vGv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -40039,6 +40225,10 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
+"vHh" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/electrical)
 "vHz" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -40102,7 +40292,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/department/science/central)
 "vIW" = (
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
@@ -40126,7 +40316,12 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
+"vJz" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "vJE" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -40688,6 +40883,7 @@
 	name = "Privacy Control";
 	req_access_txt = "27"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "vXj" = (
@@ -41072,7 +41268,7 @@
 	name = "Medical blue half"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central/aft)
+/area/hallway/primary/central/fore)
 "weD" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/siding/red{
@@ -41418,14 +41614,12 @@
 /obj/item/pen,
 /obj/machinery/light/directional/east,
 /obj/item/storage/box/monkeycubes,
-/obj/structure/cable,
 /obj/item/reagent_containers/dropper{
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/dropper{
 	pixel_y = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "wpp" = (
@@ -41815,6 +42009,7 @@
 /area/hallway/primary/central/aft)
 "wxS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wxV" = (
@@ -42092,7 +42287,9 @@
 "wCu" = (
 /obj/item/trash/boritos,
 /obj/effect/mob_spawn/corpse/human/assistant,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "o2=12;n2=72;n2o=20;TEMP=293.15"
+	},
 /area/maintenance/port/fore)
 "wCv" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -42286,10 +42483,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
-"wGT" = (
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/bridge)
 "wGV" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -42456,12 +42649,6 @@
 	},
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
-"wLq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
 "wLs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43375,6 +43562,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tcomms)
+"xkv" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "xkz" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/camera/directional/south{
@@ -43453,6 +43649,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"xni" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
 "xnm" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
@@ -43611,17 +43812,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"xss" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/grenade/chem_grenade/cleaner,
-/obj/item/mop,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "xst" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -43837,6 +44027,11 @@
 "xzq" = (
 /turf/closed/wall/r_wall,
 /area/command/meeting_room/council)
+"xzr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xzB" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/pew,
@@ -43933,13 +44128,13 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "xDy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/service/bar/atrium)
 "xDI" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -44037,6 +44232,7 @@
 /obj/item/storage/book/bible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/service/chapel)
 "xHc" = (
@@ -44616,6 +44812,10 @@
 "xSR" = (
 /turf/closed/wall,
 /area/security/courtroom)
+"xSS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xTa" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -44872,7 +45072,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner,
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
-/area/hallway/primary/central/fore)
+/area/hallway/primary/central/aft)
 "xXS" = (
 /obj/item/trash/chips,
 /obj/structure/rack,
@@ -45079,6 +45279,14 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
+"ydE" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ydG" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
@@ -45394,10 +45602,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "yki" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/black,
-/area/service/chapel)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "yko" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -63111,7 +63319,7 @@ sGv
 hXq
 uFM
 uGg
-reV
+wtv
 cRk
 qXi
 xEx
@@ -63383,7 +63591,7 @@ wqG
 nrd
 ykr
 sZC
-ykr
+dgF
 mgu
 mgu
 vlD
@@ -63895,7 +64103,7 @@ fhd
 kHx
 sWw
 qGo
-mgu
+qGo
 sZC
 gWf
 hra
@@ -64349,7 +64557,7 @@ ois
 nku
 pkG
 aSz
-vxF
+apG
 pkG
 uji
 pkG
@@ -65180,7 +65388,7 @@ rKh
 rVr
 slA
 qGo
-mgu
+qGo
 sZC
 ykr
 gCS
@@ -66208,7 +66416,7 @@ hXq
 hXq
 hXq
 hXq
-fbm
+hlp
 sZC
 orr
 gCS
@@ -66926,7 +67134,7 @@ aBS
 aGP
 bae
 bhP
-xDy
+bhP
 bhP
 htt
 bGD
@@ -66948,10 +67156,10 @@ bEh
 bEh
 bEh
 ovP
-mRE
-fnV
+eky
+rKR
 bYz
-uJl
+iQa
 uXi
 tLO
 sHa
@@ -67183,8 +67391,8 @@ vKP
 aJL
 beP
 ble
-mgG
-sPU
+ble
+ble
 bAr
 xDx
 mmV
@@ -67208,7 +67416,7 @@ mNf
 bYz
 vBc
 bYz
-uJl
+iQa
 vlK
 wcs
 xtk
@@ -67440,7 +67648,7 @@ vKP
 ipD
 beP
 ble
-bql
+ble
 cDF
 mLA
 rCn
@@ -67465,7 +67673,7 @@ sfa
 nkJ
 dDP
 bYz
-uJl
+iQa
 hab
 qeC
 eDr
@@ -67720,9 +67928,9 @@ kuZ
 fEd
 sfa
 nkJ
-fpd
+vJz
 bYz
-uJl
+iQa
 vuq
 vhv
 nnF
@@ -67956,7 +68164,7 @@ sgQ
 afY
 ble
 ble
-ble
+nWZ
 ble
 ble
 lgE
@@ -67977,9 +68185,9 @@ kuZ
 fEd
 sfa
 nkJ
-fpd
+vJz
 bZf
-uJl
+iQa
 vXJ
 nja
 vXJ
@@ -68212,9 +68420,9 @@ aQw
 sgQ
 blu
 ble
-ble
-ble
-ble
+nbd
+pWg
+reV
 ble
 ble
 cxy
@@ -68230,13 +68438,13 @@ mrW
 sEP
 fRX
 cCO
-tVW
+gxL
 pHa
 mTT
 nkJ
 hSl
 bZf
-uJl
+iQa
 fJK
 vhv
 vhv
@@ -68493,7 +68701,7 @@ sfa
 vIy
 hSl
 bZf
-uJl
+iQa
 mTr
 xtk
 pXH
@@ -68745,12 +68953,12 @@ eCY
 abG
 kuK
 sEP
-sEP
+sdD
 sfa
 vIy
 vdi
 bZf
-uJl
+iQa
 mTE
 nar
 noe
@@ -69002,12 +69210,12 @@ lcI
 jqb
 nxR
 tVW
-tVW
+dMB
 sfa
-fnV
+rKR
 mvG
 bZf
-uJl
+iQa
 tji
 naD
 noy
@@ -69258,13 +69466,13 @@ sfa
 sfa
 sfa
 sfa
-tVW
-tVW
+pIm
+vHh
 sfa
-fnV
-dEz
+rKR
+dys
 bZf
-uJl
+iQa
 vXL
 fWI
 gHG
@@ -69518,10 +69726,10 @@ sfa
 sfa
 sfa
 sfa
-fnV
+rKR
 mvG
 bZf
-uJl
+iQa
 thy
 xtk
 fqj
@@ -69775,10 +69983,10 @@ sUb
 ukm
 ukm
 sfa
-fnV
+rKR
 hSl
 bZf
-uJl
+iQa
 gdq
 xtk
 xac
@@ -70032,18 +70240,18 @@ bvL
 bvL
 bvL
 sfa
-fnV
+rKR
 hSl
 bZf
-uJl
-uJl
-uJl
-uJl
-uJl
-uJl
-uJl
-uJl
-uJl
+iQa
+iQa
+iQa
+iQa
+iQa
+iQa
+iQa
+iQa
+iQa
 rXm
 agu
 rFs
@@ -70548,16 +70756,16 @@ sfa
 sfa
 eZy
 bPR
-fnV
+rKR
 lVr
-fnV
-uJl
-uJl
-uJl
-uJl
+rKR
+iQa
+iQa
+iQa
+iQa
 nRR
-uJl
-uJl
+iQa
+iQa
 pci
 xCL
 oFN
@@ -70808,7 +71016,7 @@ hSl
 hSl
 hSl
 hSl
-uJl
+iQa
 gkd
 bWl
 qZl
@@ -71621,10 +71829,10 @@ ybf
 lMU
 nSZ
 ybf
-qCp
-qCp
-qCp
-qCp
+bGl
+bGl
+bGl
+bGl
 ybf
 lpN
 tCT
@@ -71874,7 +72082,7 @@ vdG
 lDe
 ybf
 mFk
-qCp
+bGl
 lMU
 nWT
 ybf
@@ -72130,8 +72338,8 @@ kEY
 kEY
 lDo
 ybf
-qCp
-qCp
+bGl
+bGl
 lMU
 ybf
 ybf
@@ -72139,7 +72347,7 @@ ybf
 ybf
 ybf
 ybf
-tfL
+iZC
 vjJ
 xQY
 umW
@@ -72388,15 +72596,15 @@ uMm
 kLY
 ybf
 mMO
-qCp
+bGl
 lMU
 ofS
 vYO
 wSK
 xda
 ybf
-qCp
-qCp
+bGl
+bGl
 vjJ
 xQY
 unJ
@@ -72645,7 +72853,7 @@ hpn
 hpn
 ybf
 ybf
-qCp
+bGl
 lMU
 ybf
 oSh
@@ -73159,14 +73367,14 @@ pYM
 pYM
 lRW
 ybf
-qCp
+bGl
 lMU
 ybf
 oUA
 wST
 qOc
 ybf
-qCp
+bGl
 ybf
 vjJ
 xQY
@@ -73423,7 +73631,7 @@ ybf
 ybf
 qOv
 ybf
-qCp
+bGl
 ybf
 vjJ
 xQY
@@ -73675,10 +73883,10 @@ vvi
 vKH
 vYt
 ikJ
-tfL
+iZC
 ybf
 pfu
-qCp
+bGl
 ybf
 shp
 ybf
@@ -73935,9 +74143,9 @@ wka
 qFQ
 ybf
 bQx
-qCp
-qCp
-qCp
+bGl
+bGl
+bGl
 ybf
 trU
 xQY
@@ -74176,8 +74384,8 @@ uic
 cqd
 jkT
 uTO
-vUK
-xyU
+sZC
+ykr
 tAc
 rSC
 uaY
@@ -74444,7 +74652,7 @@ pYM
 pYM
 uaD
 ybf
-qCp
+bGl
 eqU
 eqU
 eqU
@@ -74671,24 +74879,24 @@ wtY
 ycK
 nYv
 vBM
-nYv
-nYv
-nYv
-nYv
+xyU
+xyU
+xyU
+xyU
 apd
 uXE
 kLg
 vHz
 uXE
 uXE
-nYv
-jiF
-wtY
-nYv
-nYv
-nYv
-nYv
-vBM
+xyU
+pyZ
+cqE
+xyU
+xyU
+xyU
+xyU
+gFp
 xyU
 vUK
 wOM
@@ -74928,24 +75136,24 @@ mBf
 mBf
 mBf
 wQX
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-mBf
-wQX
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+vwp
+aYd
 vwp
 vUK
 tsC
@@ -74960,7 +75168,7 @@ sHl
 ybf
 bQx
 xJy
-qCp
+bGl
 oUM
 xQY
 qQq
@@ -75185,22 +75393,22 @@ kNM
 nYv
 etF
 xkq
-njm
+nDg
 ljd
-njm
-njm
-njm
-njm
-njm
+nDg
+nDg
+nDg
+nDg
+nDg
 hgJ
-njm
-njm
+nDg
+nDg
 kYH
-nYv
-nWZ
-nYv
-nYv
-nYv
+xyU
+crc
+xyU
+xyU
+xyU
 hFB
 kOf
 vYY
@@ -75216,7 +75424,7 @@ csH
 csH
 ybf
 mYj
-qCp
+bGl
 ols
 ndG
 xQY
@@ -75225,7 +75433,7 @@ cZb
 hny
 xQY
 uVS
-hHd
+pNo
 xQY
 uNR
 usm
@@ -75473,12 +75681,12 @@ bzc
 csH
 ybf
 mgP
-qCp
-qCp
-hHd
+bGl
+bGl
+pNo
 xQY
 qYh
-qCp
+bGl
 slR
 rYp
 uVS
@@ -78522,8 +78730,8 @@ nzy
 nzy
 nzy
 nzy
-dFe
-dFe
+ovH
+bzE
 hzS
 ays
 oCv
@@ -80578,7 +80786,7 @@ rZW
 uXP
 wux
 xNK
-dFe
+mgf
 dFe
 hzS
 qpX
@@ -82133,7 +82341,7 @@ irs
 irs
 xsz
 irs
-aPG
+kwI
 irs
 pMJ
 pMJ
@@ -82587,7 +82795,7 @@ eyo
 eyo
 eyo
 vdE
-sQJ
+lVP
 vdE
 ozS
 xzS
@@ -82620,7 +82828,7 @@ rBl
 vdE
 vdE
 vdE
-nYv
+yki
 mBf
 xPg
 qwq
@@ -82844,7 +83052,7 @@ eyo
 jEY
 eKT
 vdE
-sQJ
+lVP
 vdE
 jzp
 oSK
@@ -83101,7 +83309,7 @@ eyo
 eyo
 wkC
 vdE
-sQJ
+lVP
 vdE
 vdE
 ydG
@@ -83358,8 +83566,8 @@ eyo
 rbW
 eMl
 vdE
-sQJ
-sQJ
+lVP
+lVP
 vdE
 meC
 meC
@@ -83398,15 +83606,15 @@ qwq
 pGR
 qwq
 sES
-sSS
-sSS
-sSS
-sSS
-sSS
-vtr
+oCe
+oCe
+oCe
+oCe
+oCe
+xkv
 weB
-qGF
-xyU
+hPl
+nYv
 ojk
 oYo
 vtr
@@ -83616,7 +83824,7 @@ yfC
 bGv
 vdE
 sQJ
-sQJ
+lVP
 vdE
 meC
 meC
@@ -83653,18 +83861,18 @@ mBf
 mIG
 oCe
 mlr
-hIc
-qGF
-xyU
-xyU
-cqE
-xyU
-xyU
-xyU
-xyU
-xyU
-xyU
-pyZ
+eEt
+hPl
+nYv
+nYv
+wtY
+nYv
+nYv
+nYv
+nYv
+nYv
+nYv
+jiF
 gFp
 xyU
 xyU
@@ -83873,7 +84081,7 @@ vdE
 vdE
 vdE
 vdE
-sQJ
+lVP
 vdE
 meC
 meC
@@ -83900,7 +84108,7 @@ vdE
 cmZ
 kVH
 cmZ
-cmZ
+xDy
 kVH
 cmZ
 cmZ
@@ -83911,17 +84119,17 @@ bwY
 bwY
 bwY
 clS
-bQO
-bQO
-bQO
-bQO
-bQO
-bQO
-bQO
-pyZ
-pyZ
-pyZ
-pyZ
+bwY
+bwY
+bwY
+bwY
+bwY
+bwY
+bwY
+jiF
+jiF
+jiF
+jiF
 dml
 pyZ
 pyZ
@@ -84130,7 +84338,7 @@ vdE
 pud
 sKv
 vdE
-sQJ
+lVP
 vdE
 meC
 meC
@@ -84167,18 +84375,18 @@ nYv
 bwY
 nYv
 nYv
-gFp
+vBM
 qeX
-xyU
-xyU
-crc
-xyU
-xyU
-bQO
-xyU
-xyU
-xyU
-xyU
+nYv
+nYv
+fSS
+nYv
+nYv
+bwY
+nYv
+nYv
+nYv
+nYv
 gFp
 xyU
 xyU
@@ -84387,7 +84595,7 @@ vdE
 tRd
 sQJ
 sQJ
-sQJ
+lVP
 vdE
 meC
 meC
@@ -84644,7 +84852,7 @@ vdE
 uSa
 sQJ
 sQJ
-sQJ
+lVP
 vdE
 meC
 meC
@@ -84668,7 +84876,7 @@ lVP
 lVP
 lVP
 vdE
-cmZ
+vxF
 cmZ
 cmZ
 gsn
@@ -84723,8 +84931,8 @@ iur
 pUC
 qOf
 qKw
-anr
-anr
+xzr
+xzr
 qKw
 qKw
 sgR
@@ -84901,7 +85109,7 @@ vdE
 fDZ
 sQJ
 vdE
-sQJ
+lVP
 vdE
 meC
 meC
@@ -84980,7 +85188,7 @@ iur
 vXU
 mKo
 qKw
-anr
+xzr
 nri
 usZ
 rTb
@@ -85158,7 +85366,7 @@ tXp
 tXp
 tXp
 vdE
-sQJ
+lVP
 vdE
 meC
 meC
@@ -85415,7 +85623,7 @@ meC
 meC
 meC
 vdE
-sQJ
+lVP
 vdE
 meC
 meC
@@ -85494,7 +85702,7 @@ iur
 qEz
 qKw
 rbE
-anr
+xzr
 rzT
 iur
 rTe
@@ -85672,7 +85880,7 @@ meC
 meC
 meC
 vdE
-sQJ
+lVP
 vdE
 vdE
 vdE
@@ -85751,7 +85959,7 @@ iur
 dNB
 qKw
 qKw
-anr
+xzr
 czb
 iur
 qKw
@@ -85929,7 +86137,7 @@ meC
 meC
 meC
 vdE
-sQJ
+lVP
 sQJ
 vdE
 lEH
@@ -85937,8 +86145,8 @@ lME
 vdE
 rbh
 uzC
-pWg
-pWg
+wzp
+wzp
 lVP
 lVP
 vdE
@@ -86008,7 +86216,7 @@ iur
 iur
 iur
 qKw
-anr
+xzr
 rAf
 iur
 icT
@@ -86186,15 +86394,15 @@ meC
 meC
 meC
 vdE
-sQJ
-sQJ
-sQJ
-sQJ
+lVP
+lVP
+lVP
+lVP
 lSf
-iiC
-sQJ
-sQJ
-sQJ
+bQO
+lVP
+lVP
+jUt
 rbh
 lVP
 sQJ
@@ -86261,11 +86469,11 @@ ycI
 ycI
 xOw
 iur
-hPr
-wLq
+oTR
+vzY
 iur
 iur
-anr
+xzr
 iur
 iur
 bZp
@@ -86518,11 +86726,11 @@ iJa
 yaG
 xOw
 jXz
-pUm
-anr
-log
-anr
-anr
+boU
+xzr
+gtT
+xzr
+xzr
 qKw
 iur
 iur
@@ -86775,11 +86983,11 @@ qta
 yaG
 xOw
 iur
-exx
-mks
+bhf
+rNU
 iur
 qKw
-anr
+xzr
 qKw
 iur
 meC
@@ -87035,8 +87243,8 @@ iur
 iur
 iur
 iur
-anr
-anr
+xzr
+xzr
 vXU
 iur
 meC
@@ -87289,10 +87497,10 @@ lUs
 yaG
 xOw
 iur
-hsF
-xss
+ydE
+tak
 iur
-anr
+xzr
 iur
 iur
 iur
@@ -87546,10 +87754,10 @@ yaG
 yaG
 xOw
 jXz
-iPC
-oWj
-log
-anr
+xSS
+gyK
+gtT
+xzr
 iur
 meC
 meC
@@ -87751,7 +87959,7 @@ hEC
 rvZ
 rvZ
 qOA
-vjo
+sPU
 aVI
 rvZ
 anB
@@ -87803,8 +88011,8 @@ xOw
 xOw
 xOw
 iur
-aFA
-dyc
+aMI
+usy
 iur
 qKw
 iur
@@ -87996,7 +88204,7 @@ vdE
 vdE
 xWS
 lkY
-lVP
+mgG
 lVP
 lVP
 lVP
@@ -88563,14 +88771,14 @@ hRI
 xXV
 iBd
 xXV
-jUt
+rpQ
 xAv
 yaG
 yaG
 yaG
 yaG
-ctE
-ctE
+aVQ
+aVQ
 xOw
 meC
 meC
@@ -88799,7 +89007,7 @@ bPB
 bcA
 ljp
 tTz
-yjs
+rcu
 wKe
 yjs
 qyU
@@ -88822,12 +89030,12 @@ hCP
 hCP
 dLV
 jWU
-nbd
-hFL
-gNd
-kUc
-uSo
-ctE
+gMb
+cjR
+izV
+xni
+aWz
+aVQ
 xOw
 meC
 meC
@@ -89080,11 +89288,11 @@ xHl
 glK
 jYo
 yiq
-wGT
-djj
-vGc
-oFK
-ctE
+ajc
+peO
+izT
+oQE
+aVQ
 xOw
 meC
 meC
@@ -89337,11 +89545,11 @@ bpn
 bpf
 bpn
 bpn
-eFS
-lqk
-lFz
-dpM
-ctE
+gbp
+scW
+dna
+nfy
+aVQ
 xOw
 meC
 meC
@@ -89594,11 +89802,11 @@ iMq
 eAD
 kel
 bpn
-ctE
-ctE
-ctE
-ctE
-ctE
+aVQ
+aVQ
+aVQ
+aVQ
+aVQ
 xOw
 meC
 meC
@@ -91853,8 +92061,8 @@ xOw
 xOw
 meC
 meC
-meC
-meC
+xOw
+xOw
 lkY
 txc
 wAK
@@ -92111,7 +92319,7 @@ xOw
 meC
 meC
 meC
-meC
+xOw
 lkY
 lkY
 wAK
@@ -92368,8 +92576,8 @@ xOw
 meC
 meC
 meC
-meC
-meC
+xOw
+xOw
 lkY
 wAK
 wAK
@@ -92626,7 +92834,7 @@ meC
 meC
 meC
 meC
-meC
+xOw
 lkY
 pRp
 oee
@@ -92883,7 +93091,7 @@ meC
 meC
 meC
 meC
-meC
+xOw
 lkY
 lkY
 lkY
@@ -93140,10 +93348,10 @@ meC
 meC
 meC
 meC
-meC
-meC
-meC
-meC
+xOw
+xOw
+xOw
+xOw
 wFQ
 jUW
 kdw
@@ -95489,7 +95697,7 @@ gvh
 sxh
 jpm
 qMW
-yki
+oAf
 qMW
 jpm
 aQI
@@ -95746,7 +95954,7 @@ gvh
 sXj
 xqL
 dub
-yki
+oAf
 heN
 utl
 sXj
@@ -96260,8 +96468,8 @@ gvh
 sXj
 lGo
 qMW
-yki
-yki
+oAf
+oAf
 lGo
 sXj
 mAc
@@ -96518,9 +96726,9 @@ keu
 sgz
 qMW
 qMW
-yki
+oAf
 vWT
-mXM
+vtd
 gvh
 wXw
 wXw
@@ -97036,8 +97244,8 @@ meC
 caa
 iRe
 prs
-pBD
-pBD
+fLD
+hQV
 pBD
 cql
 sHh
@@ -97296,7 +97504,7 @@ caa
 caa
 caa
 caa
-iCn
+lmB
 caa
 caa
 caa


### PR DESCRIPTION
Fixes more areas
Makes sure each room has an APC, and each non-maint room has an Air Alarm
Adds disposal units around the map
Adds an Engineering security outpost, as well as a Cargo security outpost
Fixes decals, mostly in toxins
Adds a radiation shelter in the Bridge
Adds 2 new small maint rooms
Splits maints into more area types (sec maints/dorms added, instead of all being aft port, just as an example)