### PR TITLE
Overhaul Atmo

### DIFF
--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -19,11 +19,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aaB" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "N2 to Pure"
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "abq" = (
 /obj/machinery/firealarm/directional/west,
@@ -37,10 +36,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/security/checkpoint/medical)
 "abu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/off{
+	name = "O2 To Pure"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "abz" = (
 /obj/structure/closet/mini_fridge,
@@ -145,17 +144,18 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/coldroom)
+"aeM" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/space/basic,
+/area/space)
 "afW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "afY" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "agf" = (
 /obj/effect/turf_decal/tile/yellow/anticorner{
@@ -165,14 +165,19 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "agi" = (
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
-	},
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "N2O Outlet"
 	},
+/obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"agj" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "agm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
@@ -246,19 +251,31 @@
 "aiZ" = (
 /turf/open/floor/wood,
 /area/security/prison/workout)
+"ajb" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ajd" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"ajy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+"aju" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
+/turf/open/space/basic,
+/area/space/nearstation)
+"ajy" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release"
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "ajH" = (
 /obj/structure/bed,
@@ -360,10 +377,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "amG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "anB" = (
 /obj/machinery/deepfryer,
@@ -388,12 +403,12 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
-"aog" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+"aol" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "aoP" = (
 /obj/effect/turf_decal/tile/brown{
@@ -428,10 +443,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/meeting_room/council)
-"apG" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+"apC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/upper)
+"apG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -451,6 +472,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"aqr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/upper)
 "aqF" = (
 /obj/machinery/duct,
 /obj/machinery/door/airlock{
@@ -475,6 +501,9 @@
 /obj/structure/easel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ard" = (
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/upper)
 "arf" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -505,18 +534,17 @@
 	},
 /area/command/heads_quarters/ce)
 "ase" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Ports to Mix"
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "asq" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "ass" = (
 /obj/structure/table/wood,
@@ -543,15 +571,16 @@
 "asz" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
-"asC" = (
+"ata" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "atq" = (
 /obj/machinery/light/directional/north,
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "atO" = (
@@ -694,8 +723,8 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ayA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -708,6 +737,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"ayS" = (
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/engineering/atmos/upper)
 "azb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -766,10 +800,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"aAz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "aAH" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"aAI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/engineering/atmos/upper)
 "aAL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -779,6 +827,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"aAS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "aAV" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -794,8 +848,8 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "aBb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -814,9 +868,11 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "aBq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "aBy" = (
 /obj/structure/chair/comfy{
@@ -825,20 +881,23 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "aBB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aBG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/upper)
+"aBH" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aBS" = (
-/obj/machinery/atmospherics/components/unary/bluespace_sender,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aCj" = (
@@ -855,9 +914,7 @@
 /area/security/office)
 "aCq" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank,
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
-	},
+/obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aCu" = (
@@ -927,11 +984,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
 /area/service/theater)
-"aEh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+"aEu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aEz" = (
@@ -971,7 +1025,7 @@
 /area/security/detectives_office)
 "aFp" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -1011,13 +1065,9 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "aGP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Filter"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -1030,6 +1080,13 @@
 	luminosity = 2
 	},
 /area/ai_monitored/command/nuke_storage)
+"aHB" = (
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Pure to Port"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "aHF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -1065,9 +1122,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
+"aIy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "aIz" = (
 /turf/closed/wall/r_wall,
 /area/science/test_area)
+"aIU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aIX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -1096,12 +1166,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aJL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "aJM" = (
 /obj/structure/sign/departments/science{
@@ -1136,14 +1203,6 @@
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"aLa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "aLi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -1167,6 +1226,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"aMq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/upper)
 "aMt" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "AI Core - Southwest";
@@ -1194,6 +1259,13 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/engineering/main)
+"aNm" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "aOc" = (
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Console"
@@ -1291,21 +1363,18 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "aQw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "aQz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "aQC" = (
 /turf/open/floor/iron,
@@ -1335,17 +1404,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "aSm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "aSt" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -1367,10 +1431,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "aSz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aSA" = (
 /obj/machinery/atmospherics/components/tank/air,
@@ -1387,6 +1454,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"aTf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "aTw" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan{
@@ -1401,20 +1475,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aTA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"aTW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+"aTK" = (
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/atmos/office)
+"aTW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/office)
 "aUo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1427,10 +1500,19 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"aVD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+"aUY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"aVD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -1445,12 +1527,27 @@
 /turf/open/floor/wood,
 /area/service/library)
 "aVY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"aWu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
