### PR TITLE
Fixes command issues, updates ordnance equipment and updates wrong medkit/powercell's paths.

### DIFF
--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -383,7 +383,7 @@
 "aoP" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -1279,7 +1279,7 @@
 /area/command/heads_quarters/ce)
 "aQe" = (
 /obj/structure/rack,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "aQu" = (
@@ -2055,8 +2055,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "ai-exterior"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -3354,7 +3354,7 @@
 "cgw" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/machinery/camera/directional/south{
 	c_tag = "Virology - West";
@@ -11977,10 +11977,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "bridge-entrance"
-	},
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/command/bridge)
 "gZy" = (
@@ -13454,7 +13452,7 @@
 /area/engineering/storage/tcomms)
 "hQJ" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /obj/machinery/requests_console/directional/north{
 	department = "Holodeck";
 	name = "Holodeck Requests Console"
@@ -13511,6 +13509,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
 /area/service/abandoned_gambling_den)
+"hSg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/command/gateway)
 "hSi" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -14306,17 +14309,17 @@
 /area/science/misc_lab)
 "imP" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/brute{
+/obj/item/storage/medkit/brute{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid/brute,
+/obj/item/storage/medkit/brute,
 /obj/machinery/door/window/northleft{
 	name = "First-Aid Supplies";
 	red_alert_access = 1;
 	req_access_txt = "5"
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = -3;
 	pixel_y = -3
 	},
@@ -15043,6 +15046,21 @@
 /obj/machinery/photocopier,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
+"iFQ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge Access";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/command/bridge)
 "iFT" = (
 /obj/machinery/computer/communications{
 	dir = 4
@@ -15293,15 +15311,15 @@
 	name = "research purple"
 	},
 /obj/structure/table,
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	empty = 1;
 	name = "First-Aid (empty)"
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	empty = 1;
 	name = "First-Aid (empty)"
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	empty = 1;
 	name = "First-Aid (empty)"
 	},
@@ -16001,7 +16019,7 @@
 	dir = 4;
 	name = "research purple"
 	},
-/obj/item/storage/firstaid/toxin{
+/obj/item/storage/medkit/toxin{
 	name = "ordnance treatment kit"
 	},
 /turf/open/floor/iron/white,
@@ -16265,8 +16283,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "ai-exterior"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/iron/smooth,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -17017,11 +17035,11 @@
 	name = "Command blue corner"
 	},
 /obj/structure/table,
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = 4;
 	pixel_y = 5
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = -4;
 	pixel_y = -2
 	},