+"aWE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/engineering/atmos/office)
 "aXe" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -1484,10 +1581,9 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aYi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "aYo" = (
 /obj/structure/filingcabinet,
@@ -1506,23 +1602,27 @@
 	},
 /area/service/chapel)
 "aZl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
 "aZI" = (
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
-"bae" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+"aZO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/office)
+"baj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "bas" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/iron,
@@ -1540,6 +1640,14 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
+"bbm" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/engineering/atmos)
 "bbt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1577,13 +1685,14 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bcO" = (
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 4;
+	name = "Mix 1 Output"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "bcU" = (
 /obj/effect/turf_decal/siding/green/corner{
@@ -1663,10 +1772,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"beP" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "beX" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -1770,13 +1875,19 @@
 	dir = 1
 	},
 /area/construction/mining/aux_base)
+"bgP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "bgY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
 "bhP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bie" = (
 /obj/effect/turf_decal/stripes/line,
@@ -1863,10 +1974,21 @@
 /obj/structure/flora/junglebush,
 /turf/open/floor/grass,
 /area/medical/virology)
+"bkv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "bkw" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"bkF" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos/upper)
 "bkG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -1879,8 +2001,21 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"bkK" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "ble" = (
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Mix"
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bln" = (
 /obj/structure/flora/junglebush,
@@ -1892,8 +2027,8 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "blu" = (
-/obj/machinery/pipedispenser,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "blz" = (
 /obj/machinery/light/directional/south,
@@ -1919,6 +2054,16 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"blV" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Mix 1 to Filter"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "blX" = (
 /obj/machinery/shower{
 	dir = 4
@@ -1991,10 +2136,8 @@
 /area/science/genetics)
 "bnS" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "boe" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -2005,6 +2148,25 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
+"bom" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+"bop" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Waste to Filter"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "bor" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -2016,10 +2178,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"boz" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "boJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "O2 Outlet Pump"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/engineering/atmos/upper)
 "boO" = (
 /obj/machinery/door/airlock/engineering{
@@ -2085,17 +2261,23 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"bpF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
+"bpV" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+"bqf" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "bql" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "bqn" = (
 /obj/machinery/door/window/southleft{
@@ -2134,7 +2316,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
 /area/engineering/atmos/upper)
 "brM" = (
 /obj/machinery/computer/secure_data/laptop{
@@ -2228,11 +2412,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"bsI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+"bsz" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
+"bsI" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bsK" = (
@@ -2258,26 +2450,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"btl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "btO" = (
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "btU" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/pipedispenser/disposal,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "buv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -2285,7 +2471,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "bvC" = (
 /obj/structure/chair{
 	dir = 8
@@ -2301,6 +2487,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"bwe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
+"bwq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bwK" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -2316,10 +2517,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"bwV" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
 "bwX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "bwY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2327,6 +2535,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"bwZ" = (
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos)
+"bxg" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Distro to Waste"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos)
 "bxR" = (
 /obj/machinery/computer/station_alert,
 /obj/effect/turf_decal/tile/yellow{
@@ -2354,9 +2572,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "byV" = (
@@ -2378,6 +2595,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"bzt" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos/office)
 "bzI" = (
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -2388,12 +2612,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
-"bAr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "bAu" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -2408,7 +2626,7 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/sign/warning/radiation,
 /turf/open/floor/plating,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "bAG" = (
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -2424,6 +2642,11 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"bBQ" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "bCe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -2553,6 +2776,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/science/genetics)
+"bFc" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bFl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2588,12 +2818,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
-"bGs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bGv" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/wizard,
@@ -2606,13 +2830,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"bGD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+"bGO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
+"bGR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "bHo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
@@ -2697,6 +2924,11 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"bLf" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "bLh" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -2742,11 +2974,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "bMc" = (
-/obj/machinery/shower{
-	dir = 4;
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bMm" = (
@@ -2770,6 +3001,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"bMJ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "bNF" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -2781,7 +3018,7 @@
 /obj/item/holosign_creator/atmos,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "bOb" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/camera/directional/east{
@@ -2822,12 +3059,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"bPI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bPR" = (
 /obj/structure/closet/mini_fridge,
 /turf/open/floor/plating,
@@ -2845,7 +3076,7 @@
 "bQL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "bQO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2894,6 +3125,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"bSO" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+"bSU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air to Distro"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "bSX" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -2919,6 +3169,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/medical/virology)
+"bTe" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "bTh" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications";
@@ -2934,10 +3191,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
 "bTC" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
 /area/engineering/atmos)
 "bTI" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -3057,10 +3313,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "bXM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/turf/open/floor/iron/white,
 /area/engineering/atmos)
 "bYw" = (
 /obj/machinery/computer/cargo{
@@ -3096,20 +3358,22 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"bZe" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste Release"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "bZf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"bZg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "bZp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3136,13 +3400,16 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "bZV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "caa" = (
 /turf/closed/wall/r_wall,
 /area/service/chapel/office)
@@ -3210,12 +3477,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"cbh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "cbp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3295,10 +3556,10 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
-"cfi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"ceT" = (
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/atmos)
 "cfA" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -3324,12 +3585,12 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "cfD" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "O2 To Pure"
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "cfY" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/wall/virusfood/directional/south,
@@ -3355,6 +3616,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"cgD" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "cgF" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy{
@@ -3402,15 +3669,31 @@
 "cgV" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
+"chc" = (
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "chL" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/engineering/atmos/office)
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "cid" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -3419,6 +3702,13 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"ciy" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ciK" = (
 /turf/closed/wall,
 /area/service/janitor)
@@ -3439,6 +3729,11 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"cjl" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cjr" = (
 /obj/structure/table,
 /obj/item/seeds/tower,
@@ -3472,6 +3767,21 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"cjU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
+"cjW" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "cko" = (
 /obj/structure/reflector/single,
 /obj/effect/turf_decal/siding/yellow{
@@ -3539,6 +3849,16 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"cmo" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "cmt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3573,6 +3893,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"cnx" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cnG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -3593,24 +3922,24 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "cnM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cnP" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"cnR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
+"coa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
-"cnV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "con" = (
 /obj/machinery/hydroponics/constructable,
@@ -3659,7 +3988,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cqx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "cqE" = (
@@ -3714,9 +4048,9 @@
 /area/security/execution/education)
 "csy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "csA" = (
@@ -3724,8 +4058,11 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
 "csG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
@@ -3743,6 +4080,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"ctM" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ctO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -3783,21 +4127,35 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "cuN" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 8;
-	initialize_directions = 8
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
 	},
+/obj/machinery/airalarm/directional/west,
+/obj/structure/fireaxecabinet/directional/south,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "cvs" = (
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air Outlet Pump"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/engineering/atmos/upper)
+"cvt" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/multitool,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/atmos)
 "cvz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
@@ -3858,7 +4216,12 @@
 /area/science/misc_lab)
 "cxy" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Distro"
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos)
 "cxH" = (
 /obj/structure/table,
@@ -3888,26 +4251,34 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"cyj" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
+"cxT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engineering/atmos/upper)
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
+"cxZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "cyy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "cyE" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron{
-	amount = 50
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/radiation,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/multitool,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "cyQ" = (
@@ -3955,10 +4326,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/storage/tcomms)
 "czs" = (
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "czD" = (
@@ -3999,12 +4370,12 @@
 /turf/open/space/basic,
 /area/maintenance/solars/starboard/aft)
 "cAS" = (
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/item/analyzer,
-/obj/item/analyzer,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cAW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half{
@@ -4110,7 +4481,9 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
 "cDo" = (
-/obj/machinery/pipedispenser/disposal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "cDs" = (
@@ -4121,10 +4494,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "cDF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
 /turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
+"cDQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "cEc" = (
 /obj/structure/reflector/double/anchored{
@@ -4286,6 +4670,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"cIs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cIt" = (
 /obj/machinery/conveyor/inverted{
 	dir = 4;
@@ -4298,9 +4691,13 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cID" = (
-/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
+"cJa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cJI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4323,7 +4720,12 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "cJQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "cKH" = (
@@ -4331,10 +4733,9 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "cLM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "cLQ" = (
 /obj/machinery/door/firedoor,
@@ -4342,6 +4743,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"cLU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cMe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -4366,12 +4772,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
-"cNB" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cOo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -4396,12 +4796,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"cOR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cOZ" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -4454,11 +4848,17 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "cQr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
+/obj/machinery/button/door/directional/east{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Control";
+	pixel_y = 8;
+	req_access_txt = "24"
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "cQD" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -4502,12 +4902,8 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "cRz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "cRL" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -4525,7 +4921,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "cSd" = (
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
@@ -4548,6 +4944,14 @@
 	dir = 1
 	},
 /area/science/research)
+"cSS" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast door"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos/office)
 "cTe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4685,7 +5089,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cVo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -4724,16 +5127,24 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"cWm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast door"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos/office)
 "cWL" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "cXa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/tile/blue/full{
-	color = "#4169E1";
-	name = "Command blue full"
-	},
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cXc" = (
@@ -4803,6 +5214,11 @@
 	dir = 8
 	},
 /area/science/research)
+"cYB" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "cYK" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -4852,6 +5268,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"dad" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dan" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -4869,10 +5293,12 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "daA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "daO" = (
@@ -4957,10 +5383,15 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "dcC" = (
+/obj/structure/table,
+/obj/item/storage/box{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/storage/box,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dcW" = (
@@ -4973,6 +5404,14 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"ddS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "ddT" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -4998,6 +5437,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"dem" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "deB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/light/directional/south,
@@ -5011,6 +5457,34 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"deZ" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
+"dfi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dfw" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light/small/directional/east,
@@ -5042,21 +5516,20 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "dgo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dgT" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
@@ -5086,6 +5559,27 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
+"dhZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
+"dia" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dir" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -5103,8 +5597,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "diz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -5145,9 +5639,16 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "dje" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
+/obj/structure/sign/poster/official/build{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "dji" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -5165,6 +5666,9 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"dkj" = (
+/turf/closed/wall,
+/area/engineering/atmos/office)
 "dkk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/textured_large,
@@ -5219,6 +5723,13 @@
 /obj/item/watertank,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"dlk" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "dls" = (
 /obj/structure/rack,
 /obj/item/mod/module/thermal_regulator,
@@ -5342,11 +5853,33 @@
 	dir = 10
 	},
 /area/science/research)
+"doD" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "doN" = (
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"doU" = (
+/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
+"dpc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dpf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -5361,6 +5894,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
+"dpn" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "dpB" = (
 /obj/structure/reflector/single,
 /obj/effect/turf_decal/siding/yellow{
@@ -5377,11 +5915,9 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "dqa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
 /area/engineering/atmos)
 "dqq" = (
 /turf/closed/wall,
@@ -5395,6 +5931,27 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/engineering/storage/tcomms)
+"dqJ" = (
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
+"dqL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "drb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
 /turf/open/floor/engine/n2o,
@@ -5471,15 +6028,6 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"dtp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dtq" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -5493,6 +6041,18 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"dtw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"dtN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "dub" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/black,
@@ -5504,6 +6064,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"duu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "dux" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5554,6 +6123,15 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"dvK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "dwm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -5566,7 +6144,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison/workout)
 "dwu" = (
-/obj/structure/cable,
+/obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -5583,6 +6161,20 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/genetics)
+"dwC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "dwH" = (
 /obj/structure/chair/stool/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -5614,6 +6206,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/mixing)
+"dyf" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "dyg" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/white/smooth_large,
@@ -5645,13 +6243,6 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
-"dzw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "dzz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5663,9 +6254,14 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "dzH" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dzR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5691,6 +6287,30 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"dAu" = (
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "dAD" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -5706,7 +6326,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "dAS" = (
 /obj/machinery/light/directional/north,
@@ -5784,10 +6406,9 @@
 /turf/open/floor/plating,
 /area/science/storage)
 "dDf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dDs" = (
@@ -5808,12 +6429,10 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "dDF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/machinery/computer/atmos_control{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "dDI" = (
@@ -5856,16 +6475,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "dEJ" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dET" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/morgue)
 "dEV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dFe" = (
 /turf/open/floor/iron/white/textured_large,
@@ -5885,12 +6506,37 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
+"dFv" = (
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"dFB" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "dFK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"dFV" = (
+/obj/machinery/atmospherics/components/unary/bluespace_sender,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
+"dGq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dGL" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -5962,7 +6608,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "dJu" = (
 /obj/structure/cable,
@@ -5975,8 +6623,8 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
 "dJv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dJG" = (
@@ -6034,7 +6682,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
+"dKz" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/internals,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "dLf" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -6067,6 +6720,30 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"dLW" = (
+/obj/structure/table,
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/book/manual/wiki/atmospherics{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "dMd" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 4
@@ -6184,7 +6861,7 @@
 /turf/open/floor/wood,
 /area/service/lawoffice/upper)
 "dPm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -6203,6 +6880,12 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"dQe" = (
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dQu" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -6215,8 +6898,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dRb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -6235,7 +6917,7 @@
 /obj/item/storage/belt/utility/atmostech,
 /obj/item/storage/belt/utility/atmostech,
 /obj/item/storage/belt/utility/atmostech,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dSP" = (
 /obj/machinery/disposal/bin,
@@ -6366,9 +7048,8 @@
 /turf/closed/wall,
 /area/commons/vacant_room)
 "dXd" = (
-/obj/machinery/computer/atmos_control{
-	dir = 1
-	},
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -6381,25 +7062,21 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "dXA" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dXM" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/analyzer,
+/obj/item/analyzer,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dXO" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dXX" = (
@@ -6410,12 +7087,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"dYj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "dYy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 8
@@ -6518,22 +7189,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"eaK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
-"eaV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
 "ebf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -6698,12 +7353,8 @@
 /area/science/misc_lab)
 "eep" = (
 /obj/machinery/light/directional/south,
-/obj/structure/closet/crate/internals,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
-"eeu" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
 /area/engineering/atmos/office)
 "eeR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -6713,7 +7364,8 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/item/t_scanner,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "eeT" = (
 /obj/structure/closet/firecloset,
@@ -6748,12 +7400,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "efq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/west,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "efY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -6782,7 +7435,7 @@
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "egl" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table/glass,
@@ -6798,22 +7451,18 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tcomms)
 "egF" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
 /obj/machinery/camera/directional/south{
 	c_tag = "Atmospherics SE";
 	name = "Atmos Camera";
 	network = list("ss13","engineering","atmos")
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "egQ" = (
 /obj/structure/cable,
@@ -6911,22 +7560,10 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "ejy" = (
-/obj/structure/table,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ejB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -6984,22 +7621,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ejZ" = (
-/obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
 /obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ekt" = (
 /obj/structure/chair/stool/directional/south,
@@ -7044,24 +7670,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "elD" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/item/analyzer{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/book/manual/wiki/atmospherics,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "elF" = (
 /obj/machinery/light/directional/west,
@@ -7094,10 +7706,12 @@
 /area/science/research)
 "ema" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "emc" = (
 /obj/effect/turf_decal/siding/brown{
@@ -7118,15 +7732,8 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library/private)
-"emh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "emj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "emr" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -7147,9 +7754,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "emQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/end,
-/obj/machinery/space_heater,
-/turf/open/floor/iron,
+/obj/structure/tank_dispenser{
+	pixel_x = -1
+	},
+/turf/open/floor/iron/white,
 /area/engineering/atmos)
 "emW" = (
 /obj/machinery/door/airlock/external{
@@ -7282,15 +7890,6 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"eqS" = (
-/obj/structure/rack,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/iron,
-/area/engineering/storage)
 "eqU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -8199,13 +8798,13 @@
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
 "eSp" = (
-/obj/machinery/computer/atmos_control/tank/mix_tank{
+/obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/engineering/atmos/upper)
 "eSJ" = (
 /obj/effect/turf_decal/tile/brown{
@@ -8587,7 +9186,7 @@
 /area/service/bar)
 "feQ" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "feU" = (
 /obj/structure/chair/comfy/brown{
@@ -8671,13 +9270,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"fhR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Air to Mix"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "fic" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -8828,12 +9420,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"fmE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "fmF" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -8953,7 +9539,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "fsp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -9119,13 +9705,14 @@
 /turf/open/floor/wood,
 /area/service/library)
 "fyP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Mix Input"
 	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "fze" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -9398,18 +9985,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"fHF" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "fHP" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/white,
@@ -9509,10 +10084,13 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "fKw" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "fKz" = (
 /obj/effect/turf_decal/tile/purple{
@@ -9593,7 +10171,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "fOG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Port"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "fPg" = (
@@ -10225,12 +10806,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
-"git" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "giE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10378,7 +10953,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "gmk" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics Internal Airlock";
@@ -10393,12 +10968,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"gmD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos/upper)
 "gmF" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "gmG" = (
@@ -11047,16 +11619,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
-"gCi" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gCk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -11100,7 +11662,7 @@
 "gEn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "gEt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11248,10 +11810,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
-"gJw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "gJK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 8
@@ -11440,6 +11998,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gQG" = (
@@ -11947,10 +12506,6 @@
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"hhy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "hhB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12180,10 +12735,10 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "htt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/dark{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "htD" = (
@@ -12422,7 +12977,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "hAO" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -12712,15 +13267,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"hHa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hHg" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
@@ -12888,7 +13434,7 @@
 	name = "Mix Input"
 	},
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "hLR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
@@ -13114,11 +13660,8 @@
 /turf/closed/wall,
 /area/commons/toilet)
 "hQO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "hRu" = (
 /turf/closed/wall,
@@ -13155,7 +13698,7 @@
 "hSi" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "hSl" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -13184,11 +13727,17 @@
 	},
 /area/engineering/gravity_generator)
 "hTs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/machinery/requests_console/directional/south{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "hTI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13315,11 +13864,15 @@
 	},
 /area/command/gateway)
 "hYb" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump"
+/obj/machinery/meter{
+	name = "Mixed Air Tank Out"
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/engineering/atmos/upper)
 "hYj" = (
 /obj/structure/table/reinforced,
@@ -13372,13 +13925,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"hYR" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "hZb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno3";
@@ -13434,12 +13980,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
-"iag" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "iah" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -13520,13 +14060,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
-"ice" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos/upper)
 "icf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -13728,22 +14261,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 9
 	},
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ihL" = (
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "ihM" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/south{
@@ -13984,9 +14504,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "inY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "iog" = (
@@ -14031,12 +14555,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"ipD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "ipK" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -14127,7 +14645,7 @@
 "iqM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "iqU" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -14373,10 +14891,13 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/fore)
 "ixA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "iya" = (
 /obj/effect/landmark/event_spawn,
@@ -14391,8 +14912,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "iyA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Ports to Mix"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -14579,9 +15101,7 @@
 /area/security/brig/upper)
 "iEZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF6700"
-	},
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "iFa" = (
@@ -14627,16 +15147,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
-"iGu" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/shoes/magboots,
-/obj/structure/sign/poster/official/build{
-	pixel_x = -32
-	},
-/turf/open/floor/iron,
-/area/engineering/storage)
 "iGC" = (
 /obj/modular_map_root/solitairestation{
 	dir = 1;
@@ -14695,18 +15205,11 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"iHL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos/office)
 "iHS" = (
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255;
-	color = "#000000"
-	},
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "CO2 Outlet"
 	},
+/obj/effect/turf_decal/tile/dark/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "iIb" = (
@@ -14732,13 +15235,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"iIY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "iJa" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -15156,10 +15652,7 @@
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "iRo" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Pure to Port"
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "iRr" = (
@@ -15286,8 +15779,18 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "iUf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
@@ -15651,10 +16154,8 @@
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
 "jfC" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "jfO" = (
 /obj/effect/spawner/random/entertainment/drugs,
@@ -15790,10 +16291,7 @@
 /area/command/heads_quarters/captain)
 "jkB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255;
-	color = "#000000"
-	},
+/obj/effect/turf_decal/tile/dark/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "jkG" = (
@@ -15860,17 +16358,6 @@
 /obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"jmr" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/engineering/atmos/office)
 "jmW" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16126,10 +16613,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"jvH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "jvJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -16380,10 +16863,10 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "jEX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Air to Mix"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "jEY" = (
@@ -16432,14 +16915,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
-"jFY" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air to Distro"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "jGf" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -16729,16 +17204,15 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "jNF" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "jNG" = (
 /obj/machinery/door/airlock/security/glass{
@@ -16760,10 +17234,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"jOa" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/engineering/atmos/office)
 "jOc" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
@@ -16815,7 +17285,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "jOQ" = (
 /obj/machinery/light/directional/east,
@@ -16961,10 +17433,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig/upper)
-"jSe" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/iron,
-/area/engineering/storage)
 "jSm" = (
 /obj/structure/bed,
 /obj/item/toy/plush/bubbleplush,
@@ -16977,13 +17445,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
-"jSL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "jTa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17025,9 +17486,7 @@
 /area/security/warden)
 "jTQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
-	},
+/obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "jTW" = (
@@ -17836,15 +18295,9 @@
 "kqV" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "krm" = (
-/obj/structure/sign/poster/official/wtf_is_co2{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "kro" = (
@@ -17914,16 +18367,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kui" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "kuq" = (
 /obj/structure/cable,
@@ -18064,14 +18516,12 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "kxB" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kxS" = (
@@ -19442,12 +19892,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"lfq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "lfv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output,
 /turf/open/floor/engine/n2o,
@@ -19480,6 +19924,7 @@
 /area/security/prison/mess)
 "lfP" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "lgn" = (
@@ -19494,8 +19939,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "lgE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
@@ -19511,15 +19956,6 @@
 "lgW" = (
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"lhg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "lho" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -19995,10 +20431,10 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "lve" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "lvr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -20239,10 +20675,10 @@
 /turf/open/space/basic,
 /area/medical/psychology)
 "lBg" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "lBE" = (
@@ -20378,9 +20814,8 @@
 /area/medical/medbay/lobby)
 "lEm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "N2 To Pure"
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -20438,7 +20873,7 @@
 	name = "Atmos Camera";
 	network = list("ss13","engineering","atmos")
 	},
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "lGo" = (
 /obj/structure/table/wood/fancy,
@@ -21618,12 +22053,6 @@
 "mgu" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
-"mgG" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "mgL" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -21852,13 +22281,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"mmV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "mne" = (
 /obj/machinery/camera/autoname/directional/north{
 	c_tag = "Holodeck - Fore";
@@ -21939,10 +22361,9 @@
 /turf/open/space/basic,
 /area/space)
 "mpx" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
@@ -22204,10 +22625,7 @@
 /area/hallway/secondary/service)
 "mxI" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank,
-/obj/effect/turf_decal/tile/blue/full{
-	color = "#4169E1";
-	name = "Command blue full"
-	},
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "mxY" = (
@@ -22926,10 +23344,10 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "mLA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "mLC" = (
@@ -23115,12 +23533,8 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "mOJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
 "mPn" = (
@@ -23786,7 +24200,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "nhW" = (
 /obj/machinery/disposal/bin,
@@ -23853,7 +24269,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "njL" = (
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "njQ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -23870,12 +24286,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "nku" = (
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
-	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "N2 Outlet Pump"
 	},
+/obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "nkJ" = (
@@ -24325,16 +24739,7 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"nye" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/trimline/yellow/filled/end{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "nyh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -24661,12 +25066,10 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "nGc" = (
-/obj/structure/fireaxecabinet/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Port"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "nHk" = (
@@ -24936,13 +25339,13 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "nQO" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
+/obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255
+/obj/effect/turf_decal/tile/yellow/full{
+	color = "#FFD700"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "nQU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -25091,12 +25494,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/medical/medbay/lobby)
-"nUB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "nVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/glass,
@@ -25557,12 +25954,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
-"oiE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "oiI" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/open/floor/iron,
@@ -25654,14 +26045,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/security/courtroom)
-"omp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Mix"
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "omD" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -25962,13 +26345,10 @@
 /turf/open/floor/carpet,
 /area/security/courtroom)
 "ouw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "ovi" = (
 /obj/machinery/camera{
@@ -25991,10 +26371,8 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "ovr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "ovP" = (
 /turf/closed/wall/r_wall,
@@ -26500,8 +26878,8 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "oGG" = (
-/obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
 /area/engineering/atmos/office)
 "oGL" = (
 /obj/structure/table/wood/poker,
@@ -26576,10 +26954,7 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "oJF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/meter/atmos/atmos_waste_loop,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "oJR" = (
@@ -26620,12 +26995,8 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "oKk" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "oKH" = (
 /obj/effect/turf_decal/siding/blue{
@@ -26658,7 +27029,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "oLb" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
@@ -26931,7 +27302,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "oUA" = (
 /obj/structure/closet/crate/grave,
 /obj/structure/sign/poster/official/ian{
@@ -27157,9 +27528,8 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "pbc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -27462,14 +27832,15 @@
 /area/security/brig/upper)
 "pkG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
 /area/engineering/atmos/upper)
 "pkX" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "plk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27635,11 +28006,9 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "ppH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "ppK" = (
@@ -27679,8 +28048,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "psH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -27938,7 +28307,9 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "pDX" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "pEe" = (
@@ -28174,11 +28545,12 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "pLB" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "pLN" = (
 /obj/structure/cable,
@@ -28202,7 +28574,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "pMp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -28435,10 +28807,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "pUF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers{
-	dir = 1
+/turf/open/floor/iron/dark/side{
+	dir = 4
 	},
-/turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "pUL" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
@@ -29059,7 +29430,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "qpI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -29081,8 +29452,8 @@
 /turf/open/space/basic,
 /area/command/heads_quarters/cmo)
 "qqh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -29172,9 +29543,7 @@
 /area/command/heads_quarters/hop)
 "que" = (
 /obj/machinery/computer/atmos_control/tank/plasma_tank,
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF6700"
-	},
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "qum" = (
@@ -29243,7 +29612,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "qxH" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
@@ -29384,14 +29753,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"qCx" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "qCy" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
@@ -29699,7 +30060,7 @@
 "qIC" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "qID" = (
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos/upper)
@@ -29775,13 +30136,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
-"qJv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "qJQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30188,10 +30542,10 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "qYF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "qYK" = (
 /obj/structure/table/reinforced,
@@ -30341,11 +30695,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"rdI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "rdU" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -30583,13 +30932,7 @@
 /turf/open/floor/iron/dark,
 /area/science/research)
 "rlh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Waste to Filter"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "rlM" = (
@@ -30607,13 +30950,6 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"rlV" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "rms" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -31043,7 +31379,7 @@
 /area/ai_monitored/security/armory)
 "ryF" = (
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "ryT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -31185,11 +31521,7 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "rCn" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Distro"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "rCr" = (
@@ -31550,7 +31882,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "rKn" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 9
@@ -31655,7 +31987,7 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "rLO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -32271,8 +32603,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "sba" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	name = "plasma mixer"
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -32295,7 +32627,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "scd" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -32408,13 +32740,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/prison/toilet)
 "seR" = (
-/obj/effect/turf_decal/tile/blue/full{
-	color = "#4169E1";
-	name = "Command blue full"
-	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "O2 Outlet Pump"
 	},
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "seZ" = (
@@ -32474,7 +32803,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "shd" = (
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/upper)
 "shp" = (
 /obj/item/assembly/mousetrap/armed,
@@ -32704,7 +33033,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/engineering/atmos/upper)
 "snZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -32774,7 +33105,7 @@
 /area/service/chapel/office)
 "soN" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/upper)
 "soV" = (
 /obj/effect/turf_decal/siding/brown/corner{
@@ -32887,11 +33218,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"srt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "srF" = (
 /obj/structure/chair/comfy/black{
 	dir = 1;
@@ -33177,7 +33503,6 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "syG" = (
-/obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage)
@@ -33456,7 +33781,7 @@
 	name = "Atmos Camera";
 	network = list("ss13","engineering","atmos")
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/upper)
 "sKs" = (
 /turf/closed/wall/r_wall,
@@ -33610,9 +33935,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "sPU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
@@ -33894,8 +34220,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "sWD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -34194,8 +34521,11 @@
 	},
 /area/medical/treatment_center)
 "tff" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "tfh" = (
 /turf/closed/wall,
@@ -34242,12 +34572,10 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "tha" = (
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF6700"
-	},
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Plasma Outlet"
 	},
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "thg" = (
@@ -34722,10 +35050,10 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "ttQ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/upper)
 "ttS" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -34775,13 +35103,6 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"tuJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos/upper)
 "tuK" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/structure/sign/warning/pods{
@@ -34869,13 +35190,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"txl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "txq" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -35156,7 +35470,7 @@
 /area/maintenance/solars/port/aft)
 "tDj" = (
 /turf/closed/wall/r_wall,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "tDH" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -35239,10 +35553,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"tEw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "tEJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/ai_all,
@@ -35251,7 +35561,7 @@
 "tEZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "tFb" = (
 /obj/structure/reagent_dispensers/wall/peppertank{
 	pixel_y = 32
@@ -35300,13 +35610,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
-"tHH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "tHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -35322,8 +35625,8 @@
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "tHX" = (
-/obj/machinery/portable_atmospherics/canister/tier_3,
-/turf/open/floor/engine/vacuum,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/upper)
 "tIl" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -35501,16 +35804,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"tOg" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/turf/open/floor/iron,
-/area/engineering/storage)
 "tOH" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -35528,10 +35821,8 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "tPx" = (
-/obj/machinery/air_sensor/atmos/mix_tank{
-	name = "mix 1 tank gas sensor"
-	},
-/turf/open/floor/engine/vacuum,
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/upper)
 "tPE" = (
 /obj/machinery/light/directional/north,
@@ -35711,10 +36002,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "tTw" = (
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "tTy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35832,10 +36123,10 @@
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "tWu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
 	dir = 4
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/upper)
 "tWA" = (
 /obj/structure/tank_holder/extinguisher,
@@ -35861,10 +36152,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tWV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
 "tXd" = (
@@ -35960,7 +36250,7 @@
 /area/engineering/lobby)
 "tYq" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -35971,14 +36261,14 @@
 	pixel_y = 30
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "tYF" = (
 /turf/closed/wall/r_wall,
 /area/security/lockers)
 "tZj" = (
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "tZG" = (
 /obj/machinery/vending/coffee,
 /obj/structure/sign/poster/contraband/hacking_guide{
@@ -36168,7 +36458,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "ucK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -36263,12 +36553,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"uex" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "ueI" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/pew/right,
@@ -36333,9 +36617,10 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "ugB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "ugE" = (
@@ -36361,13 +36646,13 @@
 "uhe" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "uhf" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "uhg" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -36378,6 +36663,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uhs" = (
@@ -36477,10 +36763,9 @@
 /turf/closed/wall,
 /area/service/kitchen/diner)
 "uiU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "uiY" = (
@@ -36499,16 +36784,25 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ujh" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/thermomachine/heater/on{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos)
 "uji" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "Mix 1 Output"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/floor/iron,
+/obj/machinery/meter,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/engineering/atmos/upper)
 "ujn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -36560,7 +36854,7 @@
 "ukN" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "ukP" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 10
@@ -36829,10 +37123,10 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice/upper)
 "upV" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 4
 	},
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "upX" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -36932,7 +37226,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "urm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37156,8 +37450,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "uwp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "uwA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -37251,7 +37545,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "uyA" = (
 /obj/structure/moisture_trap,
 /turf/open/floor/plating,
@@ -37261,7 +37555,7 @@
 	color = "#52B4E9"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "uzd" = (
 /obj/item/storage/briefcase/lawyer,
 /obj/structure/rack,
@@ -37689,11 +37983,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/range)
 "uIU" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "uIW" = (
@@ -37745,13 +38037,13 @@
 "uKl" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "uKs" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "uKW" = (
 /obj/item/toy/cards/deck{
 	pixel_x = -8;
@@ -37878,7 +38170,7 @@
 	pixel_x = -15
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "uNv" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 7
@@ -37924,8 +38216,8 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uNY" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
+/obj/machinery/portable_atmospherics/canister/tier_3,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "uOb" = (
 /obj/effect/turf_decal/tile/blue{
@@ -37972,14 +38264,13 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "uPd" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 8;
-	name = "Mix Input"
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/full{
-	color = "#FFD700"
+/obj/effect/turf_decal/tile/blue/half{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/engineering/atmos/upper)
 "uPf" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -38025,12 +38316,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
-"uPz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
 "uPT" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Court Room";
@@ -38074,7 +38359,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "uQO" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/effect/turf_decal/trimline/red/warning,
@@ -38088,8 +38373,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "uRi" = (
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air,
+/obj/machinery/air_sensor/atmos/mix_tank{
+	name = "mix 1 tank gas sensor"
+	},
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "uRm" = (
 /obj/machinery/door/airlock/maintenance{
@@ -38329,9 +38616,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uWk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uWr" = (
@@ -38353,7 +38638,9 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "uWV" = (
-/turf/closed/wall/r_wall,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/engineering/main)
 "uXb" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -38500,8 +38787,10 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "vaE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "vaF" = (
 /obj/machinery/hydroponics/constructable,
@@ -39051,12 +39340,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "vmZ" = (
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "vnK" = (
 /obj/structure/lattice/catwalk,
@@ -39071,13 +39356,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"voc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "vom" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -39445,7 +39723,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "vvT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -39499,7 +39777,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "vwK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vwQ" = (
@@ -39546,11 +39825,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "vxF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/engineering/atmos/upper)
 "vxR" = (
 /obj/effect/turf_decal/siding/purple{
@@ -39664,16 +39944,13 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "vAC" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "vAD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "vAH" = (
@@ -39756,7 +40033,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "vCk" = (
 /mob/living/simple_animal/mouse/brown/tom,
 /obj/machinery/duct,
@@ -39769,7 +40046,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "vDj" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39842,7 +40119,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "vFn" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39971,7 +40248,7 @@
 "vJE" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "vJH" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -40027,8 +40304,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
 "vKP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "vKV" = (
@@ -40121,10 +40398,10 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "vMc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
 	dir = 4
 	},
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "vMB" = (
 /obj/machinery/status_display/ai/directional/south,
@@ -40410,11 +40687,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"vUt" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "vUy" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -41069,12 +41341,9 @@
 /turf/open/floor/iron/grimy,
 /area/security/interrogation)
 "wjx" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "wjL" = (
@@ -41395,10 +41664,11 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "wtt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "wtv" = (
 /obj/item/trash/candy,
@@ -41471,7 +41741,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "wvn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42099,7 +42369,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "wFQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42218,7 +42488,7 @@
 "wJB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "wJD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -42312,7 +42582,7 @@
 "wLt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "wLG" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -42457,7 +42727,7 @@
 "wPQ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "wPW" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/stripes/line,
@@ -42806,7 +43076,7 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "wZg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -42934,7 +43204,9 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "xdy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "xdH" = (
@@ -43176,9 +43448,7 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "xka" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "xkj" = (
@@ -43262,8 +43532,7 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "xmr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/obj/machinery/meter/atmos/atmos_waste_loop,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "xmQ" = (
@@ -43691,7 +43960,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "xBo" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/blue/half{
@@ -43736,27 +44005,15 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/research)
-"xCO" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Incinerator"
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "xDx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "xDy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron/dark/textured_large,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "xDI" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -43797,7 +44054,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "xFv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -43833,12 +44090,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
-"xGt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xGI" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
@@ -43915,7 +44166,7 @@
 "xHD" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "xHU" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
@@ -44092,7 +44343,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos/hfr_room)
+/area/engineering/atmospherics_engine)
 "xMh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44186,7 +44437,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/smooth_large,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "xOu" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -44202,9 +44453,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "xOC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "xOI" = (
@@ -44214,7 +44465,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xOP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xOT" = (
@@ -44660,7 +44911,9 @@
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
 "xWV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Filter"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "xXi" = (
@@ -45046,12 +45299,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"yhg" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Mix 1 to Filter"
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/engineering/atmos)
 "yhr" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /obj/machinery/disposal/bin,
@@ -45092,10 +45339,7 @@
 /area/hallway/secondary/exit)
 "yif" = (
 /obj/machinery/computer/atmos_control/tank/carbon_tank,
-/obj/effect/turf_decal/tile/neutral/full{
-	alpha = 255;
-	color = "#000000"
-	},
+/obj/effect/turf_decal/tile/dark/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "yiq" = (
@@ -45125,19 +45369,13 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "yiF" = (
 /obj/machinery/computer/atmos_control/tank/nitrous_tank,
-/obj/effect/turf_decal/tile/red/full{
-	color = "#FF0000"
-	},
+/obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "yiK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "yiL" = (
 /turf/open/floor/iron/smooth,
@@ -60834,7 +61072,7 @@ ukN
 uKs
 uhe
 wLt
-xFT
+baj
 xFT
 qpH
 tTm
@@ -61608,7 +61846,7 @@ tDj
 tDj
 tDj
 tDj
-qEC
+tDj
 xOc
 xOc
 cDs
@@ -61865,10 +62103,10 @@ xOw
 xOw
 xOw
 xOw
-qEC
-qEC
-qEC
-trM
+tDj
+tDj
+tDj
+chL
 ebr
 cIm
 kYu
@@ -63139,13 +63377,13 @@ meC
 meC
 xOw
 seZ
-tuJ
+tWV
 sgj
 tWV
 seZ
 aZl
 sgj
-aZl
+aMq
 seZ
 xOw
 meC
@@ -63396,13 +63634,13 @@ xOw
 xOw
 xOw
 xOw
-txl
+tYq
 xOw
 tYq
 xOw
 aFp
 xOw
-aFp
+aNm
 xOw
 xOw
 xOw
@@ -63655,11 +63893,11 @@ jFX
 szr
 wZg
 jFX
-ice
+wZg
 szr
 rLO
 jFX
-rLO
+aQw
 szr
 szr
 xOw
@@ -63906,10 +64144,10 @@ seZ
 seZ
 seZ
 xOw
-szr
+aol
 aaB
 amG
-amG
+ata
 uPd
 eSp
 cvs
@@ -64163,19 +64401,19 @@ qWC
 rVo
 fXP
 jrY
-ois
+apC
 nku
 pkG
 aSz
 vxF
-pkG
+ayS
 uji
-pkG
+ayS
 fKw
-fqA
+ayS
 hYb
 boJ
-sgQ
+bbm
 kxB
 uhh
 rBG
@@ -64184,10 +64422,10 @@ ckp
 ihJ
 cLM
 dqa
-cLM
-cLM
-cLM
-cLM
+cYB
+doU
+doU
+dFV
 efq
 emQ
 ebr
@@ -64424,27 +64662,27 @@ jFX
 aCq
 pLB
 lEm
-jvH
-fqA
+sWD
+aAz
 sWD
 xmr
 uiU
-cQr
+fqA
 vvT
-bpF
+wjx
 bsI
 bxW
-aQC
-bPI
-aQC
+vwK
+vwK
+vwK
 vwK
 gQr
-aQC
-aQC
-aQC
-aQC
-aQC
-aQC
+cnx
+cAS
+dad
+dpc
+dzH
+dGq
 egF
 aNh
 ebr
@@ -64680,28 +64918,28 @@ wuA
 vDn
 jTQ
 dJq
-fmE
-aog
+aYY
+ppH
 qqh
-fqA
-hhy
+aAS
+vAD
 vAD
 aVY
 vvT
-fqA
+aUY
 xOP
 psH
-tff
-bTC
-aQC
-aQC
-gQr
-aQC
-bPI
 aQC
 aQC
 aQC
 aQC
+ciy
+cnM
+cDQ
+ddS
+cDQ
+cDQ
+cDQ
 ejy
 aNh
 end
@@ -64934,31 +65172,31 @@ seZ
 seZ
 seZ
 xOw
-szr
+aol
 abu
 ixA
-cfD
-ixA
-aYY
-aBB
-pkG
-xka
-aVY
-vvT
+kVO
+ppH
+qqh
 fqA
+krm
+krm
+aIy
+aSm
+aUY
 xOP
-psH
-aQC
-bXM
 aQC
 aQC
-gQr
+aQC
+aQC
+aQC
+uWk
 tff
 bTC
-aQC
-aQC
-aQC
-aQC
+dem
+dpn
+dpn
+dKz
 ejZ
 aNh
 eoC
@@ -65191,31 +65429,31 @@ rav
 sCL
 fXP
 hqY
-ois
+apC
 seR
 dAO
 ugB
 apG
-asC
+qqh
 xka
+krm
 fqA
-tEw
 ppH
-vvT
-fqA
+aTf
+wjx
 xOP
-psH
-aQC
-xGt
 aQC
 aQC
-gQr
 aQC
+aQC
+aQC
+uWk
+tff
 bXM
-aQC
-aQC
-aQC
-aQC
+deZ
+dqJ
+dAu
+dLW
 elD
 aNh
 mNS
@@ -65450,29 +65688,29 @@ sgj
 xOw
 jFX
 mxI
-ixA
-uPz
-ase
+asq
+aYY
+fqA
 iyA
-dYj
+iRo
 pDX
-oiE
-eaK
-btl
-aEh
-gCi
-aSm
+fqA
+ppH
+vvT
+wjx
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
 uWk
-uWk
-uWk
-uWk
-uWk
-uWk
-uWk
-uWk
-uWk
-uWk
-uWk
+coa
+cIs
+dfi
+cIs
+cIs
+cIs
 ema
 tFZ
 rTt
@@ -65709,28 +65947,28 @@ vDn
 cXa
 jOG
 aYY
-tyi
-ayA
-xWV
 fqA
-aEh
-lhg
-ihL
+tyi
+xWV
+aEu
+fqA
+ppH
+vvT
 wjx
-sgQ
-hHa
-bGs
-bZV
-bGs
-csy
-bGs
-cNB
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
 uWk
-aQC
-aQC
-aQC
-aQC
-emh
+emj
+cJa
+dhZ
+emj
+dEJ
+emj
+emj
 aNh
 arU
 ezW
@@ -65964,30 +66202,30 @@ seZ
 xOw
 szr
 afW
-ixA
-aYY
 asq
+aYY
+fqA
 aBb
 pbc
+aGP
 fqA
-qCx
 lve
-lfq
-gJw
-gJw
-xCO
-srt
-fHF
-srt
-sgQ
-sgQ
-cOR
+qYF
+pkX
+xOP
+aQC
+aQC
+aQC
+aQC
+aQC
 uWk
-aQC
-aQC
-aQC
-aQC
-emh
+emj
+emj
+dhZ
+emj
+emj
+emj
+dQe
 aNh
 ewL
 ewL
@@ -66221,26 +66459,26 @@ fXP
 hqY
 ois
 iHS
-hYR
+ixA
 kVO
+fqA
 tyi
-iag
+aBB
 tyi
-rlV
 nGc
 wtt
 hQO
 pkX
-pkX
+xOP
 aBq
-cyy
-yhg
-git
-ble
-sgQ
-cRz
-uWk
 aQC
+aQC
+aQC
+ceT
+cjl
+cRz
+emj
+dhZ
 dEV
 dRY
 eeR
@@ -66478,26 +66716,26 @@ sgj
 xOw
 jFX
 yif
-ixA
+asq
 aYY
+fqA
 tyi
-iag
+aBB
 tyi
-fhR
 jEX
 uwp
 qYF
-qYF
-qYF
-omp
-iIY
+aVD
+sgQ
+sgQ
 ovr
-cnR
-uex
-nUB
-aTA
-gQr
-aQC
+ovr
+ovr
+sgQ
+sgQ
+sgQ
+cLU
+dia
 dJv
 sgQ
 ovP
@@ -66737,24 +66975,24 @@ vDn
 jkB
 snX
 aYY
-tHH
+fqA
 fOG
+aBH
 tyi
-aBS
-aGP
-bae
+fqA
+lve
 bhP
 xDy
-bhP
+bgP
 htt
-bGD
 rlh
-cnV
+rlh
+rlh
 cuN
-vUt
-cOR
-gQr
-aQC
+sgQ
+csy
+dPm
+dDf
 dPm
 dSP
 ovP
@@ -66990,28 +67228,28 @@ seZ
 seZ
 seZ
 xOw
-szr
-abu
-ixA
+jFX
+ard
+asq
 aYY
+fqA
 tyi
 tyi
-rdI
 vKP
-aJL
-beP
+fqA
+lve
 ble
-mgG
+vwK
 sPU
-bAr
+dRb
 xDx
-mmV
-voc
+xDx
+xDx
 dRb
 jNF
 cVo
-gQr
 aQC
+dDf
 aQC
 dTy
 ovP
@@ -67249,26 +67487,26 @@ fXP
 hqY
 ois
 tha
-hYR
+ixA
 sba
-qqh
+fqA
 evj
 iRo
-vKP
-ipD
-beP
-ble
+aHB
+fqA
+aIU
+aTA
 bql
 cDF
 mLA
 rCn
-jFY
+rCn
 uIU
-dzw
+dRb
 kui
 nyh
-gQr
 aQC
+dDf
 aQC
 dTy
 ovP
@@ -67506,27 +67744,27 @@ sgj
 xOw
 jFX
 que
-ixA
-fqA
-fmE
+asq
+ayA
+oJF
 lBg
 oJF
 xOC
-aLa
+oJF
 oKk
 vaE
-vaE
-vaE
+vwK
+sgQ
 csG
 lgE
-cbh
+lgE
 cqx
-bql
-srt
-cOR
-gQr
-aQC
-aQC
+csG
+sgQ
+ctM
+blu
+dDf
+dqL
 dXd
 ovP
 evh
@@ -67764,25 +68002,25 @@ wuA
 vDn
 iEZ
 nhu
-fqA
 aYY
-qJv
-cfi
-vKP
+fqA
+wuV
 krm
-sgQ
+krm
+krm
 afY
-ble
-ble
-ble
-ble
-ble
-lgE
+afY
+vwK
+lfP
+bkK
+boz
+bwZ
+bSO
 ujh
 jfC
 daA
-gQr
-aQC
+afY
+dDf
 aQC
 dXA
 ovP
@@ -68020,26 +68258,26 @@ seZ
 xOw
 szr
 afW
-ixA
-fqA
+asq
 aYY
-wuV
 fqA
-cnM
-aQw
-sgQ
+wuV
+aBS
+fqA
+fqA
+aQC
 blu
-ble
-ble
-ble
-ble
-ble
-ble
+vwK
+lfP
+blV
+bpV
+bwZ
+bSU
 cxy
 sgQ
-cOR
-gQr
+cvt
 aQC
+dDf
 aQC
 dXM
 ovP
@@ -68277,28 +68515,28 @@ fXP
 hqY
 ois
 agi
-hYR
+ixA
 xdy
-iyA
+fqA
 wuV
 fqA
-dYj
-aTW
-sgQ
-sgQ
+fqA
+fqA
+aQC
+aQC
+aQC
 lfP
-lfP
-lfP
-lfP
-lfP
-lfP
-sgQ
+bom
+bqf
+bxg
+bTe
+cfD
 sgQ
 dcC
-gQr
 aQC
+dDf
 aQC
-dTy
+dFv
 ovP
 evh
 sfa
@@ -68534,27 +68772,27 @@ sgj
 xOw
 jFX
 yiF
-ixA
+asq
 fqA
 fqA
 wuV
 fqA
-ipD
-aVD
-szr
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
+fqA
+fqA
+fqA
+aTK
+aWu
+bkv
+bop
+bsz
+bzt
+bZg
+cgD
 sgQ
 dgo
-dtp
+pkX
 dDf
-bGs
+dtw
 dXO
 ovP
 evh
@@ -68790,29 +69028,29 @@ drb
 tTK
 wuA
 vDn
-jTQ
+ase
 brL
-fqA
-fqA
-wuV
-fqA
 pUF
-bZe
-gmD
-cyj
-xOw
-xOw
-xOw
-xOw
-xOw
+pUF
+aAI
+pUF
+pUF
+pUF
+pUF
+pUF
+aWE
+xMB
+xMB
+bwe
+bBQ
 xMB
 xMB
 xMB
 dgT
 hTs
-dgT
-xMB
-xMB
+dkj
+dtN
+oGG
 ovP
 evh
 sfa
@@ -69045,31 +69283,31 @@ seZ
 seZ
 seZ
 seZ
-xOw
-szr
+agj
+aqr
 ajy
 ouw
-jSL
+yiK
 vmZ
 aQz
-jSL
+vmZ
 yiK
 aYi
-szr
-xOw
-xOw
-xOw
-xOw
-xOw
-xOw
-iHL
+aJL
+aTW
+aZO
+bkF
+xMB
+bwq
+bFc
+xMB
 mpx
 cGn
 diz
 mOJ
 dDF
-cGn
-eaV
+dtN
+oGG
 ovP
 evh
 sfa
@@ -69302,9 +69540,9 @@ xOw
 xOw
 xOw
 xOw
-xOw
-jFX
-nye
+ajb
+szr
+szr
 czj
 kpB
 kpB
@@ -69317,16 +69555,16 @@ sFC
 sFC
 sFC
 sFC
-xOw
-xOw
-iHL
+bwV
+bGO
+xMB
 cyE
 cGG
-cGG
+mOJ
 dwu
-cGG
-cGG
-cGG
+dlk
+dtN
+oGG
 fPS
 evh
 sfa
@@ -69558,8 +69796,8 @@ meC
 meC
 meC
 meC
-meC
-xOw
+aeM
+aju
 czj
 kpB
 vdt
@@ -69574,16 +69812,16 @@ iYV
 faN
 aYo
 sFC
-xOw
-xOw
-iHL
+uWV
+bGR
+xMB
 czs
-cGG
+cjU
 cJQ
-dwu
-cGG
-cGG
-cGG
+cQr
+doD
+duu
+oGG
 ovP
 evh
 sfa
@@ -69831,15 +70069,15 @@ eeg
 iyM
 nHk
 sFC
-xOw
-xOw
-iHL
-cAS
-cGG
-cGG
-dwu
-cGG
-cGG
+uWV
+bGR
+xMB
+xMB
+cjW
+cjW
+xMB
+xMB
+dvK
 eep
 ovP
 evh
@@ -70089,15 +70327,15 @@ wuF
 dcm
 sFC
 uWV
-uWV
+bLf
 xMB
-xMB
+chc
 cID
-cGG
-dwu
-cGG
-cGG
-eeu
+cxT
+cSS
+xMB
+dvK
+oGG
 ovP
 evh
 sfa
@@ -70344,16 +70582,16 @@ sFC
 xdq
 sFC
 sFC
-hQH
+sFC
+ptq
 bMc
-bMc
-xMB
+bZV
 cDo
-cGG
-cGG
-dwu
+cDo
+cxZ
+cWm
 iUf
-cGG
+dwC
 oGG
 ovP
 qVh
@@ -70603,15 +70841,15 @@ wQU
 wXX
 hQH
 cGm
-cGm
-jmr
+bMJ
+xMB
 inY
-inY
-inY
-dwu
 cGG
-cGG
-oGG
+cyy
+cSS
+xMB
+dyf
+dFB
 ovP
 bEh
 sfa
@@ -70861,12 +71099,12 @@ vHS
 hQH
 cGm
 xOI
-chL
-jOa
-cGG
-cGG
-cGG
-cGG
+qSj
+qSj
+qSj
+qSj
+qSj
+qSj
 qSj
 qSj
 qSj
@@ -71118,12 +71356,12 @@ nWh
 lGp
 cGm
 vME
-xMB
+yaU
 btU
-cGG
+cmo
 dje
-dzH
-dEJ
+bLs
+bLs
 qSj
 pnV
 pnV
@@ -71375,12 +71613,12 @@ nWh
 laM
 cGm
 vME
-qSj
-qSj
-qSj
-qSj
-qSj
-qSj
+yaU
+pRO
+pRO
+pRO
+pRO
+pRO
 qSj
 wjY
 pRO
@@ -71633,11 +71871,11 @@ hQH
 cGm
 bGx
 yaU
-eqS
-tOg
-iGu
-bLs
-bLs
+pRO
+pRO
+pRO
+pRO
+pRO
 qSj
 wjY
 fYf
@@ -72407,7 +72645,7 @@ yaU
 veB
 fdu
 uFj
-jSe
+pRO
 syG
 fVk
 fVk
@@ -94949,7 +95187,7 @@ meC
 meC
 meC
 meC
-bZt
+meC
 meC
 meC
 meC
@@ -95229,7 +95467,7 @@ meC
 meC
 meC
 meC
-bZt
+meC
 meC
 meC
 meC

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -403,6 +403,7 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
+<<<<<<< Updated upstream
 "aol" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
@@ -410,6 +411,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+=======
+>>>>>>> Stashed changes
 "aoP" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -443,6 +446,7 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/meeting_room/council)
+<<<<<<< Updated upstream
 "apC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
@@ -455,6 +459,15 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
+=======
+"apG" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+>>>>>>> Stashed changes
 /area/engineering/atmos/upper)
 "apO" = (
 /obj/machinery/duct,
@@ -534,6 +547,7 @@
 	},
 /area/command/heads_quarters/ce)
 "ase" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron,
@@ -545,6 +559,22 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
+=======
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+	},
+/turf/open/floor/engine/co2,
+/area/engineering/atmos/upper)
+"asq" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+	},
+/turf/open/floor/engine/plasma,
+>>>>>>> Stashed changes
 /area/engineering/atmos/upper)
 "ass" = (
 /obj/structure/table/wood,
@@ -571,6 +601,7 @@
 "asz" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
+<<<<<<< Updated upstream
 "ata" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
@@ -578,6 +609,8 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
+=======
+>>>>>>> Stashed changes
 "atq" = (
 /obj/machinery/light/directional/north,
 /obj/structure/tank_dispenser/oxygen,
@@ -723,10 +756,17 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ayA" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 1
+=======
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics Mixing Chamber";
+	name = "Atmos Camera";
+	network = list("ss13","engineering","atmos")
+>>>>>>> Stashed changes
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine/n2o,
 /area/engineering/atmos/upper)
 "ayH" = (
 /obj/structure/cable,
@@ -770,6 +810,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"azs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air to Distro"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "azw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -881,14 +931,21 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "aBB" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 1
+=======
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+>>>>>>> Stashed changes
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/turf/open/space/basic,
+/area/space/nearstation)
 "aBG" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
+<<<<<<< Updated upstream
 /area/engineering/atmos/upper)
 "aBH" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -899,6 +956,15 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
+=======
+/area/engineering/atmos/upper)
+"aBS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+>>>>>>> Stashed changes
 /area/engineering/atmos/upper)
 "aCj" = (
 /obj/structure/table/reinforced,
@@ -984,10 +1050,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
 /area/service/theater)
+<<<<<<< Updated upstream
 "aEu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+=======
+>>>>>>> Stashed changes
 "aEz" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -1065,11 +1134,17 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/mechbay)
 "aGP" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Port to Filter"
+=======
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+>>>>>>> Stashed changes
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "aGY" = (
 /obj/machinery/light/directional/east,
@@ -1167,8 +1242,13 @@
 /area/hallway/secondary/entry)
 "aJL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+<<<<<<< Updated upstream
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
+=======
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+>>>>>>> Stashed changes
 /area/engineering/atmos/upper)
 "aJM" = (
 /obj/structure/sign/departments/science{
@@ -1353,6 +1433,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"aQo" = (
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aQu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -1363,11 +1451,15 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
 "aQw" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
+=======
+/turf/open/floor/iron/dark,
+>>>>>>> Stashed changes
 /area/engineering/atmos/upper)
 "aQz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -1404,10 +1496,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "aSm" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+=======
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/effect/turf_decal/tile/yellow/full,
+>>>>>>> Stashed changes
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aSt" = (
@@ -1475,6 +1572,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aTA" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
@@ -1488,6 +1586,22 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/office)
+=======
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/engineering/atmos/upper)
+"aTW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "aUo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1500,10 +1614,26 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+<<<<<<< Updated upstream
 "aUY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+=======
+"aUS" = (
+/obj/effect/turf_decal/tile/blue/half{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue half"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/command/bridge)
+"aVD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "aVD" = (
@@ -1610,6 +1740,7 @@
 "aZI" = (
 /turf/open/floor/iron/dark/textured,
 /area/medical/virology)
+<<<<<<< Updated upstream
 "aZO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -1623,6 +1754,8 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
+=======
+>>>>>>> Stashed changes
 "bas" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/iron,
@@ -1654,6 +1787,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"bbT" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "bbY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/glass,
@@ -2261,6 +2403,7 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+<<<<<<< Updated upstream
 "bpV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
@@ -2278,6 +2421,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
+=======
+"bql" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+>>>>>>> Stashed changes
 /area/engineering/atmos)
 "bqn" = (
 /obj/machinery/door/window/southleft{
@@ -2412,6 +2565,7 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+<<<<<<< Updated upstream
 "bsz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -2420,6 +2574,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
+=======
+>>>>>>> Stashed changes
 "bsI" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -2535,6 +2691,7 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+<<<<<<< Updated upstream
 "bwZ" = (
 /turf/open/floor/iron/dark/textured_half,
 /area/engineering/atmos)
@@ -2544,6 +2701,16 @@
 	name = "Distro to Waste"
 	},
 /turf/open/floor/iron/dark/textured_half,
+=======
+"bxB" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+>>>>>>> Stashed changes
 /area/engineering/atmos)
 "bxR" = (
 /obj/machinery/computer/station_alert,
@@ -2758,6 +2925,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
+"bEu" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "bEw" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 1
@@ -2830,6 +3004,7 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+<<<<<<< Updated upstream
 "bGO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2840,6 +3015,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
+=======
+>>>>>>> Stashed changes
 "bHo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
@@ -3036,6 +3213,9 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"bPf" = (
+/turf/closed/wall,
+/area/engineering/atmos/office)
 "bPs" = (
 /obj/structure/training_machine,
 /obj/item/target/syndicate,
@@ -3358,6 +3538,18 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+<<<<<<< Updated upstream
+=======
+"bYX" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/ce)
+>>>>>>> Stashed changes
 "bZf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3400,6 +3592,7 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "bZV" = (
+<<<<<<< Updated upstream
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -3410,6 +3603,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
+=======
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/air,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "caa" = (
 /turf/closed/wall/r_wall,
 /area/service/chapel/office)
@@ -3556,7 +3754,11 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
+<<<<<<< Updated upstream
 "ceT" = (
+=======
+"cfy" = (
+>>>>>>> Stashed changes
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -3585,8 +3787,12 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "cfD" = (
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+=======
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+>>>>>>> Stashed changes
 	dir = 9
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -3670,6 +3876,7 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/engineering/atmospherics_engine)
+<<<<<<< Updated upstream
 "chc" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
@@ -3680,11 +3887,13 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
+=======
+>>>>>>> Stashed changes
 "chL" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
+/turf/open/floor/iron/dark/side{
+	dir = 8
 	},
+<<<<<<< Updated upstream
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -3694,6 +3903,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+=======
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "cid" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -3922,16 +4134,25 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "cnM" = (
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+=======
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "cnP" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+<<<<<<< Updated upstream
 "coa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3941,6 +4162,8 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+=======
+>>>>>>> Stashed changes
 "con" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/door/window/westleft{
@@ -4047,12 +4270,22 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "csy" = (
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+=======
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "csA" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
@@ -4251,6 +4484,7 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+<<<<<<< Updated upstream
 "cxT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -4272,6 +4506,14 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
+=======
+"cyy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "cyE" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/closet/radiation,
@@ -4289,6 +4531,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
+"cyV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "czb" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -4370,12 +4618,20 @@
 /turf/open/space/basic,
 /area/maintenance/solars/starboard/aft)
 "cAS" = (
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+=======
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "cAW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/half{
@@ -4585,6 +4841,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/hydroponics)
+"cFQ" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cGm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4848,6 +5109,7 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "cQr" = (
+<<<<<<< Updated upstream
 /obj/machinery/button/door/directional/east{
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Control";
@@ -4859,6 +5121,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/atmos/office)
+=======
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "cQD" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -5082,12 +5349,17 @@
 	name = "Delivery Office";
 	req_one_access_txt = "48;50"
 	},
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/storage)
+=======
+/turf/open/floor/wood,
+/area/commons/vacant_room)
+>>>>>>> Stashed changes
 "cVo" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -6254,6 +6526,7 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "dzH" = (
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -6262,6 +6535,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+=======
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "dzR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6475,11 +6755,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "dEJ" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+=======
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "dET" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -6567,6 +6853,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"dIG" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dIZ" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -6683,11 +6976,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmospherics_engine)
+<<<<<<< Updated upstream
 "dKz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/internals,
 /turf/open/floor/iron/white,
 /area/engineering/atmos)
+=======
+>>>>>>> Stashed changes
 "dLf" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -6897,6 +7193,13 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dQL" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos/office)
 "dRb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -7035,6 +7338,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"dWX" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "dWZ" = (
 /obj/structure/reflector/box/anchored,
 /obj/effect/turf_decal/siding/yellow{
@@ -7179,6 +7488,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/engineering/lobby)
 "eaC" = (
+<<<<<<< Updated upstream
 /obj/machinery/door/airlock/mining/glass{
 	name = "Warehouse";
 	req_access_txt = "31"
@@ -7189,6 +7499,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+=======
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/storage)
+>>>>>>> Stashed changes
 "ebf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -7657,6 +7973,7 @@
 /turf/closed/wall/r_wall,
 /area/service/hydroponics)
 "ely" = (
+<<<<<<< Updated upstream
 /obj/machinery/door/window/eastright{
 	base_state = "left";
 	icon_state = "left";
@@ -7669,6 +7986,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+=======
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
+>>>>>>> Stashed changes
 "elD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7890,6 +8214,16 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+<<<<<<< Updated upstream
+=======
+"eqS" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Filter"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "eqU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -7904,6 +8238,10 @@
 "erd" = (
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"ern" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "erL" = (
 /obj/effect/turf_decal/siding/yellow{
 	color = "#FFD700";
@@ -7935,6 +8273,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"esn" = (
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "esD" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -8017,10 +8379,19 @@
 /turf/open/floor/iron/smooth,
 /area/security/warden)
 "eue" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+=======
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 8;
+	name = "Pure to Port"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "euv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -8033,6 +8404,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
+"euE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "euI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/side,
@@ -9185,8 +9565,15 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "feQ" = (
+<<<<<<< Updated upstream
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/vacuum,
+=======
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+>>>>>>> Stashed changes
 /area/engineering/atmos/upper)
 "feU" = (
 /obj/structure/chair/comfy/brown{
@@ -9270,6 +9657,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+<<<<<<< Updated upstream
+=======
+"fhR" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "fic" = (
 /obj/effect/turf_decal/tile/blue/half{
 	color = "#73c2fb";
@@ -9340,6 +9734,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"fjB" = (
+/obj/structure/table,
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/book/manual/wiki/atmospherics{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "fjG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9890,10 +10308,34 @@
 /turf/open/floor/iron,
 /area/security/brig/upper)
 "fDv" = (
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/cargo/storage)
+=======
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/structure/window{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/commons/vacant_room)
+"fDH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
+"fDI" = (
+/obj/structure/table,
+/turf/open/floor/carpet/orange,
+/area/command/heads_quarters/ce)
+>>>>>>> Stashed changes
 "fDS" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -9985,6 +10427,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+<<<<<<< Updated upstream
+=======
+"fHF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "fHP" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/white,
@@ -10177,6 +10629,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"fOV" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "fPg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10319,6 +10776,17 @@
 /obj/item/laser_pointer/blue,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
+"fRV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast door"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos/office)
 "fRX" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -10806,6 +11274,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/fore)
+<<<<<<< Updated upstream
+=======
+"git" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "giE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11078,6 +11555,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"gpv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "gpF" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/dark,
@@ -11238,6 +11722,11 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/miningdock)
+"grW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gsf" = (
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
@@ -11641,6 +12130,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"gCI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "gCS" = (
 /turf/closed/wall,
 /area/commons/dorms)
@@ -12067,11 +12562,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
+<<<<<<< Updated upstream
 "gSu" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+=======
+"gRO" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/project)
+>>>>>>> Stashed changes
 "gSv" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#FF0000";
@@ -12738,6 +13239,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/dark{
 	dir = 8
 	},
+<<<<<<< Updated upstream
+=======
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
+"htt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/dark{
+	dir = 8
+	},
+>>>>>>> Stashed changes
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
@@ -13267,6 +13777,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
+<<<<<<< Updated upstream
+=======
+"hHa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "hHg" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
@@ -13980,6 +14498,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/genetics)
+<<<<<<< Updated upstream
+=======
+"iag" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "iah" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -14060,6 +14587,24 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
+<<<<<<< Updated upstream
+=======
+"ibO" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "icf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -14555,6 +15100,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+<<<<<<< Updated upstream
+=======
+"ipD" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+>>>>>>> Stashed changes
 "ipK" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -15147,6 +15702,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
+<<<<<<< Updated upstream
+=======
+"iGu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "iGC" = (
 /obj/modular_map_root/solitairestation{
 	dir = 1;
@@ -15205,6 +15770,23 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+<<<<<<< Updated upstream
+=======
+"iHC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/main)
+"iHL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "iHS" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "CO2 Outlet"
@@ -15896,6 +16478,13 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/service/bar)
+"iWK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "iWS" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Canteen"
@@ -16092,6 +16681,7 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "jda" = (
+<<<<<<< Updated upstream
 /obj/machinery/door/window/northright{
 	name = "Incoming Mail";
 	req_one_access_txt = "50"
@@ -16101,6 +16691,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+=======
+/turf/closed/wall,
+/area/security/checkpoint/supply)
+"jdd" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "jdB" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -16358,6 +16957,16 @@
 /obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron,
 /area/security/courtroom)
+<<<<<<< Updated upstream
+=======
+"jmr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "jmW" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16642,6 +17251,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"jxC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "jxX" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
@@ -17093,6 +17708,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"jIP" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "jIW" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/conveyor{
@@ -17234,6 +17858,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+<<<<<<< Updated upstream
+=======
+"jOa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "jOc" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
@@ -17433,6 +18067,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig/upper)
+<<<<<<< Updated upstream
+=======
+"jSe" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "jSm" = (
 /obj/structure/bed,
 /obj/item/toy/plush/bubbleplush,
@@ -17484,6 +18127,11 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/security/warden)
+"jTL" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "jTQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/red/full,
@@ -17681,6 +18329,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
+"jZo" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "jZz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -17707,6 +18362,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jZX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "kah" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/grimy,
@@ -17882,6 +18545,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"kev" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "kew" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -18473,6 +19145,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
+"kwQ" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kwT" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -18593,6 +19272,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/kitchen)
+"kzO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "kzQ" = (
 /obj/machinery/light/directional/north,
 /obj/structure/reagent_dispensers/fueltank,
@@ -18703,6 +19393,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
+"kEl" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast door"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos/office)
 "kEo" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit/green{
@@ -19922,11 +20620,14 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
+<<<<<<< Updated upstream
 "lfP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+=======
+>>>>>>> Stashed changes
 "lgn" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -20667,6 +21368,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"lAU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "lAX" = (
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/iron,
@@ -23022,6 +23729,12 @@
 	dir = 9
 	},
 /area/science/lab)
+"mEi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "mEn" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23058,6 +23771,11 @@
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"mFW" = (
+/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "mFX" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
@@ -23269,6 +23987,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"mKG" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/internals,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "mKI" = (
 /obj/effect/turf_decal/tile/red/half{
 	color = "#FF0000"
@@ -24319,6 +25042,32 @@
 "nlz" = (
 /turf/closed/wall,
 /area/service/hydroponics)
+<<<<<<< Updated upstream
+=======
+"nlF" = (
+/obj/effect/turf_decal/tile/brown/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
+"nlK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
+"nmf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
+>>>>>>> Stashed changes
 "nmS" = (
 /obj/machinery/telecomms/bus/preset_one,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -24630,6 +25379,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"nvy" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "nvA" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -24847,6 +25603,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"nzt" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/multitool,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nzx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -25295,6 +26063,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"nOR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nPE" = (
 /obj/machinery/computer/department_orders/service{
 	dir = 4
@@ -25304,6 +26078,12 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"nQc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "nQg" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/tile/purple/half{
@@ -25487,6 +26267,24 @@
 /obj/structure/chair,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+"nUr" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "nUu" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25494,6 +26292,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/medical/medbay/lobby)
+<<<<<<< Updated upstream
+=======
+"nUB" = (
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
+"nVG" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/door_timer{
+	id = "cargocell";
+	name = "Cargo Cell";
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
+>>>>>>> Stashed changes
 "nVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/glass,
@@ -25653,6 +26469,16 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"nZD" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "nZY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25954,6 +26780,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+<<<<<<< Updated upstream
+=======
+"oiE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/office)
+>>>>>>> Stashed changes
 "oiI" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /turf/open/floor/iron,
@@ -26045,6 +26878,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/security/courtroom)
+<<<<<<< Updated upstream
+=======
+"omp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "omD" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -27221,7 +28063,18 @@
 	name = "Dear Ian 2"
 	},
 /turf/open/floor/plating/elevatorshaft,
+<<<<<<< Updated upstream
 /area/maintenance/department/crew_quarters/dorms)
+=======
+/area/maintenance/department/security)
+"oSm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
+>>>>>>> Stashed changes
 "oSr" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
@@ -27476,6 +28329,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/security)
+"oZE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
 "oZL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27822,6 +28681,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"pke" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -28128,6 +28995,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"pvL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "pwb" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -29174,7 +30047,22 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
+<<<<<<< Updated upstream
 /area/hallway/primary/central/fore)
+=======
+/area/security/checkpoint/supply)
+"qhb" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
+"qhe" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/bridge)
+>>>>>>> Stashed changes
 "qhj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29263,6 +30151,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/security/lockers)
+"qju" = (
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
 "qkn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -29277,11 +30172,21 @@
 /obj/item/toy/figure/geneticist,
 /turf/open/floor/grass,
 /area/science/genetics)
+<<<<<<< Updated upstream
 "qkW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
+=======
+"qld" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "qln" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	color = "#FF6700";
@@ -29400,6 +30305,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
+"qoO" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "qoR" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -29753,6 +30668,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+<<<<<<< Updated upstream
+=======
+"qCx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "qCy" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
@@ -29871,9 +30796,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/prison)
-"qEC" = (
-/turf/closed/wall/r_wall,
-/area/engineering/atmos/project)
 "qET" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -30096,7 +31018,11 @@
 /obj/structure/table,
 /obj/item/crowbar,
 /turf/open/floor/plating,
+<<<<<<< Updated upstream
 /area/maintenance/starboard/fore)
+=======
+/area/engineering/atmos/project)
+>>>>>>> Stashed changes
 "qIV" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -30136,6 +31062,16 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+<<<<<<< Updated upstream
+=======
+"qJv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "qJQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30694,7 +31630,17 @@
 	name = "security red"
 	},
 /turf/open/floor/iron,
+<<<<<<< Updated upstream
 /area/security/checkpoint)
+=======
+/area/security/checkpoint/customs)
+"rdI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "rdU" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
@@ -30811,6 +31757,14 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/service/library/private)
+"rhh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "rho" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -30884,6 +31838,16 @@
 /obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/iron/dark/textured_large,
 /area/medical/virology)
+"rka" = (
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "rkj" = (
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
@@ -30950,6 +31914,15 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+<<<<<<< Updated upstream
+=======
+"rlV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
+>>>>>>> Stashed changes
 "rms" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -31380,6 +32353,19 @@
 "ryF" = (
 /turf/open/floor/iron/smooth_large,
 /area/engineering/atmospherics_engine)
+<<<<<<< Updated upstream
+=======
+"ryJ" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Cargo";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/checkpoint/supply)
+>>>>>>> Stashed changes
 "ryT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -31525,6 +32511,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "rCr" = (
+<<<<<<< Updated upstream
 /obj/structure/chair/comfy/brown{
 	color = "#EFB341";
 	dir = 1
@@ -31535,6 +32522,18 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/carpet/royalblack,
 /area/command/heads_quarters/ce)
+=======
+/obj/structure/closet/wardrobe/miner,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
+"rCH" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "rCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31788,6 +32787,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"rIL" = (
+/obj/machinery/atmospherics/components/unary/bluespace_sender,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "rIN" = (
 /obj/machinery/duct,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -32289,6 +33293,13 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/commons/fitness/recreation)
+"rUD" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Distro to Waste"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos)
 "rUE" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/white/line{
@@ -33218,6 +34229,19 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+<<<<<<< Updated upstream
+=======
+"srt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/engineering/atmos/office)
+>>>>>>> Stashed changes
 "srF" = (
 /obj/structure/chair/comfy/black{
 	dir = 1;
@@ -33882,6 +34906,7 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "sNp" = (
+<<<<<<< Updated upstream
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	freq = 1400;
@@ -33899,6 +34924,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+=======
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stamp,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/cargo/sorting)
+"sNE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+>>>>>>> Stashed changes
 "sNV" = (
 /obj/machinery/door/airlock/external/glass{
 	req_access_txt = "31"
@@ -34200,6 +35240,9 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"sVS" = (
+/turf/open/floor/iron/dark/textured_half,
+/area/engineering/atmos)
 "sVY" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34952,7 +35995,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/engineering/atmos/project)
+/area/engineering/atmospherics_engine)
 "trU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -35508,6 +36551,20 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig/upper)
+"tDV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "tEe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35553,6 +36610,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+<<<<<<< Updated upstream
+=======
+"tEw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/office)
+>>>>>>> Stashed changes
 "tEJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/ai_all,
@@ -35579,6 +36647,11 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"tFS" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
 "tFZ" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -35610,6 +36683,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+<<<<<<< Updated upstream
+=======
+"tHH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
+>>>>>>> Stashed changes
 "tHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -35804,6 +36885,17 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+<<<<<<< Updated upstream
+=======
+"tOg" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "tOH" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -36067,6 +37159,12 @@
 	dir = 8
 	},
 /area/engineering/gravity_generator)
+"tUv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tUw" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -36553,6 +37651,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+<<<<<<< Updated upstream
+=======
+"uex" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "ueI" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/pew/right,
@@ -36631,6 +37736,14 @@
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"ugM" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "ugO" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -37298,6 +38411,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"usY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "usZ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -37430,6 +38550,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"uvR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/main)
 "uwg" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -37748,6 +38872,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"uEo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "uEK" = (
 /obj/effect/turf_decal/tile/purple/half{
 	color = "#4D0067";
@@ -38159,6 +39289,16 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/textured_large,
 /area/security/brig)
+"uNa" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/iron,
+/area/engineering/storage)
 "uNs" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 8
@@ -38188,6 +39328,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"uNM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "uNR" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
@@ -38316,6 +39465,17 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
+<<<<<<< Updated upstream
+=======
+"uPz" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "uPT" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Court Room";
@@ -38391,7 +39551,21 @@
 	},
 /obj/effect/turf_decal/tile/brown/half,
 /turf/open/floor/iron,
+<<<<<<< Updated upstream
 /area/cargo/qm)
+=======
+/area/cargo/sorting)
+"uRo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "uRu" = (
 /obj/structure/cable,
 /turf/open/floor/iron/chapel{
@@ -38961,6 +40135,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/science/explab)
+"vey" = (
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "veB" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -39445,6 +40625,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/service/janitor)
+"vrb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vrc" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/sunglasses{
@@ -39825,6 +41012,7 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "vxF" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 8
 	},
@@ -39832,6 +41020,12 @@
 	dir = 8
 	},
 /area/engineering/atmos/upper)
+=======
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "vxR" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -39971,6 +41165,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"vAS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "vAT" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
@@ -40687,6 +41890,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+<<<<<<< Updated upstream
+=======
+"vUt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/plating,
+/area/engineering/atmos/office)
+>>>>>>> Stashed changes
 "vUy" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -40741,6 +41953,13 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"vUW" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
 "vVv" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
@@ -42715,6 +43934,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"wPd" = (
+/obj/machinery/button/door/directional/east{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Control";
+	pixel_y = 8;
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
 "wPh" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/east{
@@ -42811,6 +44042,7 @@
 /turf/open/floor/stone,
 /area/command/heads_quarters/hos)
 "wSd" = (
+<<<<<<< Updated upstream
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -42826,6 +44058,16 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+=======
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "wSe" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 1
@@ -42849,6 +44091,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/service/abandoned_gambling_den)
+"wSF" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "wSK" = (
 /obj/item/stack/sheet/animalhide/corgi,
 /obj/item/bedsheet/ian,
@@ -44005,15 +45254,34 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/research)
+<<<<<<< Updated upstream
+=======
+"xCO" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white,
+/area/engineering/atmos/upper)
+>>>>>>> Stashed changes
 "xDx" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/atmos)
 "xDy" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
+=======
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Mix 1 to Filter"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+>>>>>>> Stashed changes
 /area/engineering/atmos)
 "xDI" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -44055,6 +45323,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
+<<<<<<< Updated upstream
+=======
+"xFa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard)
+>>>>>>> Stashed changes
 "xFv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -44090,6 +45367,18 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/security/brig/upper)
+<<<<<<< Updated upstream
+=======
+"xGt" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "xGI" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
@@ -45113,6 +46402,21 @@
 /obj/item/toy/figure/cargotech,
 /turf/open/floor/iron,
 /area/cargo/office)
+"yci" = (
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/iron/white,
+/area/engineering/atmos)
 "ycF" = (
 /obj/effect/spawner/random/clothing/bowler_or_that,
 /turf/open/floor/plating,
@@ -45284,6 +46588,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
+"ygN" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/office)
 "ygP" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet,
@@ -45299,6 +46609,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/commons/dorms)
+<<<<<<< Updated upstream
+=======
+"yhg" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Waste to Filter"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos/office)
+>>>>>>> Stashed changes
 "yhr" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /obj/machinery/disposal/bin,
@@ -45450,10 +46773,19 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "yki" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/black,
 /area/service/chapel)
+=======
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/engineering/atmos)
+>>>>>>> Stashed changes
 "yko" = (
 /obj/effect/turf_decal/siding/brown{
 	color = "#FF6700";
@@ -61072,7 +62404,11 @@ ukN
 uKs
 uhe
 wLt
+<<<<<<< Updated upstream
 baj
+=======
+tHH
+>>>>>>> Stashed changes
 xFT
 qpH
 tTm
@@ -62106,7 +63442,11 @@ xOw
 tDj
 tDj
 tDj
+<<<<<<< Updated upstream
 chL
+=======
+trM
+>>>>>>> Stashed changes
 ebr
 cIm
 kYu
@@ -62863,11 +64203,19 @@ meC
 meC
 xOw
 seZ
+<<<<<<< Updated upstream
 soN
 tHX
 shd
 seZ
 feQ
+=======
+bZV
+tHX
+shd
+seZ
+fhR
+>>>>>>> Stashed changes
 uNY
 njL
 seZ
@@ -63383,7 +64731,11 @@ tWV
 seZ
 aZl
 sgj
+<<<<<<< Updated upstream
 aMq
+=======
+iag
+>>>>>>> Stashed changes
 seZ
 xOw
 meC
@@ -63640,7 +64992,11 @@ tYq
 xOw
 aFp
 xOw
+<<<<<<< Updated upstream
 aNm
+=======
+ipD
+>>>>>>> Stashed changes
 xOw
 xOw
 xOw
@@ -63897,7 +65253,11 @@ wZg
 szr
 rLO
 jFX
+<<<<<<< Updated upstream
 aQw
+=======
+iGu
+>>>>>>> Stashed changes
 szr
 szr
 xOw
@@ -64144,10 +65504,17 @@ seZ
 seZ
 seZ
 xOw
+<<<<<<< Updated upstream
 aol
 aaB
 amG
 ata
+=======
+aBS
+aaB
+amG
+aTW
+>>>>>>> Stashed changes
 uPd
 eSp
 cvs
@@ -64161,8 +65528,13 @@ sgQ
 sgQ
 sgQ
 sgQ
+<<<<<<< Updated upstream
 qEC
 trM
+=======
+gRO
+qIQ
+>>>>>>> Stashed changes
 ebr
 ebr
 ebr
@@ -64401,6 +65773,7 @@ qWC
 rVo
 fXP
 jrY
+<<<<<<< Updated upstream
 apC
 nku
 pkG
@@ -64414,6 +65787,21 @@ ayS
 hYb
 boJ
 bbm
+=======
+aGP
+nku
+pkG
+aSz
+apG
+chL
+uji
+chL
+fKw
+chL
+hYb
+boJ
+tOg
+>>>>>>> Stashed changes
 kxB
 uhh
 rBG
@@ -64422,10 +65810,17 @@ ckp
 ihJ
 cLM
 dqa
+<<<<<<< Updated upstream
 cYB
 doU
 doU
 dFV
+=======
+fOV
+mFW
+mFW
+rIL
+>>>>>>> Stashed changes
 efq
 emQ
 ebr
@@ -64663,7 +66058,11 @@ aCq
 pLB
 lEm
 sWD
+<<<<<<< Updated upstream
 aAz
+=======
+cnM
+>>>>>>> Stashed changes
 sWD
 xmr
 uiU
@@ -64677,12 +66076,21 @@ vwK
 vwK
 vwK
 gQr
+<<<<<<< Updated upstream
 cnx
 cAS
 dad
 dpc
 dzH
 dGq
+=======
+nlK
+usY
+rhh
+iWK
+kev
+jxC
+>>>>>>> Stashed changes
 egF
 aNh
 ebr
@@ -64921,18 +66329,27 @@ dJq
 aYY
 ppH
 qqh
+<<<<<<< Updated upstream
 aAS
+=======
+cyy
+>>>>>>> Stashed changes
 vAD
 vAD
 aVY
 vvT
+<<<<<<< Updated upstream
 aUY
+=======
+omp
+>>>>>>> Stashed changes
 xOP
 psH
 aQC
 aQC
 aQC
 aQC
+<<<<<<< Updated upstream
 ciy
 cnM
 cDQ
@@ -64940,6 +66357,15 @@ ddS
 cDQ
 cDQ
 cDQ
+=======
+kwQ
+wSF
+cyV
+pke
+cyV
+cyV
+cyV
+>>>>>>> Stashed changes
 ejy
 aNh
 end
@@ -65172,7 +66598,11 @@ seZ
 seZ
 seZ
 xOw
+<<<<<<< Updated upstream
 aol
+=======
+aBS
+>>>>>>> Stashed changes
 abu
 ixA
 kVO
@@ -65181,9 +66611,15 @@ qqh
 fqA
 krm
 krm
+<<<<<<< Updated upstream
 aIy
 aSm
 aUY
+=======
+fHF
+iHL
+omp
+>>>>>>> Stashed changes
 xOP
 aQC
 aQC
@@ -65193,10 +66629,17 @@ aQC
 uWk
 tff
 bTC
+<<<<<<< Updated upstream
 dem
 dpn
 dpn
 dKz
+=======
+jZo
+qhb
+qhb
+mKG
+>>>>>>> Stashed changes
 ejZ
 aNh
 eoC
@@ -65429,17 +66872,29 @@ rav
 sCL
 fXP
 hqY
+<<<<<<< Updated upstream
 apC
 seR
 dAO
 ugB
 apG
+=======
+aGP
+seR
+dAO
+ugB
+cfD
+>>>>>>> Stashed changes
 qqh
 xka
 krm
 fqA
 ppH
+<<<<<<< Updated upstream
 aTf
+=======
+jmr
+>>>>>>> Stashed changes
 wjx
 xOP
 aQC
@@ -65450,10 +66905,17 @@ aQC
 uWk
 tff
 bXM
+<<<<<<< Updated upstream
 deZ
 dqJ
 dAu
 dLW
+=======
+nUr
+yci
+esn
+fjB
+>>>>>>> Stashed changes
 elD
 aNh
 mNS
@@ -65688,7 +67150,11 @@ sgj
 xOw
 jFX
 mxI
+<<<<<<< Updated upstream
 asq
+=======
+aTA
+>>>>>>> Stashed changes
 aYY
 fqA
 iyA
@@ -65705,12 +67171,21 @@ aQC
 aQC
 aQC
 uWk
+<<<<<<< Updated upstream
 coa
 cIs
 dfi
 cIs
 cIs
 cIs
+=======
+euE
+uNM
+uRo
+uNM
+uNM
+uNM
+>>>>>>> Stashed changes
 ema
 tFZ
 rTt
@@ -65950,23 +67425,40 @@ aYY
 fqA
 tyi
 xWV
+<<<<<<< Updated upstream
 aEu
+=======
+dEJ
+>>>>>>> Stashed changes
 fqA
 ppH
 vvT
 wjx
 xOP
+<<<<<<< Updated upstream
+aQC
+=======
+>>>>>>> Stashed changes
 aQC
 aQC
 aQC
 aQC
-aQC
+<<<<<<< Updated upstream
 uWk
 emj
 cJa
 dhZ
 emj
 dEJ
+=======
+aQC
+uWk
+emj
+ern
+uEo
+emj
+mEi
+>>>>>>> Stashed changes
 emj
 emj
 aNh
@@ -66202,22 +67694,34 @@ seZ
 xOw
 szr
 afW
+<<<<<<< Updated upstream
 asq
+=======
+aTA
+>>>>>>> Stashed changes
 aYY
 fqA
 aBb
 pbc
+<<<<<<< Updated upstream
 aGP
+=======
+eqS
+>>>>>>> Stashed changes
 fqA
 lve
 qYF
 pkX
 xOP
+<<<<<<< Updated upstream
+aQC
+=======
+>>>>>>> Stashed changes
 aQC
 aQC
 aQC
 aQC
-aQC
+<<<<<<< Updated upstream
 uWk
 emj
 emj
@@ -66226,6 +67730,17 @@ emj
 emj
 emj
 dQe
+=======
+aQC
+uWk
+emj
+emj
+uEo
+emj
+emj
+emj
+vey
+>>>>>>> Stashed changes
 aNh
 ewL
 ewL
@@ -66453,7 +67968,11 @@ meC
 xOw
 seZ
 qnG
+<<<<<<< Updated upstream
 rgW
+=======
+ase
+>>>>>>> Stashed changes
 sUf
 fXP
 hqY
@@ -66463,7 +67982,11 @@ ixA
 kVO
 fqA
 tyi
+<<<<<<< Updated upstream
 aBB
+=======
+cAS
+>>>>>>> Stashed changes
 tyi
 nGc
 wtt
@@ -66474,11 +67997,19 @@ aBq
 aQC
 aQC
 aQC
+<<<<<<< Updated upstream
 ceT
 cjl
 cRz
 emj
 dhZ
+=======
+cfy
+cFQ
+cRz
+emj
+uEo
+>>>>>>> Stashed changes
 dEV
 dRY
 eeR
@@ -66716,16 +68247,28 @@ sgj
 xOw
 jFX
 yif
+<<<<<<< Updated upstream
 asq
 aYY
 fqA
 tyi
 aBB
+=======
+aTA
+aYY
+fqA
+tyi
+cAS
+>>>>>>> Stashed changes
 tyi
 jEX
 uwp
 qYF
+<<<<<<< Updated upstream
 aVD
+=======
+qCx
+>>>>>>> Stashed changes
 sgQ
 sgQ
 ovr
@@ -66734,8 +68277,13 @@ ovr
 sgQ
 sgQ
 sgQ
+<<<<<<< Updated upstream
 cLU
 dia
+=======
+grW
+ibO
+>>>>>>> Stashed changes
 dJv
 sgQ
 ovP
@@ -66977,20 +68525,33 @@ snX
 aYY
 fqA
 fOG
+<<<<<<< Updated upstream
 aBH
+=======
+cQr
+>>>>>>> Stashed changes
 tyi
 fqA
 lve
 bhP
+<<<<<<< Updated upstream
 xDy
 bgP
+=======
+qJv
+uex
+>>>>>>> Stashed changes
 htt
 rlh
 rlh
 rlh
 cuN
 sgQ
+<<<<<<< Updated upstream
 csy
+=======
+vrb
+>>>>>>> Stashed changes
 dPm
 dDf
 dPm
@@ -67229,8 +68790,13 @@ seZ
 seZ
 xOw
 jFX
+<<<<<<< Updated upstream
 ard
 asq
+=======
+aQw
+aTA
+>>>>>>> Stashed changes
 aYY
 fqA
 tyi
@@ -67240,7 +68806,11 @@ fqA
 lve
 ble
 vwK
+<<<<<<< Updated upstream
 sPU
+=======
+uPz
+>>>>>>> Stashed changes
 dRb
 xDx
 xDx
@@ -67481,7 +69051,11 @@ meC
 xOw
 seZ
 qvn
+<<<<<<< Updated upstream
 roC
+=======
+asq
+>>>>>>> Stashed changes
 yhd
 fXP
 hqY
@@ -67492,11 +69066,19 @@ sba
 fqA
 evj
 iRo
+<<<<<<< Updated upstream
 aHB
 fqA
 aIU
 aTA
 bql
+=======
+eue
+fqA
+git
+jOa
+rdI
+>>>>>>> Stashed changes
 cDF
 mLA
 rCn
@@ -67744,6 +69326,7 @@ sgj
 xOw
 jFX
 que
+<<<<<<< Updated upstream
 asq
 ayA
 oJF
@@ -67765,6 +69348,29 @@ ctM
 blu
 dDf
 dqL
+=======
+aTA
+aVD
+oJF
+lBg
+oJF
+feQ
+oJF
+oKk
+jSe
+vwK
+sgQ
+bql
+lgE
+lgE
+cqx
+bql
+sgQ
+rCH
+blu
+dDf
+tUv
+>>>>>>> Stashed changes
 dXd
 ovP
 evh
@@ -68011,11 +69617,19 @@ krm
 afY
 afY
 vwK
+<<<<<<< Updated upstream
 lfP
 bkK
 boz
 bwZ
 bSO
+=======
+vxF
+wSd
+bxB
+sVS
+jIP
+>>>>>>> Stashed changes
 ujh
 jfC
 daA
@@ -68258,16 +69872,25 @@ seZ
 xOw
 szr
 afW
+<<<<<<< Updated upstream
 asq
 aYY
 fqA
 wuV
 aBS
+=======
+aTA
+aYY
+fqA
+wuV
+dzH
+>>>>>>> Stashed changes
 fqA
 fqA
 aQC
 blu
 vwK
+<<<<<<< Updated upstream
 lfP
 blV
 bpV
@@ -68276,6 +69899,16 @@ bSU
 cxy
 sgQ
 cvt
+=======
+vxF
+xDy
+yki
+sVS
+azs
+cxy
+sgQ
+nzt
+>>>>>>> Stashed changes
 aQC
 dDf
 aQC
@@ -68509,7 +70142,11 @@ meC
 xOw
 seZ
 qID
+<<<<<<< Updated upstream
 rFL
+=======
+ayA
+>>>>>>> Stashed changes
 lfv
 fXP
 hqY
@@ -68525,18 +70162,31 @@ fqA
 aQC
 aQC
 aQC
+<<<<<<< Updated upstream
 lfP
 bom
 bqf
 bxg
 bTe
 cfD
+=======
+vxF
+xGt
+jdd
+rUD
+qld
+vUW
+>>>>>>> Stashed changes
 sgQ
 dcC
 aQC
 dDf
 aQC
+<<<<<<< Updated upstream
 dFv
+=======
+aQo
+>>>>>>> Stashed changes
 ovP
 evh
 sfa
@@ -68772,7 +70422,11 @@ sgj
 xOw
 jFX
 yiF
+<<<<<<< Updated upstream
 asq
+=======
+aTA
+>>>>>>> Stashed changes
 fqA
 fqA
 wuV
@@ -68780,6 +70434,7 @@ fqA
 fqA
 fqA
 fqA
+<<<<<<< Updated upstream
 aTK
 aWu
 bkv
@@ -68788,11 +70443,25 @@ bsz
 bzt
 bZg
 cgD
+=======
+nUB
+rlV
+vUt
+yhg
+ugM
+dQL
+nZD
+nQc
+>>>>>>> Stashed changes
 sgQ
 dgo
 pkX
 dDf
+<<<<<<< Updated upstream
 dtw
+=======
+nOR
+>>>>>>> Stashed changes
 dXO
 ovP
 evh
@@ -69028,28 +70697,49 @@ drb
 tTK
 wuA
 vDn
+<<<<<<< Updated upstream
 ase
 brL
 pUF
 pUF
 aAI
+=======
+aSm
+brL
+pUF
+pUF
+csy
+>>>>>>> Stashed changes
 pUF
 pUF
 pUF
 pUF
 pUF
+<<<<<<< Updated upstream
 aWE
 xMB
 xMB
 bwe
 bBQ
+=======
+srt
+xMB
+xMB
+jZX
+tFS
+>>>>>>> Stashed changes
 xMB
 xMB
 xMB
 dgT
 hTs
+<<<<<<< Updated upstream
 dkj
 dtN
+=======
+bPf
+gCI
+>>>>>>> Stashed changes
 oGG
 ovP
 evh
@@ -69283,8 +70973,13 @@ seZ
 seZ
 seZ
 seZ
+<<<<<<< Updated upstream
 agj
 aqr
+=======
+aBB
+aJL
+>>>>>>> Stashed changes
 ajy
 ouw
 yiK
@@ -69293,6 +70988,7 @@ aQz
 vmZ
 yiK
 aYi
+<<<<<<< Updated upstream
 aJL
 aTW
 aZO
@@ -69300,13 +70996,26 @@ bkF
 xMB
 bwq
 bFc
+=======
+hHa
+oiE
+tEw
+xCO
+xMB
+sNE
+dIG
+>>>>>>> Stashed changes
 xMB
 mpx
 cGn
 diz
 mOJ
 dDF
+<<<<<<< Updated upstream
 dtN
+=======
+gCI
+>>>>>>> Stashed changes
 oGG
 ovP
 evh
@@ -69555,15 +71264,25 @@ sFC
 sFC
 sFC
 sFC
+<<<<<<< Updated upstream
 bwV
 bGO
+=======
+qju
+oZE
+>>>>>>> Stashed changes
 xMB
 cyE
 cGG
 mOJ
 dwu
+<<<<<<< Updated upstream
 dlk
 dtN
+=======
+nvy
+gCI
+>>>>>>> Stashed changes
 oGG
 fPS
 evh
@@ -69813,6 +71532,7 @@ faN
 aYo
 sFC
 uWV
+<<<<<<< Updated upstream
 bGR
 xMB
 czs
@@ -69821,6 +71541,16 @@ cJQ
 cQr
 doD
 duu
+=======
+uvR
+xMB
+czs
+dWX
+cJQ
+wPd
+qoO
+fDH
+>>>>>>> Stashed changes
 oGG
 ovP
 evh
@@ -70070,6 +71800,7 @@ iyM
 nHk
 sFC
 uWV
+<<<<<<< Updated upstream
 bGR
 xMB
 xMB
@@ -70078,6 +71809,16 @@ cjW
 xMB
 xMB
 dvK
+=======
+uvR
+xMB
+xMB
+bbT
+bbT
+xMB
+xMB
+vAS
+>>>>>>> Stashed changes
 eep
 ovP
 evh
@@ -70327,6 +72068,7 @@ wuF
 dcm
 sFC
 uWV
+<<<<<<< Updated upstream
 bLf
 xMB
 chc
@@ -70335,6 +72077,16 @@ cxT
 cSS
 xMB
 dvK
+=======
+jTL
+xMB
+rka
+cID
+bEu
+kEl
+xMB
+vAS
+>>>>>>> Stashed changes
 oGG
 ovP
 evh
@@ -70582,6 +72334,7 @@ sFC
 xdq
 sFC
 sFC
+<<<<<<< Updated upstream
 sFC
 ptq
 bMc
@@ -70592,6 +72345,18 @@ cxZ
 cWm
 iUf
 dwC
+=======
+hQH
+ptq
+bMc
+kzO
+cDo
+cDo
+oSm
+fRV
+iUf
+tDV
+>>>>>>> Stashed changes
 oGG
 ovP
 qVh
@@ -70841,6 +72606,7 @@ wQU
 wXX
 hQH
 cGm
+<<<<<<< Updated upstream
 bMJ
 xMB
 inY
@@ -70850,6 +72616,17 @@ cSS
 xMB
 dyf
 dFB
+=======
+pvL
+xMB
+inY
+cGG
+gpv
+kEl
+xMB
+lAU
+ygN
+>>>>>>> Stashed changes
 ovP
 bEh
 sfa
@@ -71358,7 +73135,11 @@ cGm
 vME
 yaU
 btU
+<<<<<<< Updated upstream
 cmo
+=======
+uNa
+>>>>>>> Stashed changes
 dje
 bLs
 bLs


### PR DESCRIPTION
Overhaul atmosphere room's piping and stuff. **The pipenet is mostly the same as the old one** (Different pipes are connected the same way as they were), but in cleaner layout, I think. Yeah.

![New Atmos](https://user-images.githubusercontent.com/64306407/157261735-06d592ca-040b-4523-a06b-ae8c20a56b51.png)

Sidenote:
Engine storage is a bit bigger now but that's not important.
Re-area HFR room from atmos to atmos engine 

I might miss something because I was in a hurry.