@@ -19044,15 +19062,15 @@
 	color = "#FF0000";
 	dir = 8
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid/toxin{
+/obj/item/storage/medkit/toxin{
 	pixel_x = -4
 	},
 /turf/open/floor/iron/white,
@@ -19733,7 +19751,7 @@
 "kYZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high,
 /obj/machinery/light/directional/east,
 /obj/item/wallframe/camera{
 	pixel_y = 9
@@ -20124,7 +20142,7 @@
 "lho" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
 	dir = 4;
@@ -22532,14 +22550,11 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "mlS" = (
-/obj/effect/turf_decal/siding/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "command blue"
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
+/area/hallway/secondary/command)
 "mmb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -22588,7 +22603,7 @@
 "mmP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
 	dir = 6;
@@ -22835,7 +22850,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "muF" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/red/anticorner{
 	color = "#FF0000";
 	dir = 1
@@ -23509,7 +23524,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
@@ -23577,7 +23592,7 @@
 /area/maintenance/starboard)
 "mKq" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/blue/anticorner{
 	color = "#4169E1";
 	name = "Command blue corner"
@@ -25203,18 +25218,18 @@
 /area/security/checkpoint/customs)
 "nyv" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/toxin{
+/obj/item/storage/medkit/toxin{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid/toxin,
+/obj/item/storage/medkit/toxin,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = -3;
 	pixel_y = -3
 	},
@@ -26356,7 +26371,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "ofs" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
@@ -27492,7 +27507,7 @@
 /turf/closed/wall,
 /area/engineering/storage/tech)
 "oHJ" = (
-/obj/machinery/doppler_array/research/science{
+/obj/machinery/doppler_array{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -29857,7 +29872,7 @@
 /area/medical/pharmacy)
 "qgi" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /obj/item/healthanalyzer,
 /obj/effect/turf_decal/siding/blue{
 	color = "#73c2fb";
@@ -30887,11 +30902,11 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "qII" = (
@@ -32374,7 +32389,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "rBC" = (
-/obj/structure/bed/dogbed/ian,
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /turf/open/floor/carpet,
@@ -38050,7 +38064,7 @@
 "umc" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/east,
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/smooth_large,
 /area/command/meeting_room/council)
 "umh" = (
@@ -39733,7 +39747,6 @@
 	dir = 8;
 	name = "command blue"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "uSy" = (
@@ -42070,7 +42083,7 @@
 /turf/open/floor/iron,
 /area/security/range)
 "vSo" = (
-/obj/machinery/research/explosive_compressor,
+/obj/machinery/atmospherics/components/binary/tank_compressor,
 /turf/open/floor/iron,
 /area/science/mixing)
 "vSJ" = (
@@ -42919,9 +42932,6 @@
 	dir = 8;
 	name = "Command blue half"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	id = "teleporterhubshutters";
 	name = "Teleporter Shutters";
@@ -44581,11 +44591,11 @@
 /area/science/genetics)
 "wWw" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/o2{
+/obj/item/storage/medkit/o2{
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/item/storage/firstaid/o2,
+/obj/item/storage/medkit/o2,
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "First-Aid Supplies";
@@ -44598,7 +44608,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = -3;
 	pixel_y = -3
 	},
@@ -45575,18 +45585,18 @@
 /area/engineering/storage/tech)
 "xxE" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/fire{
+/obj/item/storage/medkit/fire{
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/item/storage/firstaid/fire,
+/obj/item/storage/medkit/fire,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/storage/firstaid/regular{
+/obj/item/storage/medkit/regular{
 	pixel_x = -3;
 	pixel_y = -3
 	},
@@ -86083,7 +86093,7 @@ xLb
 xLb
 ycI
 eKZ
-xyU
+vwp
 vUK
 vwp
 pXe
@@ -86592,7 +86602,7 @@ rTu
 jeh
 iaP
 cZj
-wCD
+hSg
 xwt
 uOb
 ycI
@@ -87345,7 +87355,7 @@ urb
 ciK
 yjs
 bFl
-yjs
+mlS
 cUW
 vwh
 hNa
@@ -87861,7 +87871,7 @@ yjs
 bFl
 yjs
 vPE
-mlS
+tgl
 uRX
 uRX
 uRX
@@ -89915,7 +89925,7 @@ qmO
 ljp
 yjs
 bFl
-yjs
+mvz
 uwA
 dla
 dJp
@@ -90946,7 +90956,7 @@ bFl
 bFl
 gYY
 dhe
-gYY
+iFQ
 yfP
 yfP
 yfP

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -12184,7 +12184,7 @@
 /area/command/heads_quarters/captain)
 "hgw" = (
 /obj/machinery/door/airlock/command{
-	name = "Head of Personnel's EVA Storage";
+	name = "Head of Personnel's Office";
 	req_access_txt = "18;57"
 	},
 /obj/machinery/door/firedoor,
@@ -41904,11 +41904,11 @@
 	dir = 8;
 	name = "command blue"
 	},
+/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage Private";
-	req_access_txt = "18"
+	req_access_txt = "18;19"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "vOS" = (
@@ -41923,7 +41923,7 @@
 	},
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage Private";
-	req_access_txt = "18"
+	req_access_txt = "18;19"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -41907,7 +41907,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage Private";
-	req_access_txt = "18;19"
+	req_access_txt = "19"
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
@@ -41923,7 +41923,7 @@
 	},
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage Private";
-	req_access_txt = "18;19"
+	req_access_txt = "19"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,

--- a/SolitaireStation/Solitairestation.dmm
+++ b/SolitaireStation/Solitairestation.dmm
@@ -18983,6 +18983,7 @@
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/atmospherics/components/binary/tank_compressor,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "kIK" = (
@@ -42083,7 +42084,7 @@
 /turf/open/floor/iron,
 /area/security/range)
 "vSo" = (
-/obj/machinery/atmospherics/components/binary/tank_compressor,
+/obj/machinery/research/anomaly_refinery,
 /turf/open/floor/iron,
 /area/science/mixing)
 "vSJ" = (


### PR DESCRIPTION
Closes #39  
Gateway, EVA and teleporter room are now connected with the station's powernet and atmos system.
HoP's queue line windows are electrified, the door stating that EVA was owned by the HoP was renamed and Ian now has one bed instead of two on the same tile.
"EVA Private" doors now require command access to open.
Replaced a couple of multi airlock cycles with regular ones, as they were unnecessary.
Ordnance now has the updated equipment.
